### PR TITLE
Update Variables-Master-List_16352570.mdx

### DIFF
--- a/docs/FreeSWITCH-Explained/Dialplan/Variables-Master-List_16352570.mdx
+++ b/docs/FreeSWITCH-Explained/Dialplan/Variables-Master-List_16352570.mdx
@@ -3769,7 +3769,7 @@ string
 
 string
 
-Syntax: `rtp_secure_media=<permission>[:<list of encryption suites>]`
+Syntax: `rtp_secure_media=<permission>[:<colon separated list of encryption suites>]`
 
 `sip_secure_media` is no longer implemented
 
@@ -3797,8 +3797,8 @@ encryption suites:
 
 Examples:
 
-* `rtp_secure_media=mandatory:AES_CM_256_HMAC_SHA1_80,AES_CM_256_HMAC_SHA1_32`
-* `rtp_secure_media=true:AES_CM_256_HMAC_SHA1_80,AES_CM_256_HMAC_SHA1_32`
+* `rtp_secure_media=mandatory:AES_CM_256_HMAC_SHA1_80:AES_CM_256_HMAC_SHA1_32`
+* `rtp_secure_media=true:AES_CM_256_HMAC_SHA1_80:AES_CM_256_HMAC_SHA1_32`
 * `rtp_secure_media=optional:AES_CM_256_HMAC_SHA1_80`
 * `rtp_secure_media=true:AES_CM_256_HMAC_SHA1_80`
 
@@ -3806,11 +3806,11 @@ Examples:
 
 string
 
-Same syntax as [rtp\_secure\_media](Variables-Master-List_16352570.mdx#rtp_secure_media): `rtp_secure_media_inbound=<permission>[:<list of encryption suites>]`
+Same syntax as [rtp\_secure\_media](Variables-Master-List_16352570.mdx#rtp_secure_media): `rtp_secure_media_inbound=<permission>[:<colon separated list of encryption suites>]`
 
 Examples:
 
-`rtp_secure_media_inbound=true:AEAD_AES_256_GCM_8,AES_CM_256_HMAC_SHA1_80,AES_CM_256_HMAC_SHA1_32`
+`rtp_secure_media_inbound=true:AEAD_AES_256_GCM_8:AES_CM_256_HMAC_SHA1_80:AES_CM_256_HMAC_SHA1_32`
 
 `rtp_secure_media_inbound=mandatory:AEAD_AES_256_GCM_8`
 
@@ -3818,7 +3818,7 @@ Examples:
 
 string
 
-Same syntax as [rtp\_secure\_media](Variables-Master-List_16352570.mdx#rtp_secure_media): `rtp_secure_media_outbound=<permission>[:<list of encryption suites>]`
+Same syntax as [rtp\_secure\_media](Variables-Master-List_16352570.mdx#rtp_secure_media): `rtp_secure_media_outbound=<permission>[:<colon separated list of encryption suites>]`
 
 Examples:
 
@@ -3828,7 +3828,7 @@ Examples:
 
 ### rtp_secure_media_suites
 
-string An alternative, optional variable that specifies a comma-separated list of available encryption suites. If this is specified, then [rtp\_secure\_media](Variables-Master-List_16352570.mdx#rtp_secure_media) need only specify the permission flag without the list of suites.
+string An alternative, optional variable that specifies a colon-separated list of available encryption suites. If this is specified, then [rtp\_secure\_media](Variables-Master-List_16352570.mdx#rtp_secure_media) need only specify the permission flag without the list of suites.
 
 Syntax: `rtp_secure_media_suites=<list of encryption suites>`
 


### PR DESCRIPTION
Modified the syntax for specifying crtpto suites - it needs to be colon separated, not comma separated.