### PR TITLE
Update mod_valet_parking_3966447.mdx

### DIFF
--- a/docs/FreeSWITCH-Explained/Modules/mod_valet_parking_3966447.mdx
+++ b/docs/FreeSWITCH-Explained/Modules/mod_valet_parking_3966447.mdx
@@ -152,11 +152,15 @@ exit
 ## Channel Variables
 
 valet_parking_timeout  - Timeout in Seconds
+
 valet_parking_orbit_exten - Extensions to transfer to when timeout happens.
+
 valet_parking_orbit_dialplan - What dialplan (defaults to current sessions dialplan)
+
 valet_parking_orbit_context - What context (defaults to current sessions context)
 
 valet_hold_music - Set hold music (defaults to ${hold_music} value)
+
 valet_announce_slot - Enable/disable the park slot announcement (default announcement is enabled)
 
 ## API valet_info


### PR DESCRIPTION
currently the way it is, the text is all together rather than on new lines. See https://developer.signalwire.com/freeswitch/FreeSWITCH-Explained/Modules/mod_valet_parking_3966447/#channel-variables