### PR TITLE
Swap docs for digit-timeout and input-timeout

### DIFF
--- a/docs/FreeSWITCH-Explained/Modules/mod_httapi_3966423.mdx
+++ b/docs/FreeSWITCH-Explained/Modules/mod_httapi_3966423.mdx
@@ -103,8 +103,8 @@ name                : Parameter name into which to save result
 error-file          : Error file to play on invalid input
 action              : Change the new target url
 temp-action         : Change url to submit to, just for the next loop
-digit-timeout       : Pause to wait for digits after file plays (when input bindings are present)
-input-timeout       : Pause to wait for more digits in a multi-digit input
+digit-timeout       : Pause to wait for more digits in a multi-digit input (in milliseconds)
+input-timeout       : Pause to wait for digits after file plays when input bindings are present (in milliseconds)
 loops               : Maximum number of times to play the file when input bindings are present
 asr-engine          : Automatic speech recognition engine to use
 asr-grammar         : ASR grammar to use
@@ -117,8 +117,8 @@ name                : Parameter name into which to save result
 error-file          : Error file to play on invalid input
 action              : Change the new target url
 temp-action         : Change url to submit to, just for the next loop
-digit-timeout       : Pause to wait for digits after file plays (when input bindings are present)
-input-timeout       : Pause to wait for more digits in a multi-digit input
+digit-timeout       : Pause to wait for more digits in a multi-digit input (in milliseconds)
+input-timeout       : Pause to wait for digits after file plays when input bindings are present (in milliseconds)
 
 <pause name error-file action digit-timeout input-timeout loops milliseconds><bind action strip>*EXPR*</bind></pause>
                     : Waits for input for a specific amount of time.
@@ -128,8 +128,8 @@ name                : Parameter name into which to save result
 error-file          : Error file to play on invalid input
 action              : Change the new target url
 temp-action         : Change url to submit to, just for the next loop
-digit-timeout       : Pause to wait for digits after file plays (when input bindings are present)
-input-timeout       : Pause to wait for more digits in a multi-digit input
+digit-timeout       : Pause to wait for more digits in a multi-digit input (in milliseconds)
+input-timeout       : Pause to wait for digits after file plays when input bindings are present (in milliseconds) (does this apply to pause?)
 loops               : Maximum number of times to play the file when input bindings are present
 
 <speak file name error-file action digit-timeout input-timeout loops engine voice><bind action strip>*EXPR*</bind></speak>
@@ -140,9 +140,9 @@ name                : Parameter name into which to save result
 error-file          : Error file to play on invalid input
 action              : Change the new target url
 temp-action         : Change url to submit to, just for the next loop
-digit-timeout       : Pause to wait for digits after file plays (when input bindings are present)
-input-timeout       : Pause to wait for more digits in a multi-digit input
-loops               : Maximum number of times to play the file when input bindings are present
+digit-timeout       : Pause to wait for more digits in a multi-digit input (in milliseconds)
+input-timeout       : Pause to wait for digits after speak when input bindings are present (in milliseconds)
+loops               : Maximum number of times to speak the file when input bindings are present
 engine              : Text-to-speech engine to use
 voice               : tts voice to use
 
@@ -154,9 +154,9 @@ name                : Parameter name into which to save result
 error-file          : Error file to play on invalid input
 action              : Change the new target url
 temp-action         : Change url to submit to, just for the next loop
-digit-timeout       : Pause to wait for digits after file plays (when input bindings are present)
-input-timeout       : Pause to wait for more digits in a multi-digit input
-loops               : Maximum number of times to play the file when input bindings are present
+digit-timeout       : Pause to wait for more digits in a multi-digit input (in milliseconds)
+input-timeout       : Pause to wait for digits after say when input bindings are present (in milliseconds)
+loops               : Maximum number of times to say when input bindings are present
 language            : language to speak
 type                : type (fs param)
 method              : method (fs param)


### PR DESCRIPTION
The docs for input-timeout and digit-time out were wrong. Explanation for input-timeout should have got to digit-timeout and vice-versa.

Also I have question, does input-timeout has any significance in <pause> work? It does make sense pause will wait for `n` milliseconds and again wait for `input-timeout` milliseconds for taking input.