### PR TITLE
Reorder parameter descriptions to match parameter order

### DIFF
--- a/docs/FreeSWITCH-Explained/Modules/mod-dptools/6586933.mdx
+++ b/docs/FreeSWITCH-Explained/Modules/mod-dptools/6586933.mdx
@@ -32,8 +32,8 @@ Click here to expand Table of Contents
 * terminators = digits used to end input if less than &lt;max> digits have been pressed. If it starts with '=', then a terminator must be present for the input to be accepted (Since FS 1.2). (Typically '#', can be empty). Add '+' in front of terminating digit to always append it to the result variable specified in `var_name`.
 * file = Sound file to play to prompt for digits to be dialed by the caller; playback can be interrupted by the first dialed digit (can be empty or the special string "silence" to omit the message).
 * invalid\_file = Sound file to play when digits don't match the regexp (can be empty to omit the message).
-* regexp = Regular expression to match digits (optional, an empty string allows all input (default)).
 * var\_name = Channel variable into which valid digits should be placed (optional, no variable is set by default. See also 'var\_name\_invalid' below).
+* regexp = Regular expression to match digits (optional, an empty string allows all input (default)).
 * digit\_timeout = Inter-digit timeout; number of milliseconds allowed between digits in lieu of dialing a terminator digit; once this number is reached, PAGD assumes that the caller has no more digits to dial (optional, defaults to the value of &lt;timeout>).
 * transfer\_on\_failure = where to transfer call when max tries has been reached, example: "1 XML hangup" (optional, by default no transfer is executed, allowing the caller to process channel variables).
 


### PR DESCRIPTION
Parameter orders were recently corrected in the "Usage" section, this simply updates the "Parameters" section to match the corrected order as people may (like me) read down the detailed section and not realise they are not in the correct order.