### PR TITLE
the syntax of virtual host script 

### DIFF
--- a/docs/FreeSWITCH-Explained/Modules/mod-verto/RESTful-Verto_8454242.mdx
+++ b/docs/FreeSWITCH-Explained/Modules/mod-verto/RESTful-Verto_8454242.mdx
@@ -24,7 +24,7 @@ To use the HTTP interface, put the following config in your verto profile
             <rule expression="^/channels" value="/rest.lua"/>
           </rewrites>
         </vhost>
-     </vhosts>
+      </vhosts>
 ```
 
 so it looks like 

--- a/docs/FreeSWITCH-Explained/Modules/mod-verto/RESTful-Verto_8454242.mdx
+++ b/docs/FreeSWITCH-Explained/Modules/mod-verto/RESTful-Verto_8454242.mdx
@@ -24,7 +24,7 @@ To use the HTTP interface, put the following config in your verto profile
             <rule expression="^/channels" value="/rest.lua"/>
           </rewrites>
         </vhost>
-	  </vhosts>
+    </vhosts>
 ```
 
 so it looks like 

--- a/docs/FreeSWITCH-Explained/Modules/mod-verto/RESTful-Verto_8454242.mdx
+++ b/docs/FreeSWITCH-Explained/Modules/mod-verto/RESTful-Verto_8454242.mdx
@@ -24,7 +24,7 @@ To use the HTTP interface, put the following config in your verto profile
             <rule expression="^/channels" value="/rest.lua"/>
           </rewrites>
         </vhost>
-    </vhosts>
+     </vhosts>
 ```
 
 so it looks like 

--- a/docs/FreeSWITCH-Explained/Modules/mod-verto/RESTful-Verto_8454242.mdx
+++ b/docs/FreeSWITCH-Explained/Modules/mod-verto/RESTful-Verto_8454242.mdx
@@ -24,6 +24,7 @@ To use the HTTP interface, put the following config in your verto profile
             <rule expression="^/channels" value="/rest.lua"/>
           </rewrites>
         </vhost>
+	  </vhosts>
 ```
 
 so it looks like 


### PR DESCRIPTION
The  virtual host of video-demo(Verto) script is missing a </vhosts> 
On this connection https://developer.signalwire.com/freeswitch/FreeSWITCH-Explained/Modules/mod-verto/RESTful-Verto_8454242/


        <vhost domain="localhost">
          <param name="alias" value="seven.local freeswitch.org"/>
          <!-- <param name="root" value="/usr/local/freeswitch/htdocs"/> -->
          <!-- <param name="script_root" value="/usr/local/freeswitch/scripts"/> -->
          <param name="index" value="index.html"/>
<!--
          <param name="auth-realm" value="FreeSWITCH"/>
          <param name="auth-user" value="freeswitch"/>
          <param name="auth-pass" value="rocks"/>
-->
          <rewrites>
            <rule expression="^/api" value="/my_custom_api.lua"/>
            <rule expression="^/channels" value="/rest.lua"/>
          </rewrites>
        </vhost>
      </vhosts>     <!-- missing-->
