### PR TITLE
the syntax error of virtual host script 

### DIFF
--- a/docs/FreeSWITCH-Explained/Modules/mod-verto/RESTful-Verto_8454242.mdx
+++ b/docs/FreeSWITCH-Explained/Modules/mod-verto/RESTful-Verto_8454242.mdx
@@ -24,7 +24,7 @@ To use the HTTP interface, put the following config in your verto profile
             <rule expression="^/channels" value="/rest.lua"/>
           </rewrites>
         </vhost>
-     </vhosts>
+      </vhosts>
 ```
 
 so it looks like 

--- a/docs/FreeSWITCH-Explained/Modules/mod-verto/RESTful-Verto_8454242.mdx
+++ b/docs/FreeSWITCH-Explained/Modules/mod-verto/RESTful-Verto_8454242.mdx
@@ -24,7 +24,7 @@ To use the HTTP interface, put the following config in your verto profile
             <rule expression="^/channels" value="/rest.lua"/>
           </rewrites>
         </vhost>
-	  </vhosts>
+    </vhosts>
 ```
 
 so it looks like 

--- a/docs/FreeSWITCH-Explained/Modules/mod-verto/RESTful-Verto_8454242.mdx
+++ b/docs/FreeSWITCH-Explained/Modules/mod-verto/RESTful-Verto_8454242.mdx
@@ -24,7 +24,7 @@ To use the HTTP interface, put the following config in your verto profile
             <rule expression="^/channels" value="/rest.lua"/>
           </rewrites>
         </vhost>
-    </vhosts>
+     </vhosts>
 ```
 
 so it looks like 

--- a/docs/FreeSWITCH-Explained/Modules/mod-verto/RESTful-Verto_8454242.mdx
+++ b/docs/FreeSWITCH-Explained/Modules/mod-verto/RESTful-Verto_8454242.mdx
@@ -24,6 +24,7 @@ To use the HTTP interface, put the following config in your verto profile
             <rule expression="^/channels" value="/rest.lua"/>
           </rewrites>
         </vhost>
+	  </vhosts>
 ```
 
 so it looks like 


### PR DESCRIPTION
The virtual host of video-demo(Verto) script is missing a "  < /vhosts> "
On this connection https://developer.signalwire.com/freeswitch/FreeSWITCH-Explained/Modules/mod-verto/RESTful-Verto_8454242/ 

example:

< vhosts>
    < vhost domain="localhost">
....
....
    < /vhost>
  < /vhosts>     < !-- missing-- >