### PR TITLE
Update SignalWire provider instructions

### DIFF
--- a/docs/FreeSWITCH-Explained/Interoperability/Providers-ITSPs/20709712.mdx
+++ b/docs/FreeSWITCH-Explained/Interoperability/Providers-ITSPs/20709712.mdx
@@ -1,74 +1,10 @@
 
-# Provider SignalWire (US) 
+# Provider SignalWire (US)
 
- 
+See the [`mod_signalwire`](../../Modules/mod_signalwire_19595544.mdx) page on how to connect a FreeSWITCH instance to SignalWire.
 
-[https://signalwire.com/blogs/product/programmable-sip-connectivity-and-routing](https://signalwire.com/blogs/product/programmable-sip-connectivity-and-routing)
+## Send SMS notifications about FreeSWITCH activities
 
-Inbound and outbound works globally. Config files also available at: [https://www.twilio.com/docs/sip-trunking/sample-configuration#freeswitch](https://www.twilio.com/docs/sip-trunking/sample-configuration#freeswitch).
-
-  
-Add the SignalWire IP addresses into the domain section under `autoload_configs/acl.conf.xml you can nslookup sip.signalwire.com`
-
-  
-```xml
-<configuration name="acl.conf" description="Network Lists">
-    
-```
-
-Registration: /usr/local/freeswitch/conf/sip\_profiles/external/
-
-  
-```erl
-<include>
-        <gateway name="signalwire-outbound">
-                <param name="username" value="---user---"/>
-                <param name="password" value="---password---" />
-                <param name="proxy" value="example.signalwire.com" />
-                <param name="register" value="false"/>
-        </gateway>
-      <gateway name="signalwire-inbound">
-      <param name="username" value="---user---"/>
-      <param name="password" value="---password---"/>
-      <param name="proxy" value="example.signalwire.com"/>
-      <param name="register" value="false"/>
-      <param name="dtmf-type" value="rfc2833"/>
-      <param name="context" value="public"/>
-      </gateway>
-</include>
-```
-
-  
-Inbound calling: /usr/local/freeswitch/conf/dialplan/public/
-
-```xml
-<include>
-  <extension name="public_did">
-    <condition field="destination_number" expression="^\+15550000000$">
-      <action application="set" data="domain_name=$${domain}"/>
-      <action application="playback" data="phrase:greeting"/>
-      <action application="transfer" data="1000 XML default"/>
-    </condition>
-  </extension>
-</include>
-```
-
-  
-Outbound calling: /usr/local/freeswitch/conf/dialplan/default/
-
-```xml
-<include>
-   <extension name="twilio-outbound">
-    <condition field="destination_number" expression="^(1{0,1}\d{10})$">
-    <action application="set" data="effective_caller_id_number=+15550000000"/>
-    <action application="set" data="effective_caller_id_name=${outbound_caller_id_name}"/>
-    <action application="bridge" data="sofia/gateway/signalwire-outbound/+1$1"/>
-  </condition>
-   </extension>
-</include>
-```
-
-  
 Send any SMS from Dialplan to your smartphone, notifying you of various things that happening.
 
 ```xml
@@ -102,6 +38,6 @@ Send any SMS from Dialplan to your smartphone, notifying you of various things t
     </extension>
 ```
 
-For a more comprehensive walk through of provisioning SignalWire trunks, configuring FreeSWITCH, and best practices please see our signalwire.com docs [https://signalwire.com/blogs/product/programmable-sip-connectivity-and-routing](https://signalwire.com/blogs/product/programmable-sip-connectivity-and-routing)[.](https://www.twilio.com/blog/2014/12/getting-started-placing-outbound-calls-with-twilio-elastic-sip-trunking-and-freeswitch.html)
+ Please see our blog post [Programmable SIP - Connectivity and Routing](https://signalwire.com/blogs/product/programmable-sip-connectivity-and-routing) for a more comprehensive walkthrough of provisioning SignalWire trunks and best practices.
 
 


### PR DESCRIPTION
The current SignalWire provider instructions are the same as for [Twilio](https://developer.signalwire.com/freeswitch/FreeSWITCH-Explained/Interoperability/Providers-ITSPs/2883943/), so I removed those, and linked the `mod_signalwire` page that has detailed instructions.

The SMS XML example has nothing to do with this page either, but decided to leave it in out of caution, because I have no clue whether it is documented elsewhere.