### PR TITLE
Update mod_conference documentation with changes around endconf in 1.10.10

### DIFF
--- a/docs/FreeSWITCH-Explained/Modules/mod_conference_3965534.mdx
+++ b/docs/FreeSWITCH-Explained/Modules/mod_conference_3965534.mdx
@@ -316,7 +316,7 @@ These flags can be applied to individual conferees when entering the conference 
 | dist-dtmf            | Send any DTMF from this member to all participants                                                                      |              |
 | moderator            | Flag member as a moderator                                                                                              |              |
 | nomoh                | Disable music on hold when this member is the only member in the conference                                             |              |
-| endconf              | Ends conference when all members with this flag leave the conference after profile param endconf-grace-time has expired |              |
+| endconf              | Ends conference when all members with this flag leave the conference after profile param endconf-grace-time has expired. In 1.10.10 this is changed to end conference when any member with this flag leaves the conference. |              |
 | mintwo               | End conference when it drops below 2 participants after a member enters with this flag                                  |              |
 | ghost                | Do not count member in conference tally                                                                                 |              |
 | join-only            | Only allow joining a conference that already exists                                                                     |              |
@@ -326,6 +326,7 @@ These flags can be applied to individual conferees when entering the conference 
 | no-minimize-encoding | Bypass the video transcode minimizer and encode the video individually for this member                                  | 1.6          |
 | vmute                | Enter conference video muted                                                                                            | 1.6          |
 | second-screen        | Open a 'view only' connection to the conference, without impacting the conference count or data.                        | 1.6          |
+| mandatory_member_endconf	| Ends conference when all members with this flag leave the conference after profile param endconf-grace-time has expired	| 1.10.10          |
 
 **Table: Conference Flags**
 


### PR DESCRIPTION
With freeswitch PR2079 there were changes to endconf and a new member flag called mandatory_member_endconf was added that does what endconf used to do.