### PR TITLE
Update doc for p-asserted-identity

### DIFF
--- a/docs/Channel-Variables-Catalog/sip_cid_type_16352846.mdx
+++ b/docs/Channel-Variables-Catalog/sip_cid_type_16352846.mdx
@@ -25,7 +25,7 @@ Send `Remote-Party-ID` (default):
 
 Send `P-Asserted-Identity`:
 
-![(warning)](/images/icons/emoticons/warning.svg) you must set privacy flag, otherwise `P-Preferred-Identity` will be inserted instead of `P-Asserted-Identity`.
+![(warning)](/images/icons/emoticons/warning.svg) `P-Asserted-Identity` is only set if you do not set origination_privacy.  If you do set it it will send `P-Preferred-Identity` will be inserted instead of `P-Asserted-Identity`.
 
 ```xml
 {sip_cid_type=pid}sofia/default/user@example.com

--- a/docs/Channel-Variables-Catalog/sip_cid_type_16352846.mdx
+++ b/docs/Channel-Variables-Catalog/sip_cid_type_16352846.mdx
@@ -25,7 +25,7 @@ Send `Remote-Party-ID` (default):
 
 Send `P-Asserted-Identity`:
 
-![(warning)](/images/icons/emoticons/warning.svg) `P-Asserted-Identity` is only set if you do not set origination_privacy.  If you do set it it will send `P-Preferred-Identity` will be inserted instead of `P-Asserted-Identity`.
+![(warning)](/images/icons/emoticons/warning.svg) `P-Asserted-Identity` is only set if you do not set origination_privacy.  If you do set it, it will send `P-Preferred-Identity` and will be inserted instead of `P-Asserted-Identity`.
 
 ```xml
 {sip_cid_type=pid}sofia/default/user@example.com


### PR DESCRIPTION
Current documentation does not reflect reality.  testing this shows the opposite of the original statement.  This fixes the documentation.  Supporting link https://www.dandydialer.com/blog/2021-01-24-sip-caller-id-mysteries

I have also tested this and validated this is the case.