### PR TITLE
Voicemail_13174041.mdx: Replace magic quotes with standard quotes

### DIFF
--- a/docs/FreeSWITCH-Explained/Modules/mod-voicemail/Voicemail_13174041.mdx
+++ b/docs/FreeSWITCH-Explained/Modules/mod-voicemail/Voicemail_13174041.mdx
@@ -79,12 +79,12 @@ In conf/dialplan/public/3015551212.xml
 ```xml
 <extension name="public_did">
   <condition field="destination_number" expression="^(3015551212)$">
-    <action application="set" data="call_timeout=20″/>
+    <action application="set" data="call_timeout=20"/>
     <action application="set" data="continue_on_fail=true"/>
     <action application="set" data="hangup_after_bridge=true"/>
-    <action application="bridge" data="sofia/switch.gruntnet/1000,sofia/switch.gruntnet/1001″/>
+    <action application="bridge" data="sofia/switch.gruntnet/1000,sofia/switch.gruntnet/1001"/>
     <action application="answer"/>
-    <action application="voicemail" data="default $${domain} 1000″/>
+    <action application="voicemail" data="default $${domain} 1000"/>
   </condition>
 </extension>
 ```


### PR DESCRIPTION
Just a quick fix-

Replace `″` with `"` in order to:

1. To fix syntax highlighting when viewed online.
2. To save folks time and frustration if they copy/paste.