### PR TITLE
Correct broken comment syntax on FreeSWITCH Explained

### DIFF
--- a/docs/FreeSWITCH-Explained/index.mdx
+++ b/docs/FreeSWITCH-Explained/index.mdx
@@ -25,7 +25,8 @@ The FreeSWITCH documentation has undergone several migrations and is currently b
 
 ## What Is FreeSWITCH?
 
-FreeSWITCH™ is an open source carrier-grade telephony platform implemented as a back-to-back user agent. Because of this design it can perform a great number of different tasks from a PBX to transit switch, TTS (text-to-speech) conversion, audio and video conferencing host, VoIP telephone, and more.
+FreeSWITCH™ is an open source carrier-grade telephony platform implemented as a back-to-back user agent. 
+Because of this design it can perform a great number of different tasks from a PBX to transit switch, TTS (text-to-speech) conversion, audio and video conferencing host, VoIP telephone, and more.
 
 ## Documentation
 
@@ -33,13 +34,13 @@ Our documentation parallels the ongoing development by the FreeSWITCH™ core de
 
 The documentation provides usage prototypes and examples for the channel variables, dialplan applications, and API commands that can be accessed via E.S.L. (the Event Socket Layer) with scripts written in Lua, Perl, and other languages. 
 
-\{*
+{/*
 
 NOTE: The tagging system needs to be rebuilt using Docusaurus tags instead of Confluence Labels. See https://github.com/signalwire/freeswitch-docs/issues/79 for more information.
 
 Pages tagged with the label "[examples](/tags/examples)" provide reference information to configure and experiment with FreeSWITCH. Be sure to click on the labels to find pages that related to that topic.
 
-*/\}
+*/}
 
 Reference documentation of core API functions can be found on [FreeSWITCH Tech Reference](http://docs.freeswitch.org/).
 


### PR DESCRIPTION
## Before

```mdx
\{*

NOTE: The tagging system needs to be rebuilt using Docusaurus tags instead of Confluence Labels. See https://github.com/signalwire/freeswitch-docs/issues/79 for more information.

Pages tagged with the label "[examples](/tags/examples)" provide reference information to configure and experiment with FreeSWITCH. Be sure to click on the labels to find pages that related to that topic.

*/\}
```

## After

```mdx
{/*

NOTE: The tagging system needs to be rebuilt using Docusaurus tags instead of Confluence Labels. See https://github.com/signalwire/freeswitch-docs/issues/79 for more information.

Pages tagged with the label "[examples](/tags/examples)" provide reference information to configure and experiment with FreeSWITCH. Be sure to click on the labels to find pages that related to that topic.

*/}
```