### PR TITLE
Fix broken links

### DIFF
--- a/docs/FreeSWITCH-Explained/Release-Notes/FreeSWITCH-Enterprise-Release-notes_61210814.mdx
+++ b/docs/FreeSWITCH-Explained/Release-Notes/FreeSWITCH-Enterprise-Release-notes_61210814.mdx
@@ -4,7 +4,7 @@
 
 ### List of releases:
 
-* [20.24.6 (Release date: 26 Dec 2024)](#20245-release-date-26-dec-2024)
+* [20.24.6 (Release date: 26 Dec 2024)](#20246-release-date-26-dec-2024)
 * [20.24.5 (Release date: 09 Oct 2024)](#20245-release-date-09-oct-2024)
 * [20.24.4 (Release date: 25 Jul 2024)](#20244-release-date-25-jul-2024)
 * [20.24.3 (Release date: 16 Jul 2024)](#20243-release-date-16-jul-2024)


### PR DESCRIPTION
A broken link introduced in #150 is causing the build to fail. This meant the Docker image, and the production site, were not updating with recent changes.

This PR fixes the link.

A successful build is now required to merge, which will prevent this issue from reoccurring.