### PR TITLE
build: Only build, don't push

### DIFF
--- a/.github/workflows/generate-fs-docs.yml
+++ b/.github/workflows/generate-fs-docs.yml
@@ -19,11 +19,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: build image
-        id: build
-        uses: signalwire/actions-template/.github/actions/docker@main
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build image
+        uses: docker/build-push-action@v6
         with:
-          PROJECT_NAME: "freeswitch-docs"
-          PUSH: false
-          ENABLE_CACHE: true
-          CONTAINER_TEST: false
+          push: false

--- a/.github/workflows/generate-fs-docs.yml
+++ b/.github/workflows/generate-fs-docs.yml
@@ -1,38 +1,29 @@
 name: SignalWire Docs
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
 
   push:
     branches:
     - main
-    # paths:
-    #   - custom-path/**
+
   pull_request:
     branches:
     - main
 
-  #   paths:
-  #     - custom-path/**
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    name: "Build/push & deploy to swarm"
-    # The type of runner that the job will run on
-    uses: signalwire/actions-template/.github/workflows/docker-bp.yml@c53f25701311044e264e448672d40cd67d56a7e7
-    with:
-      PROJECT_NAME: "freeswitch-docs"
-      SWARM_SERVICE: "signalwire-docs_freeswitch-docs"
-      PR_MESSAGE: false
-      SWARM_DEPLOY: true
-    secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-      ENDPOINTID: ${{ secrets.DOCS_ENDPOINT_ID }}
-      PORTAINER_API_KEY: ${{ secrets.PORTAINER_API_KEY }}
+    name: "Build image"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: build image
+        id: build
+        uses: signalwire/actions-template/.github/actions/docker@main
+        with:
+          PROJECT_NAME: "freeswitch-docs"
+          PUSH: false
+          ENABLE_CACHE: true
+          CONTAINER_TEST: false


### PR DESCRIPTION
Only build the image so changes are confirmed to build successfully. Pushing/deploying will be managed separate from this repo.