### PR TITLE
Remove outdated TOCs from `/Auxiliary-Knowledge-and-Utilities/` directory

### DIFF
--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/15139695.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/15139695.mdx
@@ -8,11 +8,6 @@
 SSL encryption has been found broken in both SSLv2 and SSLv3 versions (SSLv1 was never released).
 So, because there is a little meaning in using a broken encryption, you're invited to remove SSL support from both your clients and your servers.
 
-Click here to expand Table of Contents
-
-* 1 [Disabling SSLv3 and SSLv2 in FreeSWITCH](#disabling-sslv3-and-sslv2-in-freeswitch)
-* 2 [SSL Certificates](#ssl-certificates)
-
 ## Disabling SSLv3 and SSLv2 in FreeSWITCH
 
 It's long time we already ship with correct configuration, but you may want to check your settings.

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Agent-iPhone_13173276.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Agent-iPhone_13173276.mdx
@@ -3,10 +3,6 @@
 
  
 
-Click here to expand Table of Contents
-
-* 1 [Pause-dialing from an iPhone to a FreeSWITCH directory](#pause-dialing-from-an-iphone-to-a-freeswitch-directory)
-
 ## Pause-dialing from an iPhone to a FreeSWITCH directory
 
 The iPhone comes with a nice feature for automating navigation of a closed FreeSWITCH dialplan, or even open systems which you might use regularly (DISA, for example).

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/FSmerge_13173209.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/FSmerge_13173209.mdx
@@ -10,14 +10,6 @@ any local changes. This script is designed to fit that need, in an optional mann
 
 It is based on [sysmerge(8)](http://www.openbsd.org/cgi-bin/man.cgi?query=sysmerge&apropos=0&sektion=0&manpath=OpenBSD+Current&arch=i386&format=html) from OpenBSD, which is based on [mergemaster(8)](http://www.freebsd.org/cgi/man.cgi?query=mergemaster&apropos=0&sektion=0&manpath=FreeBSD+8.0-RELEASE&format=html) from FreeBSD.
 
-Click here to expand Table of Contents
-
-* 1 [Conference Call About fsmerge](#conference-call-about-fsmerge)
-* 2 [Download](#download)
-* 3 [Usage](#usage)
-* 4 [Ideas](#ideas)
-* 5 [Optional Patches](#optional-patches)
-
 ## Conference Call About fsmerge
 
 John talks about fsmerge [Listen](http://www.voicenetwork.ca/freeswitch/fsmerge/johntow%5Ffsmerge.mp3)

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/FreeSWITCH-DB-in-RAMdrive_13173438.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/FreeSWITCH-DB-in-RAMdrive_13173438.mdx
@@ -7,11 +7,6 @@
 
 Moving the ephemeral databases to a RAM disk will greatly improve performance, and it is CRITICAL to move them to a RAM disk if you use SSDs. More info on running FreeSWITCH on SSDs is [here](../Configuration/SSD-Tuning-for-Linux_1966304.mdx#about)[.](https://wiki.freeswitch.org/wiki/SSD%5FTuning%5Ffor%5FLinux "SSD Tuning for Linux")
 
-Click here to expand Table of Contents
-
-* 1 [Discussion](#discussion)  
-   * 1.1 [Example](#example)
-
 ## Discussion
 
 Some Linux distros have quirks that cause SQLite to behave poorly when scaling up. In other cases, disk I/O becomes a bottleneck to FreeSWITCH performance. Putting the FreeSWITCH core.db file onto a RAM disk can increase performance.

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Freeswitch-Custom-VSC_13173912.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Freeswitch-Custom-VSC_13173912.mdx
@@ -7,8 +7,6 @@
 
 This is a Page to List any Custom Vertical Service Codes.
 
-Click here to expand Table of Contents
-
 custom-vsc.xml
 
 ```xml

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Freeswitch-munin-module_13173266.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Freeswitch-munin-module_13173266.mdx
@@ -7,11 +7,6 @@ For external monitoring munin modules as well as other monitoring software modul
 
 Example \* modules for munin can be found here for a [starting point](http://rodolphe.quiedeville.org/hack/munin/asterisk-1.2/).
 
-Click here to expand Table of Contents
-
-* 1 [Channel Usage](#channel-usage)  
-   * 1.1 [Channel Usage by Query core DB](#channel-usage-by-query-core-db)
-
 ## Channel Usage
 
 Thanks to hads for the python scripting help. This munin plugin will graph the channel usage:

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Freeswitch-nanpa-project_13173929.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Freeswitch-nanpa-project_13173929.mdx
@@ -9,8 +9,6 @@ This page desribes an effort to provide a US-standard configuration file for PBX
 
 The NANPA vertical service codes are [listed at(https://www.nationalnanpa.com/number_resource_info/vsc_assignments.html)
 
-Click here to expand Table of Contents
-
 nanpa.xml or us-vsc.xml //.
 
 ```xml

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Google-Voice-API_13173299.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Google-Voice-API_13173299.mdx
@@ -3,12 +3,6 @@
 
  
 
-Click here to expand Table of Contents
-
-**Error rendering macro 'toc'**
-
-null
-
 ### Adding Google Voice as an outgoing destination
 
 ## Create yourself a Google Voice account (or reconfigure an existing one)

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Googletalk_13174001.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Googletalk_13174001.mdx
@@ -3,11 +3,6 @@
 
  
 
-Click here to expand Table of Contents
-
-* 1 [FreeSWITCH and Google Talk](#freeswitch-and-google-talk)
-* 2 [FreeSWITCH – Google Talk – Dingaling – Jingle All The Way](#freeswitch--google-talk--dingaling--jingle-all-the-way)
-
 ## FreeSWITCH and Google Talk
 
 One of the reasons I chose to spend time with freeswitch over yate was google talk integration. Was a good choice, I think, for more than just gtalk.

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/HA-PBX_13174036.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/HA-PBX_13174036.mdx
@@ -7,12 +7,6 @@
 
 High Availability Class 5 Switch/PBX. This page currently captures my company's attempt at building a high-availability Class 5 PBX using FreeSWITCH.
 
-Click here to expand Table of Contents
-
-* 1 [What is a Class 5 Switch/PBX](#what-is-a-class-5-switchpbx)
-* 2 [Here are my current plans](#here-are-my-current-plans)
-* 3 [Current Progress](#current-progress)
-
 ## What is a Class 5 Switch/PBX
 
 A Class 5 switch is a phone switch that provides end-subscriber features. This includes features like call routing, IVRs, voice mail, voice mail to email, call forwarding, ACDs, call recording, etc. This presents a unique challenge, in that there are many more stateful services provided by the switch that need care and feeding.

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/HylaFax_13173342.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/HylaFax_13173342.mdx
@@ -7,23 +7,6 @@
 
 Hylafax is "The world's most advanced open source fax server".
 
-  
-Click here to expand Table of Contents
-
-* 1 [Download](#download)
-* 2 [Dependencies](#dependencies)
-* 3 [Installation](#installation)
-* 4 [mod\_spandsp](#mod_spandsp)
-* 5 [Configuration](#configuration)
-* 6 [Stop/ Start Hylafax](#stop-start-hylafax)
-* 7 [Minicom testing for CallerID](#minicom-testing-for-callerid)
-* 8 [Incoming](#incoming)  
-   * 8.1 [Dialplan](#dialplan)  
-   * 8.2 [ESL](#esl)  
-   * 8.3 [File name based on UUID](#file-name-based-on-uuid)
-* 9 [Outgoing](#outgoing)
-* 10 [Logs](#logs)
-* 11 [Modem devices permissions issue](#modem-devices-permissions-issue)
 
 ## Download
 

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/LRN_13173325.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/LRN_13173325.mdx
@@ -7,14 +7,6 @@
 
 This document covers information about storing LRN.
 
-Click here to expand Table of Contents
-
-* 1 [Storing Entire LRN data in redis](#storing-entire-lrn-data-in-redis)  
-   * 1.1 [Reasons](#reasons)  
-   * 1.2 [Method](#method)
-* 2 [Import Speed](#import-speed)
-* 3 [Persistence](#persistence)
-
 ## Storing Entire LRN data in redis
 
 This is an article written by [avimarcus](https://freeswitch.org/confluence/display/~avimarcus) about storing the entire LRN DB, not about _caching_ entries.

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Load_testing_13173304.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Load_testing_13173304.mdx
@@ -7,16 +7,6 @@
 
 This document covers information about load testing tools.
 
-Click here to expand Table of Contents
-
-* 1 [Load testing](#load-testing)  
-   * 1.1 [Load testing tools](#load-testing-tools)  
-      * 1.1.1 [SIPp](#load-testing)  
-         * 1.1.2 [WinSIP](#load-testing)  
-         * 1.1.3 [Back-to-back](#load-testing)  
-   * 1.2 [How to count calls?](#load-testing-tools)  
-   * 1.3 [Examples of load tests](#examples-of-load-tests)
-
 ## Load testing
 
 Load testing is a **dark art**. If you don't have extensive experience with load testing in a telephony environment then nothing on this page will be of any use to you. You are **much** better off doing real-world tests.

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Message_broadcasting_13173360.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Message_broadcasting_13173360.mdx
@@ -7,9 +7,6 @@
 
 This document covers information about message broadcasting.
 
-Click here to expand Table of Contents
-
-* 1 [Voice broadcasting](#voice-broadcasting)
 
 ## Voice broadcasting
 

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/MikesNotes_13173889.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/MikesNotes_13173889.mdx
@@ -13,32 +13,6 @@ I'm Mike, a telephony newbie living near Washington, D.C., and often A.K.A. **zo
 
 Update 2011-12-23 -- Ditched Opera browser in favor of HYDRA IRC on windows.
 
-Click here to expand Table of Contents
-
-* 1 [My subpages](#my-subpages)
-* 2 [FS Console / Reload config](#fs-console--reload-config)
-* 3 [Multiple Extensions in Multiple Companies ("multiple domains" and "multi-tenant")](#multiple-extensions-in-multiple-companies-multiple-domains-and-multi-tenant)
-* 4 [Strange problems caused by having a multiple-tenant Domain name set to the Default Domain](#strange-problems-caused-by-having-a-multiple-tenant-domain-name-set-to-the-default-domain)
-* 5 [The Logging Problem](#the-logging-problem)
-* 6 [Great Providers](#great-providers)
-* 7 [OneSuite](#onesuite)
-* 8 [VoIP Phones](#voip-phones)
-* 9 [Digium TDM400P analog 4port FXO/FXS interface](#digium-tdm400p-analog-4port-fxofxs-interface)
-* 10 [Digium software / drivers](#digium-software--drivers)
-* 11 [System](#system)
-* 12 [conf/openzap.conf](#confopenzapconf)
-* 13 [conf/autoload\_configs/openzap.conf.xml](#confautoload_configsopenzapconfxml)
-* 14 [conf/autoload\_configs/modules.conf.xml](#confautoload_configsmodulesconfxml)
-* 15 [Dialplan Config](#dialplan-config)
-* 16 [See Also](#see-also)
-* 17 [Conference Server](#conference-server)
-* 18 [Ring Group, Hunt Group, Fork Dial, and how to get one phone number to ring on several phones](#ring-group-hunt-group-fork-dial-and-how-to-get-one-phone-number-to-ring-on-several-phones)
-* 19 [Difference between BRIDGE and TRANSFER](#difference-between-bridge-and-transfer)
-* 20 [External control, interfacing, PHP](#external-control-interfacing-php)
-* 21 [Phone tones and DTMF goofiness](#phone-tones-and-dtmf-goofiness)
-* 22 [Bug in Linksys SPA-942 (and SPA-3102) firmware](#bug-in-linksys-spa-942-and-spa-3102-firmware)
-* 23 [Getting SPA-3102 to work: SIP and PSTN](#getting-spa-3102-to-work-sip-and-pstn)
-
 ## My subpages
 
 Subpages can be created under User profiles, by adding slash pagename, like so: \[ \[ User:username/subpage\_name \] \]

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Monitoring_13173431.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Monitoring_13173431.mdx
@@ -7,10 +7,6 @@
 
 This document covers information about monitoring.
 
-Click here to expand Table of Contents
-
-* 1 [Nagios](#nagios)
-
 ## Nagios
 
 kjhosein wrote a plugin (in Perl) that checks various health parameters on a FreeSWITCH server. It takes advantage of the \*fs\_cli\* FreeSWITCH command-line tool. It may be extended to check practically anything that fs\_cli can check.

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Multi-home-tutorial/Multiple-Companies_13173524.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Multi-home-tutorial/Multiple-Companies_13173524.mdx
@@ -11,18 +11,6 @@ This is HOWTO to make one FreeSWITCH server act as a multi-tenant system for two
 
 Basically, we want to have one FS server provide phone services to several separate companies, as if we are a VoIP provider. Let's start with two companies and give both companies the same two users (1000 for company-a and 1000 for company-b). These companies should be completely independent of each other, their identically-numbered extensions should not overlap or have anything to do with each other, and each company (and all of it's users/extensions) should have independent dialplans.
 
-Click here to expand Table of Contents
-
-* 1 [Enabling Multiple Domains](#enabling-multiple-domains)  
-   * 1.1 [Update 2011-12-23](#update-2011-12-23)
-* 2 [Creating the Files and Directories](#creating-the-files-and-directories)  
-   * 2.1 [Adding Users to the Directories](#adding-users-to-the-directories)
-* 3 [Setting Up the SIP Profile](#setting-up-the-sip-profile)
-* 4 [Creating a Dialplan for Each Domain](#creating-a-dialplan-for-each-domain)  
-   * 4.1 [Usage](#usage)
-* 5 [Gotchas](#gotchas)
-* 6 [See also](#see-also)
-
 ## Enabling Multiple Domains
 
 This is from the SIP Profiles section of [Multi-tenant](../../Examples/Multi-tenant_13173521.mdx#about):

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Multi-home-tutorial/index.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Multi-home-tutorial/index.mdx
@@ -8,30 +8,6 @@
 This document covers information about a multi home tutorial by Michael Gende back in October, 2009 so proceed with caution.
 
   
-Click here to expand Table of Contents
-
-* 1 [FREESWITCH FOR DUMMIES: DUAL-HOMED HOST EXAMPLE](#freeswitch-for-dummies-dual-homed-host-example)
-* 2 [STUFF ONE OUGHT TO KNOW BEFORE STARTING](#stuff-one-ought-to-know-before-starting)  
-   * 2.1 [PURPOSE OF THIS DOCUMENT](#purpose-of-this-document)  
-   * 2.2 [PRE-INSTALL CONSIDERATIONS](#pre-install-considerations)
-* 3 [MOVING ON: A FEW IMPORTANT FS COMMANDS FOR STARTERS](#moving-on-a-few-important-fs-commands-for-starters)  
-   * 3.1 [THE FS FILE SYSTEM: WHERE STUFF IS FOR STARTERS:](#the-fs-file-system-where-stuff-is-for-starters)
-* 4 [SETTING THE SIP PROFILES TO USE DIFFERENT ETHERNET PORTS](#setting-the-sip-profiles-to-use-different-ethernet-ports)  
-   * 4.1 [INTERNAL LAN](#internal-lan)  
-   * 4.2 [EXTERNAL WAN](#external-wan)  
-   * 4.3 [GETTING YOUR LAN PHONES REGISTERED](#getting-your-lan-phones-registered)  
-   * 4.4 [CHANGING THE PASSWORD FOR SIP REGISTRATION ON YOUR LAN](#changing-the-password-for-sip-registration-on-your-lan)  
-   * 4.5 [APPLYING YOUR CHANGES AND CHECKING YOUR WORK](#applying-your-changes-and-checking-your-work)
-* 5 [REGISTERING WITH A SIP PROVIDER](#registering-with-a-sip-provider)  
-   * 5.1 [LETS MAKE SOME CALLS (OUT-GOING)](#lets-make-some-calls-out-going)  
-   * 5.2 [IN-COMING CALLS, RINGING A GROUP](#in-coming-calls-ringing-a-group)
-* 6 [MOVING ON TO MORE ADVANCED TOPICS](#moving-on-to-more-advanced-topics)  
-   * 6.1 [VOICE MAIL (OR "HOW TO ACCESS SOME THINGS THAT FS IS PREPARED TO DO")](#voice-mail-or-how-to-access-some-things-that-fs-is-prepared-to-do)  
-   * 6.2 [INCOMING CALLS RING A GROUP AND GOES TO VM AFTER NO ANSWER](#incoming-calls-ring-a-group-and-goes-to-vm-after-no-answer)  
-   * 6.3 [ADDING ANOTHER DID](#adding-another-did)
-* 7 [CHEAT SHEET (OR MORE STUFF FS IS READY TO DO)](#cheat-sheet-or-more-stuff-fs-is-ready-to-do)
-* 8 [AND YET MORE TO COME](#and-yet-more-to-come)
-
 ## FREESWITCH FOR DUMMIES: DUAL-HOMED HOST EXAMPLE
 
 The name tells all.

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Mumble-Conference-With-ALSA_13173534.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Mumble-Conference-With-ALSA_13173534.mdx
@@ -9,22 +9,6 @@ by [Daniel O'Neill](https://freeswitch.org/confluence/display/~ver)
 
 How to set up a Mumble conference with ALSA.
 
-Click here to expand Table of Contents
-
-* 1 [Prerequisites](#prerequisites)
-* 2 [Conference Setup](#conference-setup)
-* 3 [Dialplan Setup](#conference-setup)
-* 4 [PortAudio Endpoint](#portaudio-endpoint)
-* 5 [ALSA asoundrc or asound.conf](#alsa-asoundrc-or-asoundconf)
-* 6 [Preparing FreeSWITCH](#preparing-freeswitch)
-* 7 [Mumble Configuration](#mumble-configuration)  
-   * 7.1 [Mumble manual device configuration](#mumble-manual-device-configuration)
-* 8 [Connecting it together](#connecting-it-together)
-* 9 [Testing](#conference-setup)
-* 10 [Deploying](#conference-setup)
-* 11 [TODO List](#conference-setup)
-* 12 [Credits](#conference-setup)
-
 ## Prerequisites
 
 You'll need to verify you have a few things installed before you can get started:

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/PDD_13174173.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/PDD_13174173.mdx
@@ -7,8 +7,6 @@
 
 This document covers information about PDD.
 
-Click here to expand Table of Contents
-
 Post Dial Delay - the time between the call starts (an INVITE) and there's a progress indication (a 183 or early media).
 
 You can find the delay time set as a channel variable:

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/PHP-email_13173547.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/PHP-email_13173547.mdx
@@ -7,15 +7,6 @@
 
 About text.
 
-Click here to expand Table of Contents
-
-* 1 [Introduction](#introduction)  
-   * 1.1 [PHP Mailer](#php-mailer)  
-   * 1.2 [PHP Mailer Windows](#php-mailer-windows)  
-   * 1.3 [Gmail TLS](#gmail-tls)  
-   * 1.4 [mailer\_app.php](#mailer_appphp)
-* 2 [See Also](#php-mailer)
-
 ### Introduction
 
 #### PHP Mailer

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/PfSense_13174164.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/PfSense_13174164.mdx
@@ -9,6 +9,4 @@ Here are notes on getting phones sitting behind a pfSense firewall to play conne
 
 Outbound NAT
 
-Click here to expand Table of Contents
-
 

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Prompts_13174037.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Prompts_13174037.mdx
@@ -7,13 +7,6 @@
 
 This document covers information about Prompts.
 
-Click here to expand Table of Contents
-
-* 1 [English Prompts](#english-prompts)
-* 2 [Please include other phrases that you think should be added](#please-include-other-phrases-that-you-think-should-be-added)
-* 3 [Time & Dates](#time--dates)
-* 4 [Numerical](#numerical)
-
 ### English Prompts
 
 This is  

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/SBC_Setup_13174198.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/SBC_Setup_13174198.mdx
@@ -7,18 +7,6 @@
 
 This document covers information about the SBC Setup.
 
-Click here to expand Table of Contents
-
-* 1 [Introduction](#introduction)
-* 2 [Preliminaries](#preliminaries)
-* 3 [Installation of FreeSWITCH](#installation-of-freeswitch)
-* 4 [Installation of Kamailio](#installation-of-kamailio)
-* 5 [Configuration of FreeSWITCH](#configuration-of-freeswitch)
-* 6 [Test connectivity between FreeSWITCH and Kamailio](#test-connectivity-between-freeswitch-and-kamailio)
-* 7 [Optimizations](#optimizations)
-* 8 [Check CPU usage](#check-cpu-usage)
-* 9 [Links to Kamailio and carrierroute](#links-to-kamailio-and-carrierroute)
-
 ## Introduction
 
 Below you'll find a step by step setup for installing FS as a SBC. The LCR engine is provided by Kamailio and its module carrierroute. Kamailio is an opensource SIP Proxy (not a B2BUA).   

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/SIP-Message-Logging_13174166.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/SIP-Message-Logging_13174166.mdx
@@ -7,12 +7,6 @@
 
 SIP Message Logging
 
-Click here to expand Table of Contents
-
-* 1 [Turning logging on in the FreeSWITCH SIP stack (Sofia)](#turning-logging-on-in-the-freeswitch-sip-stack-sofia)
-* 2 [Using a Network Protocol Analyser](#using-a-network-protocol-analyser)
-* 3 [Using a Sip or TCP Proxy](#using-a-sip-or-tcp-proxy)
-
 ### Turning logging on in the FreeSWITCH SIP stack (Sofia)
 
 The mod\_sofia wiki page discusses how to enable SIP messages logging [Debugging Sofia Sip](https://wiki.freeswitch.org/wiki/Sofia#Debugging%5FSofia-SIP "Sofia").

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Sipura-STUN_13174014.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Sipura-STUN_13174014.mdx
@@ -3,14 +3,6 @@
 
  
 
-Click here to expand Table of Contents
-
-* 1 [Sipura/SPA2000-2.0.2](#sipuraspa2000-202)  
-   * 1.1 [SIP settings](#sip-settings)  
-   * 1.2 [Line X settings](#sip-settings)  
-   * 1.3 [Debugging](#debugging)  
-   * 1.4 [Bugs/Issues](#bugsissues)
-
 ## Sipura/SPA2000-2.0.2
 
 * Go to web interface (get ip from phone if necessary \*\*\*\*110#)

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Virtual-servers_13174027.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Virtual-servers_13174027.mdx
@@ -3,8 +3,6 @@
 
  
 
-Click here to expand Table of Contents
-
 All the text below was last edited in 2010, it is therefore likely out-of-date, inaccurate and in dire need of a refresh
 
 Virtual Server Environments (VSE) known to support FreeSWITCH.

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Voice-files-used-by-mod-say-en_13174030.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Voice-files-used-by-mod-say-en_13174030.mdx
@@ -3,8 +3,6 @@
 
  
 
-Click here to expand Table of Contents
-
 There's a transcript of these files in the sources under docs/phrase/phrase\_en.xml
 
 ```xml

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Xmlcdrd_13173237.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/Xmlcdrd_13173237.mdx
@@ -3,19 +3,6 @@
 
  
 
-Click here to expand Table of Contents
-
-* 1 [Xmlcdrd FastCGI CDR Logger](#xmlcdrd-fastcgi-cdr-logger)  
-   * 1.1 [Overview](#overview)  
-   * 1.2 [How does it work](#how-does-it-work)  
-   * 1.3 [Requirements](#requirements)  
-   * 1.4 [Configuration overview](#configuration-overview)  
-      * 1.4.1 [Mod\_xml\_cdr Configuration](#xmlcdrd-fastcgi-cdr-logger)  
-         * 1.4.2 [mysqlcdr plugin](#xmlcdrd-fastcgi-cdr-logger)  
-         * 1.4.3 [luaexec plugin](#)  
-   * 1.5 [Build](#)  
-   * 1.6 [More complex example of radius accounting with stop packets](#xmlcdrd-fastcgi-cdr-logger)
-
 ## Xmlcdrd FastCGI CDR Logger
 
 ### Overview

--- a/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/index.mdx
+++ b/docs/FreeSWITCH-Explained/Auxiliary-Knowledge-and-Utilities/index.mdx
@@ -7,6 +7,4 @@
 
 To become a master at FreeSWITCH™, we have to gain wisdom in other places. These pages describe knowledge that might be helpful in our journey.
 
-Click here to expand Table of Contents
-
 


### PR DESCRIPTION
As part of issue #88, removed manually written Table of Contents from this directory **Auxiliary-Knowledge-and-Utilities**.