### PR TITLE
Remove outdated TOCs from /Codecs-and-Media/ directory

### DIFF
--- a/docs/FreeSWITCH-Explained/Codecs-and-Media/13173267.mdx
+++ b/docs/FreeSWITCH-Explained/Codecs-and-Media/13173267.mdx
@@ -14,17 +14,6 @@ Freeswitch currently supports several TTS options.
 * [mod\_flite](../Modules/mod_flite_3965160.mdx#about) \- An FOSS option, Flite / Festival Lite.
 * The complete list of TTS modules is available [on the modules list page](../Modules/index.mdx#about).
 
-Click here to expand Table of Contents
-
-* 1 [Javascript Implementation](#javascript-implementation)
-* 2 [Via mod\_shout using online TTS](#about)  
-   * 2.1 [Bing Translate](#bing-translate)  
-   * 2.2 [Google Translate](#bing-translate)
-* 3 [Pages in category "TTS"](#pages-in-category-tts)  
-   * 3.1 [M](#pages-in-category-tts)  
-   * 3.2 [M cont.](#pages-in-category-tts)  
-   * 3.3 [T](#pages-in-category-tts)
-
 ### Javascript Implementation
 
 [Javascript\_Session\_Speak](../Client-and-Developer-Interfaces/JavaScript/JavaScript-API-Reference/index.mdx#sessionspeak)

--- a/docs/FreeSWITCH-Explained/Codecs-and-Media/Codec-Negotiation_2883752.mdx
+++ b/docs/FreeSWITCH-Explained/Codecs-and-Media/Codec-Negotiation_2883752.mdx
@@ -9,26 +9,6 @@ Codec negotiation can be a confusing subject. If you are not familiar with [SDP]
 
 First of all, what do we mean when we say "codec negotiation"? We are talking about the _process_ of choosing which codec will be used on each leg of a call. FreeSWITCH supports a lot of codecs. Most SIP endpoints will also support multiple codecs. Each leg can have only one codec, so the codec negotiation process sifts through the choices and settles on a single codec to use. It's this "sifting process" that can cause confusion. How does this process work? How can it be modified? This page is written to help you answer those questions.
 
-Click to expand Table of Contents
-
-* 1 [Codec Negotiation in FreeSWITCH](#codec-negotiation-in-freeswitch)  
-   * 1.1 [Early Negotiation](#early-negotiation)  
-      * 1.1.1 [General principle](#general-principle)  
-         * 1.1.2 [Early Negotiation parameters](#early-negotiation-parameters)  
-   * 1.2 [Late Negotiation (requires param)](#late-negotiation-requires-param)  
-   * 1.3 [Proxy Media](#codec-negotiation-when-proxy-media-enabled)  
-   * 1.4 [Incompatible Destination](#incompatible-destination)  
-   * 1.5 [Mixing Media/Codecs on different legs (transcoding)](#mixing-mediacodecs-on-different-legs-transcoding)
-* 2 [Warnings](#codec-negotiation-in-freeswitch)
-* 3 [Examples](#codec-negotiation-in-freeswitch)  
-   * 3.1 [Modifying the codec when using proxy media mode](#modifying-the-codec-when-using-proxy-media-mode)  
-   * 3.2 [Rewriting SDP](#codec-negotiation-in-freeswitch)  
-   * 3.3 [Disable G.729b on outbound](#disable-g729b-on-outbound)  
-   * 3.4 [Codec Negotiation when proxy media enabled](#codec-negotiation-when-proxy-media-enabled)  
-      * 3.4.1 [Correct](#not-correct)  
-         * 3.4.2 [Not correct](#codec-negotiation-in-freeswitch)
-* 4 [See Also](#codec-negotiation-in-freeswitch)
-
 ## Codec Negotiation in FreeSWITCH
 
 FreeSWITCH supports two basic modes of codec negotiation: early and late. _Early_ negotiation means that the codec is negotiated between FreeSWITCH and the endpoint as soon as possible, even before FreeSWITCH needs to send media (such as ringing) or answer the the call. This occurs before an incoming call even hits the dialplan. _Late_ negotiation means to delay the choosing of the codec until after the call hits the dialplan and more information can be gathered. This additional information can be used to influence the negotiation process. Let's illustrate the differences between early- and late-negotiation.

--- a/docs/FreeSWITCH-Explained/Codecs-and-Media/Early-Media/180-vs-183-vs-Early-Media_7143480.mdx
+++ b/docs/FreeSWITCH-Explained/Codecs-and-Media/Early-Media/180-vs-183-vs-Early-Media_7143480.mdx
@@ -7,12 +7,6 @@
 
 180 vs. 183 vs. Early Media
 
-Click here to expand Table of Contents
-
-* 1 [Discussion](#discussion)
-* 2 [RFC Information](#rfc-information)
-* 3 [See Also](#see-also)
-
 ## Discussion
 
   

--- a/docs/FreeSWITCH-Explained/Codecs-and-Media/T38-Modem_9634338.mdx
+++ b/docs/FreeSWITCH-Explained/Codecs-and-Media/T38-Modem_9634338.mdx
@@ -7,12 +7,6 @@
 
 If you want to explore Hylafax with FreeSWITCH, you will need T38modem as a conduit between them.
 
-Click here to expand Table of Contents
-
-* 1 [Download](#download)
-* 2 [Installation](#installation)
-* 3 [Dialplans](#dialplans)
-
 ## Download
 
 You can get the latest version [Here](http://sourceforge.net/projects/t38modem/)


### PR DESCRIPTION
Removed manual TOCs from /Codes-and-Media/ directory as part of issue #88.