### PR TITLE
Update record_post_process_exec_app_16352899.mdx

### DIFF
--- a/docs/Channel-Variables-Catalog/record_post_process_exec_app_16352899.mdx
+++ b/docs/Channel-Variables-Catalog/record_post_process_exec_app_16352899.mdx
@@ -13,4 +13,22 @@ string Executes an app for the purpose of postprocessing recorded audio. The rea
 <action application="set" data="record_post_process_exec_app=lua::vm_test.lua" />
 ```
 
+```xml
+<action application="set" data="record_post_process_exec_app=system:/path/script.sh" />
+```
+
+> **Runs a FreeSWITCH *application* or an external *system* command _after_ `record_session` finishes — even when the A-leg hangs up first and the dialplan stops.**
+
+### Syntax
+
+```text
+record_post_process_exec_app=<app-spec>
+```
+
+`<app-spec>` supports two distinct forms:
+
+| Purpose                     | Prefix        | Example                                                                           |
+| --------------------------- | ------------- | --------------------------------------------------------------------------------- |
+| Call a FreeSWITCH app       | `<app>:[<module>::]<args>` | `lua::vm_test.lua` |
+| Execute an OS-level command | `system:`     | `system:/opt/scripts/convert_upload.sh ${record_path} ${uuid}` |
 


### PR DESCRIPTION
docs(record_post_process_exec_app): add `system:` prefix, syntax table, and security notes

* Explain the two valid <app-spec> formats and introduce a clear syntax table
* Document how to invoke external shell commands via the `system:` prefix