### PR TITLE
Remove `mod_h26x`

### DIFF
--- a/docs/FreeSWITCH-Explained/Codecs-and-Media/Video-Codecs_1048673.mdx
+++ b/docs/FreeSWITCH-Explained/Codecs-and-Media/Video-Codecs_1048673.mdx
@@ -1,24 +1,12 @@
 
-# Video Codecs 
-
- 
+# Video Codecs
 
 ## Pass-through video codecs
 
-* H261 - H.261 Video
-* H263 - H.263 Video
-* H263-1998 - H.263-1998 Video
-* H263-2000 - H.263-2000 Video
-* H264 - H.264 Video  
-   * Provided by mod\_h26X.
-* Theora passthrough.  
-   * Provided by mod\_theora.
-* MP4 Video passthrough.  
-   * Provided by mod\_mp4v.
-
-### Comments:
-
-| H264 now provided by mod\_av which use ffmpeg.also there are VP8, VP9 provided by vpx ![](/images/icons/contenttypes/comment_16.png) Posted by niuzb at Sep 09, 2020 21:45 |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-
+* H264 - H.264 Video
+   * Provided by mod\_av.
+* VP8
+   * Provided by mod\_vp8
+* VP9
+   * Built into FreeSWITCH core
 

--- a/docs/FreeSWITCH-Explained/Configuration/Configuring-FreeSWITCH/vars.xml_7144079.mdx
+++ b/docs/FreeSWITCH-Explained/Configuration/Configuring-FreeSWITCH/vars.xml_7144079.mdx
@@ -1,7 +1,7 @@
 
-# vars.xml 
+# vars.xml
 
- 
+
 
 ## About
 
@@ -9,7 +9,7 @@ FreeSWITCH™ vars.xml contains some variables used throughout the system. This 
 
 This file and all config files can be reloaded to a running FreeSWITCH with the fs\_cli command `reloadxml` which is function key F6 by default.
 
-  
+
 Click here to expand Table of Contents
 
 * 1 [Location](#location)
@@ -18,7 +18,7 @@ Click here to expand Table of Contents
 * 4 [Variable Types](#variable-types)
 * 5 [Predefined variables](#predefined-variables)
 
-  
+
 ### Location
 
 The root directory of FreeSWITCH configuration files can be discovered by executing the following fs\_cli command:
@@ -60,7 +60,7 @@ hostname
 local_ip_v4
 local_mask_v4
 local_ip_v6
-switch_serial       
+switch_serial
 base_dir
 recordings_dir
 sound_prefix
@@ -75,7 +75,7 @@ The -nonat switch eliminates the nat\_xxx variables above since it disables NAT 
 
 The following default vars.xml file was taken from FreeSWITCH 1.10.4 from the middle of 2020 (the year of Hell).
 
-  
+
 **vars.xml**
 
 ```xml
@@ -295,13 +295,10 @@ The following default vars.xml file was taken from FreeSWITCH 1.10.4 from the mi
        G723             - G723.1 in passthru mode. (mod_g723_1)
        AMR              - AMR in passthru mode. (mod_amr)
 
-       These are the passthru video codecs: (mod_h26x)
+       These are the passthru video codecs:
 
-       H261             - H.261 Video
-       H263             - H.263 Video
-       H263-1998        - H.263-1998 Video
-       H263-2000        - H.263-2000 Video
-       H264             - H.264 Video
+       H264             - H.264 Video (mod_av)
+       VP8              - VP8 (mod_vp8)
 
        RTP Dynamic Payload Numbers currently used in FreeSWITCH and their purpose.
 
@@ -533,5 +530,5 @@ The following default vars.xml file was taken from FreeSWITCH 1.10.4 from the mi
 .
 ```
 
-  
+
 

--- a/docs/FreeSWITCH-Explained/Configuration/Default-Configuration_6587388.mdx
+++ b/docs/FreeSWITCH-Explained/Configuration/Default-Configuration_6587388.mdx
@@ -1,10 +1,10 @@
 
-# Default Configuration 
+# Default Configuration
 
 
 ## 0\. About
 
-A discussion of the default configuration files and how they interact.  
+A discussion of the default configuration files and how they interact.
 
 TODO See TODOs in [Vanilla installation files](../Installation/Linux/Vanilla-installation-files_27591294.mdx#0-about).
 
@@ -24,41 +24,37 @@ When FreeSWITCH starts or when the reloadxml command is issued to the API, FreeS
 
 `log/freeswitch.xml.fsxml` contains all the individual configuration files concatenated together into one huge file. When FreeSWITCH reports a configuration file error, the line number in the error message refers to this file, which can have more than 10 thousand lines.
 
-## 3\. Dialplans 
+## 3\. Dialplans
 
 A dialplan is a series of actions, and the conditions upon which they are executed. A dialplan tells FreeSWITCH how to behave, what to do, and when to do it. FreeSWITCH supports 3 Dialplans.
 
-### [Dialplan XML](https://freeswitch.org/confluence/pages/viewpage.action?pageId=3966106) 
+### [Dialplan XML](https://freeswitch.org/confluence/pages/viewpage.action?pageId=3966106)
 
 Dialplan.xml is the primary dialplan of FreeSWITCH. As its name suggests, it's an XML formatted file.
 
-### [mod_dialplan_asterisk](../Modules/mod_dialplan_asterisk_3966416.mdx#about) 
+### [mod_dialplan_asterisk](../Modules/mod_dialplan_asterisk_3966416.mdx#about)
 
 Actually, this file is called extensions.conf, it is a compatibility file that supports Asterisk style dialplans.
 
-### [ENUM](../Modules/mod_enum_6587333.mdx#enum) 
+### [ENUM](../Modules/mod_enum_6587333.mdx#enum)
 
 ENUM is a translation system from PSTN numbers to VoIP uri.
 
-## 4\. Codecs 
+## 4\. Codecs
 
 These modules provide codecs - support for various ways of COding and DECoding speech audio.
 
-### [mod_g723_1](../Modules/mod_g723_1_3375594.mdx#about) 
+### [mod_g723_1](../Modules/mod_g723_1_3375594.mdx#about)
 
 mod\_g723\_1 is the G.723.1 pass-through implementation.
 
-### [mod_g729](../Modules/mod_g729_3375549.mdx#about) 
+### [mod_g729](../Modules/mod_g729_3375549.mdx#about)
 
 The G.729 Codec. See the [commercial G.729](../Modules/mod_com_g729_1049284.mdx#about) version for licensing information.
 
-### [mod_amr](../Modules/mod_amr_3964984.mdx#about) 
+### [mod_amr](../Modules/mod_amr_3964984.mdx#about)
 
 The AMR Codec.
-
-### [mod_h26x](../Codecs-and-Media/Video-Codecs_1048673.mdx#comments)
-
-Video codec.
 
 ### [mod_opus](../Modules/mod_opus_6586850.mdx#about)
 
@@ -68,11 +64,11 @@ WebRTC codec.
 
 Google video codec.
 
-## 5\. Modules 
+## 5\. Modules
 
 These modules provide additional functionality to FreeSWITCH.
 
-### [mod_cdr_csv](../Modules/mod_cdr_csv_6587322.mdx#legs) 
+### [mod_cdr_csv](../Modules/mod_cdr_csv_6587322.mdx#legs)
 
 The Call Detail Record module
 
@@ -80,19 +76,19 @@ The Call Detail Record module
 
 A module that contains various commands.
 
-### [mod_conference](../Modules/mod_conference_3965534.mdx#list) 
+### [mod_conference](../Modules/mod_conference_3965534.mdx#list)
 
 The conferencing module.
 
-### [mod_console](../Modules/mod_console_1048950.mdx#about) 
+### [mod_console](../Modules/mod_console_1048950.mdx#about)
 
 The module that reads and writes to the console.
 
-### [mod_dialplan_asterisk](../Modules/mod_dialplan_asterisk_3966416.mdx#about) 
+### [mod_dialplan_asterisk](../Modules/mod_dialplan_asterisk_3966416.mdx#about)
 
 The module responsible for parsing extensions.conf to provide a limited Asterisk-compatible configuration.
 
-### [mod_dialplan_xml](../Dialplan/XML-Dialplan/index.mdx#about) 
+### [mod_dialplan_xml](../Dialplan/XML-Dialplan/index.mdx#about)
 
 The module responsible for parsing and implementing the Dialplan.xml file.
 
@@ -100,7 +96,7 @@ The module responsible for parsing and implementing the Dialplan.xml file.
 
 The Dial Plan Tools module, includes various functions to deal with dialplans.
 
-### [mod_enum](../Modules/mod_enum_6587333.mdx#enum) 
+### [mod_enum](../Modules/mod_enum_6587333.mdx#enum)
 
 ENUM numbers lookup module (E.164) format
 
@@ -108,11 +104,11 @@ ENUM numbers lookup module (E.164) format
 
 Extra SIP Functionality module, provides multicast paging support.
 
-### [mod_event_socket](../Modules/mod_event_socket_1048924.mdx#11-acl) 
+### [mod_event_socket](../Modules/mod_event_socket_1048924.mdx#11-acl)
 
 Event Socket module, provides for script control of FreeSWITCH™.
 
-### [mod_expr](../Modules/mod_expr_6587353.mdx#about) 
+### [mod_expr](../Modules/mod_expr_6587353.mdx#about)
 
 Expression Evaluation Library module.
 
@@ -120,11 +116,11 @@ Expression Evaluation Library module.
 
 Basic call queuing module, for call centers.
 
-### [mod_fsv](../Modules/mod_fsv_6587435.mdx#about) 
+### [mod_fsv](../Modules/mod_fsv_6587435.mdx#about)
 
 Video File Format Module, for FreeSWITCH Video.
 
-###  mod_limit 
+###  mod_limit
 
 Limit the number of calls to or from an arbitrary resource; also implements db and group API functions and dialplan applications.
 
@@ -136,39 +132,39 @@ See also:
 * [mod\_hash](../Modules/mod_hash_6586975.mdx#api)
 * [mod\_db](../Modules/mod_db_6586567.mdx#api)
 
-### [mod_local_stream](../Modules/mod_local_stream_6587466.mdx#api) 
+### [mod_local_stream](../Modules/mod_local_stream_6587466.mdx#api)
 
 Local streaming module.
 
-### [mod_logfile](../Modules/mod_logfile_1048990.mdx#about) 
+### [mod_logfile](../Modules/mod_logfile_1048990.mdx#about)
 
 Module that controls logging to a file.
 
-### [mod_loopback](../Dialplan/Loopback-Endpoint_6587541.mdx#about) 
+### [mod_loopback](../Dialplan/Loopback-Endpoint_6587541.mdx#about)
 
 Local dialplan loopback module. Use with caution.
 
-### [mod_native_file](../Modules/mod_native_file_6587161.mdx#about) 
+### [mod_native_file](../Modules/mod_native_file_6587161.mdx#about)
 
 Native sounds playback module.
 
-### mod_say_en 
+### mod_say_en
 
 TTS (text-to-speech) services for English.
 
-### mod_sndfile 
+### mod_sndfile
 
 Sound file playback framework demo module.
 
-### [mod_sofia](../Modules/mod_sofia_1048707.mdx#about) 
+### [mod_sofia](../Modules/mod_sofia_1048707.mdx#about)
 
 FreeSWITCH SIP endpoint module.
 
-### [mod_v8](../Modules/mod_v8_1048935.mdx#api) 
+### [mod_v8](../Modules/mod_v8_1048935.mdx#api)
 
 FreeSWITCH uses the Google V8 JavaScript (ECMAScript) engine, which supersedes mod\_spidermonkey. See the [Javascript](../Client-and-Developer-Interfaces/JavaScript/index.mdx#api) page for more information and examples.
 
-### [mod_tone_stream](../Modules/mod-dptools/gentones/Tone-stream/Tone_stream_6586599.mdx#about) 
+### [mod_tone_stream](../Modules/mod-dptools/gentones/Tone-stream/Tone_stream_6586599.mdx#about)
 
 Module for tone generation. See more under [TGML](../Modules/mod-dptools/gentones/TGML_6586573.mdx#lua).
 
@@ -180,7 +176,7 @@ FreeSWITCH Voicemail Module
 
 The family of FreeSWITCH modules including mod\_fax, mod\_t38gateway, and the mod\_voipcodecs have been merged into one module called mod\_spandsp which takes advantage of all the DSP features found in the SpanDSP library including T.38 endpoint and gateway functionality.
 
-### mod_file_string 
+### mod_file_string
 
 _Function of this module are now part of mod\_dptools_
 
@@ -188,7 +184,7 @@ Play strings of files
 
 ## 6. Configuration-Files {#configuration}
 
-### [conf/](https://github.com/signalwire/freeswitch/tree/master/conf/vanilla) 
+### [conf/](https://github.com/signalwire/freeswitch/tree/master/conf/vanilla)
 
 This is the main configuration directory.
 
@@ -216,7 +212,7 @@ conf/[vars.xml](https://github.com/signalwire/freeswitch/tree/master/conf/vanill
 conf/[voicemail.tpl](https://github.com/signalwire/freeswitch/tree/master/conf/vanilla/voicemail.tpl)
 conf/[web-vm.tpl](https://github.com/signalwire/freeswitch/tree/master/conf/vanilla/web-vm.tpl)
 
-### [conf/autoload_configs/](https://github.com/signalwire/freeswitch/tree/master/conf/vanilla/autoload%5Fconfigs) 
+### [conf/autoload_configs/](https://github.com/signalwire/freeswitch/tree/master/conf/vanilla/autoload%5Fconfigs)
 
 conf/autoload_configs/[alsa.conf.xml](https://github.com/signalwire/freeswitch/blob/master/conf/vanilla/autoload%5Fconfigs/alsa.conf.xml)
 conf/autoload_configs/[cdr_csv.conf.xml](https://github.com/signalwire/freeswitch/tree/master/conf/vanilla/autoload%5Fconfigs/cdr%5Fcsv.conf.xml)
@@ -239,21 +235,21 @@ conf/autoload_configs/[post_load_modules.conf.xml](https://github.com/signalwire
 conf/autoload_configs/[rss.conf.xml](https://github.com/signalwire/freeswitch/blob/master/conf/vanilla/autoload%5Fconfigs/rss.conf.xml)
 conf/autoload_configs/[sofia.conf.xml](https://github.com/signalwire/freeswitch/blob/master/conf/vanilla/autoload%5Fconfigs/sofia.conf.xml)
 conf/autoload_configs/[switch.conf.xml](https://github.com/signalwire/freeswitch/blob/master/conf/vanilla/autoload%5Fconfigs/switch.conf.xml)
-conf/autoload_configs/[syslog.conf.xml](https://github.com/signalwire/freeswitch/blob/master/conf/vanilla/autoload%5Fconfigs/syslog.conf.xml)  
-conf/autoload_configs/[v8.conf.xml](https://github.com/signalwire/freeswitch/blob/master/conf/vanilla/autoload%5Fconfigs/v8.conf.xml)  
+conf/autoload_configs/[syslog.conf.xml](https://github.com/signalwire/freeswitch/blob/master/conf/vanilla/autoload%5Fconfigs/syslog.conf.xml)
+conf/autoload_configs/[v8.conf.xml](https://github.com/signalwire/freeswitch/blob/master/conf/vanilla/autoload%5Fconfigs/v8.conf.xml)
 conf/autoload_configs/[voicemail.conf.xml](https://github.com/signalwire/freeswitch/blob/master/conf/vanilla/autoload%5Fconfigs/voicemail.conf.xml)
 conf/autoload_configs/[xml_cdr.conf.xml](https://github.com/signalwire/freeswitch/blob/master/conf/vanilla/autoload%5Fconfigs/xml%5Fcdr.conf.xml)
 conf/autoload_configs/[xml_curl.conf.xml](https://github.com/signalwire/freeswitch/blob/master/conf/vanilla/autoload%5Fconfigs/xml%5Fcurl.conf.xml)
 conf/autoload_configs/[xml_rpc.conf.xml](https://github.com/signalwire/freeswitch/blob/master/conf/vanilla/autoload%5Fconfigs/xml%5Frpc.conf.xml)
 conf/autoload_configs/[zeroconf.conf.xml](https://github.com/signalwire/freeswitch/blob/master/conf/vanilla/autoload%5Fconfigs/zeroconf.conf.xml)
 
-### [conf/dialplan/](https://github.com/signalwire/freeswitch/tree/master/conf/vanilla/dialplan) 
+### [conf/dialplan/](https://github.com/signalwire/freeswitch/tree/master/conf/vanilla/dialplan)
 
 conf/dialplan/default.xml
 conf/dialplan/features.xml
 conf/dialplan/public.xml
 
-### [conf/directory/](https://github.com/signalwire/freeswitch/tree/master/conf/vanilla/directory) 
+### [conf/directory/](https://github.com/signalwire/freeswitch/tree/master/conf/vanilla/directory)
 
 This is the sub–directory that will hold all of the users allowed access to make calls via FreeSWITCH.
 
@@ -262,15 +258,15 @@ It's possible to define all extensions in one single XML file. In practice, espe
 For example:
 
 * conf/directory/default.xml — contains directive that causes loading of conf/directory/default/\*.xml files
-* conf/directory/default/4411.xml — contains config info for extension 4411.xml in the default-global context, meaning extension 4411 is shared across all companies; this could be useful for, say, a universal "help desk" service that could ring your FS help desk for all your clients.  
-   * conf/directory/companyA.xml — contains directive that causes loading of conf/directory/companyA/\*.xml child files  
-      * conf/directory/companyA/1000.xml — contains config info for extension 1000.xml in companyA  
-         * conf/directory/companyA/1001.xml — contains config info for extension 1001.xml in companyA  
-   * conf/directory/companyB.xml — contains directive that causes loading of conf/directory/companyB/\*.xml child files  
-      * conf/directory/companyB/1000.xml — contains config info for extension 1000.xml in companyB  
+* conf/directory/default/4411.xml — contains config info for extension 4411.xml in the default-global context, meaning extension 4411 is shared across all companies; this could be useful for, say, a universal "help desk" service that could ring your FS help desk for all your clients.
+   * conf/directory/companyA.xml — contains directive that causes loading of conf/directory/companyA/\*.xml child files
+      * conf/directory/companyA/1000.xml — contains config info for extension 1000.xml in companyA
+         * conf/directory/companyA/1001.xml — contains config info for extension 1001.xml in companyA
+   * conf/directory/companyB.xml — contains directive that causes loading of conf/directory/companyB/\*.xml child files
+      * conf/directory/companyB/1000.xml — contains config info for extension 1000.xml in companyB
          * conf/directory/companyB/1001.xml — contains config info for extension 1001.xml in companyB
 
-### [conf/lang/](https://github.com/signalwire/freeswitch/tree/master/conf/vanilla/lang) 
+### [conf/lang/](https://github.com/signalwire/freeswitch/tree/master/conf/vanilla/lang)
 
 Configuration for multiple language support. Used by mod\_say\_xx, such as mod\_say\_en.
 
@@ -289,11 +285,11 @@ Default configs includes de, en, fr, and ru.
 
 Useful in [Speech Phrase Management](./Speech-Phrase-Management_9634492.mdx#0-about).
 
-### [conf/jingle_profiles](https://github.com/signalwire/freeswitch/tree/master/conf/vanilla/jingle%5Fprofiles) 
+### [conf/jingle_profiles](https://github.com/signalwire/freeswitch/tree/master/conf/vanilla/jingle%5Fprofiles)
 
 This is where the different profiles for [mod\_dingaling](../Modules/mod_dingaling_6587385.mdx#faq) get placed.
 
-### [conf/mrcp_profiles/](https://github.com/signalwire/freeswitch/tree/master/conf/vanilla/mrcp%5Fprofiles) 
+### [conf/mrcp_profiles/](https://github.com/signalwire/freeswitch/tree/master/conf/vanilla/mrcp%5Fprofiles)
 
 Profiles for Media Resource Control Protocol (MRCP) via [mod\_unimrcp](../Modules/mod_unimrcp_6586728.mdx#tts).
 
@@ -308,7 +304,7 @@ conf/mrcp_profiles/voxeo-prophecy-8.0-mrcp-v1.xml
 
 ### [conf/sip_profiles/](https://github.com/signalwire/freeswitch/tree/master/conf/vanilla/sip%5Fprofiles)
 
-This is where the different SIP profiles (or endpoints) are defined. (See [Sofia SIP Stack](./Sofia-SIP-Stack/index.mdx#faq) and [Configuring FreeSWITCH](./Configuring-FreeSWITCH/index.mdx#set).) 
+This is where the different SIP profiles (or endpoints) are defined. (See [Sofia SIP Stack](./Sofia-SIP-Stack/index.mdx#faq) and [Configuring FreeSWITCH](./Configuring-FreeSWITCH/index.mdx#set).)
 
 Public Context for Security
 
@@ -331,10 +327,10 @@ If you look in the directory config files, `conf/directory/default/*.xml` (see I
 When a user registers and places a call, their context is set to whatever is in their `user_context` variable, thus `default` .
 
 The reasoning behind all of this is that if you manage to turn off authentication or otherwise open up the `internal` profile then you won't by default expose your private dialplan to the world (e.g., for toll fraud).
-  
-  
+
+
 ## Attachments:
 
-![](/images/icons/bullet_blue.gif) [fs\_default\_config.jpg](/attachments/6587388/7045132.jpg) (image/jpeg)  
+![](/images/icons/bullet_blue.gif) [fs\_default\_config.jpg](/attachments/6587388/7045132.jpg) (image/jpeg)
 
 

--- a/docs/FreeSWITCH-Explained/Configuration/OpenWrt_13173507.mdx
+++ b/docs/FreeSWITCH-Explained/Configuration/OpenWrt_13173507.mdx
@@ -1,7 +1,7 @@
 
-# OpenWrt 
+# OpenWrt
 
- 
+
 
 ## About
 
@@ -50,16 +50,16 @@ Also, keep in mind you cannot just directly connect your DB9 serial cable to the
 
 ## Location of Firmware
 
-RoundSparrow has been considerate enough to provide precompiled images for this [router: ](http://forum.openwrt.org/viewtopic.php?id=19475)  
+RoundSparrow has been considerate enough to provide precompiled images for this [router: ](http://forum.openwrt.org/viewtopic.php?id=19475)
 His direct [link](http://sites.google.com/a/roundsparrow.com/openwrt%5Fap81/)
 
 ## Project Files
 
 The file [freeswitch-openwrt.tar.gz](http://files.freeswitch.org/freeswitch-openwrt.tar.gz) consists of several files:
 
-\- Makefile (self explanatory)   
-\- freeswitch-modules.conf (this gets copied to the build folder during compile)   
-\- several patch files required for building in a cross compile environment 
+\- Makefile (self explanatory)
+\- freeswitch-modules.conf (this gets copied to the build folder during compile)
+\- several patch files required for building in a cross compile environment
 
 ## Compiling FreeSWITCH
 
@@ -71,7 +71,7 @@ At this point you can type: **make V=99 package/freeswitch-compile**. In the end
 
 If you don't want to build your own copy of FreeSWITCH you can attempt to install the prepackaged file, [freeswitch-openwrt.ipk](http://files.freeswitch.org/freeswitch-openwrt%5Fmips.ipk). This will ONLY work on routers that use the MIP32r2 instruction set (such as the Planex above). GCC strings that were passed to the cross compiler: "-mips32r2 -mtune=mips32r2"
 
-This package has several dependencies: libncurses, libreadline, libpthread, libpcre, libgnutls 
+This package has several dependencies: libncurses, libreadline, libpthread, libpcre, libgnutls
 
 If you're curious about the contents you can just extract it with tar as it's just a gzip tar file.
 
@@ -87,28 +87,28 @@ CPU: 9% usr 9% sys 0% nice 0% idle 81% io 0% irq 0% softirq Load average: 0.41 0
 
 ```xml
  PID  PPID USER     STAT   VSZ %MEM %CPU COMMAND
-3474  3453 root     R    18984  64%   9% /usr/local/freeswitch/bin/freeswitch 
-3719  2327 root     R     1380   5%   9% top -b 
-3542  3453 root     R    18984  64%   0% /usr/local/freeswitch/bin/freeswitch 
-3540  3453 root     R    18984  64%   0% /usr/local/freeswitch/bin/freeswitch 
-3462  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch 
-3470  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch 
-3546  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch 
-3455  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch 
-3538  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch 
-3454  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch 
-3541  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch 
-3463  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch 
-3539  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch 
-3475  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch 
-3452  3451 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch 
-3456  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch 
-3459  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch 
-3537  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch 
-3453  3452 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch 
-3473  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch 
-3457  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch 
-3458  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch 
+3474  3453 root     R    18984  64%   9% /usr/local/freeswitch/bin/freeswitch
+3719  2327 root     R     1380   5%   9% top -b
+3542  3453 root     R    18984  64%   0% /usr/local/freeswitch/bin/freeswitch
+3540  3453 root     R    18984  64%   0% /usr/local/freeswitch/bin/freeswitch
+3462  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch
+3470  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch
+3546  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch
+3455  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch
+3538  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch
+3454  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch
+3541  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch
+3463  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch
+3539  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch
+3475  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch
+3452  3451 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch
+3456  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch
+3459  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch
+3537  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch
+3453  3452 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch
+3473  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch
+3457  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch
+3458  3453 root     S    18984  64%   0% /usr/local/freeswitch/bin/freeswitch
 1103     1 root     S     2792   9%   0% hostapd -P /var/run/wifi-wlan0.pid -B
 ```
 
@@ -120,15 +120,15 @@ If you're use to running the FreeSWITCH console via a screen session on other un
 
 ```bash
 root@OpenWrt:/usr/local/freeswitch/mod# ls
-mod_amr.so                mod_esf.so                mod_iax.so                mod_sofia.so
-mod_cdr_csv.so            mod_event_multicast.so    mod_ilbc.so               mod_speex.so
-mod_commands.so           mod_event_socket.so       mod_limit.so              mod_syslog.so
-mod_conference.so         mod_expr.so               mod_local_stream.so       mod_tone_stream.so
-mod_console.so            mod_fifo.so               mod_logfile.so            mod_voicemail.so
-mod_dialplan_asterisk.so  mod_fsv.so                mod_loopback.so           mod_voipcodecs.so
-mod_dialplan_xml.so       mod_g723_1.so             mod_native_file.so        mod_xml_cdr.so
-mod_dptools.so            mod_g729.so               mod_say_en.so             mod_xml_curl.so
-mod_enum.so               mod_h26x.so               mod_sndfile.so            mod_xml_rpc.so
+mod_amr.so                mod_esf.so                mod_ilbc.so                mod_speex.so
+mod_cdr_csv.so            mod_event_multicast.so    mod_limit.so               mod_syslog.so
+mod_commands.so           mod_event_socket.so       mod_local_stream.so        mod_tone_stream.so
+mod_conference.so         mod_expr.so               mod_logfile.so             mod_voicemail.so
+mod_console.so            mod_fifo.so               mod_loopback.so            mod_voipcodecs.so
+mod_dialplan_asterisk.so  mod_fsv.so                mod_native_file.so         mod_xml_cdr.so
+mod_dialplan_xml.so       mod_g723_1.so             mod_say_en.so              mod_xml_curl.so
+mod_dptools.so            mod_g729.so               mod_sndfile.so             mod_xml_rpc.so
+mod_enum.so               mod_iax.so                mod_sofia.so
 ```
 
 ## Sample startup/shutdown scripts
@@ -140,11 +140,11 @@ mod_enum.so               mod_h26x.so               mod_sndfile.so            mo
 ulimit -s 240
 export PREFIX=/usr/local/freeswitch
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PREFIX/lib
-$PREFIX/bin/freeswitch -conf $PREFIX/conf -db $PREFIX/db -log $PREFIX/log 
+$PREFIX/bin/freeswitch -conf $PREFIX/conf -db $PREFIX/db -log $PREFIX/log
 
 ```
 
-  
+
 **stopfs.sh**
 
 ```bash
@@ -153,8 +153,8 @@ export PREFIX=/usr/local/freeswitch
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PREFIX/lib
 $PREFIX/bin/freeswitch -stop
 ```
-  
-  
+
+
 ## To Do
 
 * Get NSPR/spider\_monkey compiled (doesn't play nice in a cross compiled environment)


### PR DESCRIPTION
Fixes #218, also related to #204 and #220 but does not close them.

Needs review for accuracy of what video codecs are actually still supported. h26x, theora, and mp4 seem to be deprecated but not sure what is now built-in versus unsupported versus supported by other modules. Went based on a couple of comments but didn't find reference to VP9 elsewhere so that should perhaps come out.

Module file seems to already be deleted