### PR TITLE
Update mod_event_socket_1048924.mdx

### DIFF
--- a/docs/FreeSWITCH-Explained/Modules/mod_event_socket_1048924.mdx
+++ b/docs/FreeSWITCH-Explained/Modules/mod_event_socket_1048924.mdx
@@ -347,7 +347,7 @@ body line N           <-- or here if there's  | event body       |
                           a body              |                  |
 
 --------------------------------------------------------------------
-\n is a line feed in the form of CRLF.
+\n is a line feed in the form of LF, not CRLF.
 ```
 
   
@@ -379,7 +379,6 @@ Content-Length: 41
 #### 3.5.2 `event plain` parsing instructions
 
 1. **Look for 2 line feeds** or end-of-line sequences(EOL)  
-TODO The original text contains LF, the FreeSWITCH book says CRLF. Figure out which is correct.
 2. **Get the event data**  
 Read exactly as many bytes from the socket as specified in the `Content-Length` header  
 Note that since this is TCP, this may take more than one read so if you are supposed to read 200 bytes and the next read only returns 50, you must continue to read another 150, and so on until you have read 200 bytes or the socket has an error.  


### PR DESCRIPTION
https://github.com/Deepwalker/FreeSWITCH/blob/982adfff79aa817b837675a5d10cfc9b5ab2406a/src/mod/event_handlers/mod_event_socket/mod_event_socket.c#L1404 Based on looking at the source for mod_event_socket, it is confirmed that the line-separator sequence is `\n` (LF) and NOT `\r\n` (CRLF).