### PR TITLE
Docs: addition to document systemd startup and fs_cli usage.

### DIFF
--- a/docs/FreeSWITCH-Explained/Installation/Linux/Debian_67240088.mdx
+++ b/docs/FreeSWITCH-Explained/Installation/Linux/Debian_67240088.mdx
@@ -49,16 +49,23 @@ TOKEN=YOURSIGNALWIRETOKEN
 apt update && apt install -y curl
 curl -sSL https://freeswitch.org/fsget | bash -s $TOKEN release install
 ```
+FreeSWITCH™ is now installed.
 
-FreeSWITCH™ is now installed and can be accessed with
+Start the service and verify that it is running:
 
-##### FreeSWITCH CLI
+```bash
+systemctl daemon-reload
+systemctl start freeswitch
+systemctl status freeswitch
+```
+
+Once the service is running, connect to the FreeSWITCH CLI:
 
 ```bash
 fs_cli -rRS
 ```
 
-Master Branch ("git"):
+### Installing From the Master Branch ("git"):
 
 WARNING not suitable for production
 


### PR DESCRIPTION
This addition documents how to start FreeSWITCH using systemd after installation and how to connect to the FreeSWITCH CLI.  The reason is that the service does not start automatically, accessing the event socket requires explicitly starting the service.

## Description

<!-- What does this PR do? Why is this change needed? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

<!-- Link any related issues: Fixes #123 or Relates to #456 -->

## Testing

<!-- How did you test your changes? -->

- [ ] Added/updated unit tests
- [x] Tested manually
- [x] Tested with live SignalWire credentials (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [ ] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)
- [x] All existing tests pass

## Additional Notes

<!-- Any other context about the PR -->
While installing on Debian 12 (bookworm) on multiple servers, I came across the issue of ``fs_cli -rRS`` failing to connect the socket, then I figured that it is because Freeswitch doesn't actually start automatically.
Hence, I am adding this small fix to the documentation to make it explicit.