### PR TITLE
Add release notes for FreeSWITCH version 20.26.2

### DIFF
--- a/docs/FreeSWITCH-Explained/Release-Notes/FreeSWITCH-Enterprise-Release-notes_61210814.mdx
+++ b/docs/FreeSWITCH-Explained/Release-Notes/FreeSWITCH-Enterprise-Release-notes_61210814.mdx
@@ -4,6 +4,7 @@
 
 ### List of releases:
 
+* [20.26.2 (Release date: 21 May 2026)](#20262-release-date-21-may-2026)
 * [20.26.1 (Release date: 29 Jan 2026)](#20261-release-date-29-jan-2026)
 * [20.25.4 (Release date: 27 Oct 2025)](#20254-release-date-27-oct-2025)
 * [20.25.3 (Release date: 12 Sep 2025)](#20253-release-date-12-sep-2025)
@@ -31,6 +32,17 @@
 * [20.21.5 (Release date: 14 Oct 2021)](#20223-release-date-13-oct-2022)
 
 Previous release notes are on the [SignalWire Stack Release notes](./SignalWire-Stack-Release-notes_19595529.mdx#list-of-releases) page.
+
+## 20.26.2 (Release date: 21 May 2026)
+
+This is an important release containing critical security fixes and stability improvements, alongside the new reloadcert API for on-the-fly TLS certificate reloads in mod_verto and mod_sofia, streaming TTS format support in mod_shout (Mistral MP3 and Inworld NDJSON/base64), SIP 603+ detection and passthrough control in mod_sofia, and the removal of mod_cdr_mongodb from the tree. We encourage all users to upgrade to v20.26.2 whenever possible.
+
+* **Tarball:** [Tarball](https://fsa.freeswitch.com/downloads/freeswitch-releases/freeswitch-20.26.2.-release.tar.gz)
+* **Packaging:** [Instructions](https://freeswitch.org/confluence/display/FREESWITCH/Installation), [FSGET](https://github.com/signalwire/freeswitch/tree/master/scripts/packaging)
+* **Windows:** [Windows](https://fsa.freeswitch.com/downloads/windows/x64/release/FreeSWITCH-20.26.2-Release-x64.msi)
+* **Windows Sound Packages:** [Sound Packages](http://files.freeswitch.org/windows/installer/x64/sounds/)
+* **Installation Instructions:** [Debian](../Installation/Linux/Debian_for_FreeSWITCH_Enterprise.mdx#about)
+* **Release Notes:** [FreeSWITCH Advantage v20.26.2 Release notes on GitHub](https://github.com/signalwire/stack/releases/tag/v20.26.2)
 
 ## 20.26.1 (Release date: 29 Jan 2026)
 


### PR DESCRIPTION
Added release notes for version 20.26.2, including critical security fixes and new features.