### PR TITLE
Add Google Tag Manager (GTM-MSSDFRQM) analytics integration

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -130,7 +130,15 @@ const config = {
       },
     }),
 
-  plugins: ["docusaurus-plugin-sass"],
+  plugins: [
+    "docusaurus-plugin-sass",
+    [
+      "@docusaurus/plugin-google-tag-manager",
+      {
+        containerId: "GTM-MSSDFRQM",
+      },
+    ],
+  ],
 
   scripts: [
     {


### PR DESCRIPTION
## What

Adds the `@docusaurus/plugin-google-tag-manager` plugin to `docusaurus.config.js`, loading the **`GTM-MSSDFRQM`** Tag Manager container on the FreeSWITCH docs site.


