### PR TITLE
Manual-wide audit: completeness fixes + organization/IA pass

### DIFF
--- a/docs/applications/conferencing.mdx
+++ b/docs/applications/conferencing.mdx
@@ -29,6 +29,15 @@ FreeSWITCH multi-party audio and video conferencing is provided by `mod_conferen
   - [20.5.2 Member Flags at Join Time](#member-flags-at-join-time)
   - [20.5.3 Bridge Mode](#bridge-mode)
 - [20.6 Default Dialplan Conference Extensions](#default-dialplan-conference-extensions)
+- [20.7 The conference API](#the-conference-api)
+  - [20.7.1 Membership, Mute, and State](#api-membership-mute)
+  - [20.7.2 Audio: Energy, AGC, and Volume](#api-audio-energy)
+  - [20.7.3 Sounds and Playback](#api-sounds-playback)
+  - [20.7.4 Video](#api-video)
+  - [20.7.5 Recording](#api-recording)
+  - [20.7.6 Outbound Dial](#api-outbound-dial)
+  - [20.7.7 Locking, PIN, and Vars](#api-locking-pin-vars)
+  - [20.7.8 Listing and Status](#api-listing-status)
 
 ---
 
@@ -147,6 +156,11 @@ A `<profile>` element contains `<param name="..." value="..."/>` child elements.
 | `auto-gain-margin` | AGC adjustment margin (dead band). | Integer. | None |
 | `auto-gain-change-factor` | AGC step size per adjustment period. | Integer. | None |
 | `auto-gain-period-len` | Number of frames per AGC adjustment period. | Integer. | None |
+| `auto-energy-level` | Target energy level for automatic energy threshold tracking. When set, the energy threshold floats to keep talk detection adaptive. If `energy-level` is unset, it is initialized to half of this value. | Integer. Negative values clamp to `0`. | None (disabled) |
+| `auto-energy-seconds` | Averaging window, in seconds, used by the automatic energy tracker. | Integer seconds. `0` or unset falls back to the default. | `5` |
+| `max-energy-level` | Upper energy bound. Audio above this level can trigger a member mute (used to suppress excessively loud or noisy members). `0` disables. If set below `energy-level`, it is disabled. | Integer. Negative values clamp to `0`. | `0` (disabled) |
+| `max-energy-hit-trigger` | Number of consecutive over-`max-energy-level` frames required before the member is acted upon. Only applied when `max-energy-level` is set. | Integer. Negative values clamp to `0`. | `5` |
+| `max-energy-level-mute-ms` | Duration, in milliseconds, a member is muted after exceeding `max-energy-level`. Internally converted to a frame count using `interval`. | Integer ms. | None |
 | `timer-name` | Internal timer module to use for mixing. | Module name string (for example, `soft`). | `soft` |
 
 **Sound file parameters:**
@@ -208,6 +222,7 @@ A `<profile>` element contains `<param name="..." value="..."/>` child elements.
 | `broadcast-chat-messages` | Relay SIP MESSAGE chat messages from members to all other members. | `true`, `false`. | `true` |
 | `heartbeat-period-sec` | Interval in seconds at which a `conference-heartbeat` event is fired. `0` disables. | Integer seconds. | `0` |
 | `description` | Human-readable description string for the conference (included in CDR and events). | String. | None |
+| `outcall-templ` | Template dial string used when the conference originates outbound calls (for example, via the `dial`/`bgdial` API or call-list features). Channel variables in the template are expanded per outbound call. | Dial-string template with variable expansion. | None |
 
 **Recording parameters:**
 
@@ -233,6 +248,10 @@ A `<profile>` element contains `<param name="..." value="..."/>` child elements.
 | `video-codec-bandwidth` | Target output bandwidth for the MCU video encoder. | Value with unit suffix, for example, `3mb`. | None |
 | `video-auto-floor-msec` | Milliseconds a member must hold the audio floor before automatically receiving the video floor. `0` disables automatic promotion. | Integer ms. | `0` |
 | `video-canvas-count` | Number of simultaneous MCU canvases (for super-canvas / multi-canvas deployments). | Integer. | `1` |
+| `video-layout-conf` | Name of the layout configuration file from which this conference loads its video layouts. | Config file name string. | `conference_layouts.conf` |
+| `video-super-canvas-label-layers` | When non-zero, draw the canvas/layer label text on each layer of the super-canvas (the composite view of all canvases). | Integer (`0` off, non-zero on). | `0` |
+| `video-super-canvas-show-all-layers` | When non-zero, the super-canvas shows all layers from every canvas rather than only active ones. | Integer (`0` off, non-zero on). | `0` |
+| `video-super-canvas-bgcolor` | Background color of the super-canvas in hex RGB. | `#RRGGBB` string. | `#068df3` |
 | `video-quality` | Encoder quality preset for MCU output. | Integer `0`-`4`. | `1` |
 | `video-kps-debounce` | Milliseconds to wait before adjusting the MCU encoder bitrate in response to bandwidth changes. | Integer ms. | `5000` |
 | `video-no-video-avatar` | Image file used as a placeholder for members without a camera. | File path. | None |
@@ -529,3 +548,160 @@ The vanilla `default` dialplan context (`dialplan/default.xml`) provides pre-bui
 ```
 
 Note that the video MCU extensions (`35xx`-`38xx`) do not append `${domain_name}` to the room name, so the room name is the bare extension number. The audio-only extensions (`30xx`-`33xx`) append `-${domain_name}` to namespace rooms per domain.
+
+---
+
+## 20.7 The conference API {#the-conference-api}
+
+`mod_conference` registers a single `conference` API command. It is invoked from the FreeSWITCH CLI (`fs_cli`), from `mod_event_socket`, or from the dialplan (via `api`/`bgapi`) to inspect and control running conferences. All control actions take the form:
+
+```
+conference <conf_name> <subcommand> [args]
+```
+
+where `<conf_name>` is the room name. A few global sub-commands (`list`, `xml_list`, `json_list`) can be issued without a conference name to operate across all rooms. The sub-commands below are the complete set registered in `conference_api_sub_commands[]`.
+
+Many member-targeted sub-commands accept a member selector in place of a numeric member ID:
+
+| Selector | Meaning |
+|----------|---------|
+| `<member_id>` | A specific member by numeric ID. |
+| `all` | Every member in the conference. |
+| `last` | The most recently joined member. |
+| `non_moderator` | Every member that is not a moderator. |
+
+In the argument columns below, `\|` separates alternatives, `[ ]` marks optional arguments, and `< >` marks a placeholder.
+
+### 20.7.1 Membership, Mute, and State {#api-membership-mute}
+
+| Sub-command | Purpose | Arguments |
+|-------------|---------|-----------|
+| `mute` | Mute a member (stop their audio from being mixed). | `<member_id\|all\|last\|non_moderator> [quiet]` |
+| `unmute` | Unmute a member. | `<member_id\|all\|last\|non_moderator> [quiet]` |
+| `tmute` | Toggle a member's mute state. | `<member_id\|all\|last\|non_moderator> [quiet]` |
+| `vmute` | Video-mute a member (stop their camera from being mixed onto the canvas). | `<member_id\|all\|last\|non_moderator> [quiet]` |
+| `unvmute` | Remove a member's video mute. | `<member_id\|all\|last\|non_moderator> [quiet]` |
+| `tvmute` | Toggle a member's video-mute state. | `<member_id\|all\|last\|non_moderator> [quiet]` |
+| `vmute-snap` | Capture a still image of the member's video to use as their video-mute placeholder. | `<member_id\|all\|last\|non_moderator>` |
+| `vblind` | Make a member video-blind (they receive no video). | `<member_id\|all\|last\|non_moderator> [quiet]` |
+| `unvblind` | Remove a member's video-blind state. | `<member_id\|all\|last\|non_moderator> [quiet]` |
+| `tvblind` | Toggle a member's video-blind state. | `<member_id\|all\|last\|non_moderator> [quiet]` |
+| `deaf` | Make a member deaf (they stop hearing the conference). | `<member_id\|all\|last\|non_moderator>` |
+| `undeaf` | Remove a member's deaf state. | `<member_id\|all\|last\|non_moderator>` |
+| `hold` | Place a member on hold, optionally playing a file to them. | `<member_id\|all\|last\|non_moderator> [file]` |
+| `unhold` | Take a member off hold. | `<member_id\|all\|last\|non_moderator>` |
+| `kick` | Remove a member from the conference, optionally playing a goodbye sound. | `<member_id\|all\|last\|non_moderator> [sound_file]` |
+| `hup` | Hang up a member's channel (disconnect the call entirely). | `<member_id\|all\|last\|non_moderator>` |
+| `dtmf` | Send DTMF digits to a member's channel. | `<member_id\|all\|last\|non_moderator> <digits>` |
+| `relate` | Set a relationship between members (one-way mute/deaf, or clear). | `<member_id[,...]> <other_member_id[,...]> [nospeak\|nohear\|clear]` |
+| `transfer` | Move one or more members to another conference. | `<conference_name> <member_id> [<member_id> ...]` |
+| `floor` | Grant the audio floor to a member. | `<member_id\|last>` |
+
+### 20.7.2 Audio: Energy, AGC, and Volume {#api-audio-energy}
+
+| Sub-command | Purpose | Arguments |
+|-------------|---------|-----------|
+| `energy` | Get or set the energy (talk-detection) threshold for a member. | `<member_id\|all\|last\|non_moderator> [<newval>]` |
+| `auto-energy` | Get or set the automatic energy-tracking level for a member. | `<member_id\|all\|last\|non_moderator> [<newval>]` |
+| `max-energy` | Get or set the maximum energy level (loud-member suppression) for a member. | `<member_id\|all\|last\|non_moderator> [<newval>]` |
+| `agc` | Get or set automatic gain control for a member. | `<member_id\|all\|last\|non_moderator> [<newval>]` |
+| `volume_in` | Get or set a member's input (transmit) volume. | `<member_id\|all\|last\|non_moderator> [<newval>]` |
+| `volume_out` | Get or set a member's output (receive) volume. | `<member_id\|all\|last\|non_moderator> [<newval>]` |
+| `position` | Set a member's 3D audio position (requires positional audio). | `<member_id> <x>:<y>:<z>` |
+| `auto-3d-position` | Toggle or set automatic 3D positioning for the conference. | `[on\|off]` |
+| `file-vol` | Set the playback volume of currently playing files. | `<vol#>` |
+
+### 20.7.3 Sounds and Playback {#api-sounds-playback}
+
+| Sub-command | Purpose | Arguments |
+|-------------|---------|-----------|
+| `play` | Play a file into the conference (to all, async, or to one member). | `<file_path> [async\|<member_id> [nomux]]` |
+| `pause_play` | Pause or resume the currently playing file. Registered under the name `pause`. | `[<member_id>]` |
+| `play_status` | Report playback status of the current file. | `[<member_id>]` |
+| `file_seek` | Seek within the currently playing file. | `[+-]<val> [<member_id>]` |
+| `stop` | Stop file playback. | `<current\|all\|async\|last> [<member_id>]` |
+| `moh` | Control music-on-hold playback. | `<file_path>\|toggle\|[on\|off]` |
+| `say` | Speak text into the conference (TTS). | `<text>` |
+| `saymember` | Speak text privately to one member (TTS). | `<member_id> <text>` |
+| `enter_sound` | Control the per-member enter sound. | `on\|off\|none\|file <filename>` |
+| `exit_sound` | Control the per-member exit sound. | `on\|off\|none\|file <filename>` |
+
+### 20.7.4 Video {#api-video}
+
+| Sub-command | Purpose | Arguments |
+|-------------|---------|-----------|
+| `vid-floor` | Grant the video floor to a member, optionally forcing it. | `<member_id\|last> [force]` |
+| `clear-vid-floor` | Clear the current video floor holder. | (none) |
+| `vid-layout` | Set the video layout (or a layout group) for a canvas. | `<layout_name>\|group <group_name> [<canvas_id>]` |
+| `vid-canvas` | Get or set which canvas a member is rendered on. | `<member_id\|all\|last\|non_moderator> [<newval>]` |
+| `vid-watching-canvas` | Get or set which canvas a member watches. | `<member_id\|all\|last\|non_moderator> [<newval>]` |
+| `vid-layer` | Get or set which canvas layer a member occupies. | `<member_id\|all\|last\|non_moderator> [<newval>]` |
+| `vid-res-id` | Assign a member to a reservation ID slot (named layout position). | `<member_id>\|all <val>\|clear [force]` |
+| `vid-role-id` | Assign a video role ID to a member. | `<member_id\|last> <val>\|clear` |
+| `vid-flip` | Flip a member's inbound video vertically. | `<member_id\|all\|last\|non_moderator>` |
+| `vid-filter` | Apply a video filter string to a member. | `<member_id\|all\|last\|non_moderator> <string>` |
+| `vid-border` | Cycle/toggle the video border on a member's slot. | `<member_id\|all\|last\|non_moderator>` |
+| `vid-banner` | Set overlay banner text on a member's slot. | `<member_id\|last> <text>` |
+| `vid-mute-img` | Set or clear the member's video-mute placeholder image. | `<member_id\|last> [<path>\|clear]` |
+| `vid-logo-img` | Set or clear a logo image overlaid on the member's slot. | `<member_id\|last> [<path>\|clear]` |
+| `vid-codec-group` | Set or clear the member's video codec group. | `<member_id\|last> [<group>\|clear]` |
+| `vid-fps` | Set the canvas output frame rate. | `<fps>` |
+| `vid-res` | Set the canvas output resolution. | `<WxH>` |
+| `vid-bandwidth` | Set the video encoder bandwidth target. | `<BW>` |
+| `vid-fgimg` | Set or clear the canvas foreground image. | `<file>\|clear [<canvas_id>]` |
+| `vid-bgimg` | Set or clear the canvas background image. | `<file>\|clear [<canvas_id>]` |
+| `vid-write-png` | Write the current canvas to a PNG file. | `<path>` |
+| `vid-personal` | Toggle personal-canvas (per-member) mode for the conference. | `[on\|off]` |
+| `cam` | Adjust per-layer camera settings (zoom/pan and related layer attributes). | `<canvas_id> <layer_id> <attr>=<val> [...]` |
+| `canvas-auto-clear` | Enable or disable automatic clearing of a canvas. | `<canvas_id> <true\|false>` |
+| `get-uuid` | Return the channel UUID of a member. | `<member_id\|last>` |
+
+### 20.7.5 Recording {#api-recording}
+
+| Sub-command | Purpose | Arguments |
+|-------------|---------|-----------|
+| `record` | Start recording the conference to a file. | `<filename>` |
+| `norecord` | Stop a named recording, or all recordings. | `<filename\|all>` |
+| `chkrecord` | Check the recording status of a conference. | `<confname>` |
+| `pause` | Pause an active recording. | `<filename>` |
+| `resume` | Resume a paused recording. | `<filename>` |
+| `recording` | Combined recording control (start/stop/check/pause/resume). | `[start\|stop\|check\|pause\|resume] [<filename>\|all]` |
+
+### 20.7.6 Outbound Dial {#api-outbound-dial}
+
+| Sub-command | Purpose | Arguments |
+|-------------|---------|-----------|
+| `dial` | Originate an outbound call and join the answered party to the conference (blocking). | `<endpoint_module>/<destination> <callerid_number> <callerid_name>` |
+| `bgdial` | Same as `dial` but originates in the background (non-blocking). | `<endpoint_module>/<destination> <callerid_number> <callerid_name>` |
+
+### 20.7.7 Locking, PIN, and Vars {#api-locking-pin-vars}
+
+| Sub-command | Purpose | Arguments |
+|-------------|---------|-----------|
+| `lock` | Lock the conference (reject new members). | (none) |
+| `unlock` | Unlock the conference. | (none) |
+| `pin` | Set the conference entry PIN. | `<pin#>` |
+| `nopin` | Clear the conference entry PIN. | (none) |
+| `getvar` | Read a conference variable. | `<varname>` |
+| `setvar` | Set a conference variable. | `<varname> <value>` |
+| `get` | Read a built-in conference parameter. | `<parameter-name>` |
+| `set` | Set a built-in conference parameter. | `<max_members\|sound_prefix\|caller_id_name\|caller_id_number\|endconference_grace_time> <value>` |
+
+### 20.7.8 Listing and Status {#api-listing-status}
+
+| Sub-command | Purpose | Arguments |
+|-------------|---------|-----------|
+| `list` | List conferences and members (text). May run without a conference name. | `[delim <string>]\|[count]` |
+| `xml_list` | List conferences and members as XML. | (none) |
+| `json_list` | List conferences and members as JSON. | `[compact]` |
+| `count` | Report the member count of the conference. | (none) |
+
+**Example invocations:**
+
+```
+conference 3001-example.com mute all
+conference 3001-example.com play conference/welcome.wav async
+conference 3001-example.com vid-layout group:grid
+conference 3001-example.com bgdial sofia/internal/2000@example.com 2000 "Conf Dial"
+conference list
+```

--- a/docs/applications/conferencing.mdx
+++ b/docs/applications/conferencing.mdx
@@ -13,35 +13,35 @@ FreeSWITCH multi-party audio and video conferencing is provided by `mod_conferen
 
 ## Table of Contents
 
-- [20.1 Conference Model](#conference-model)
-- [20.2 conference.conf.xml](#conference-conf-xml)
-  - [20.2.1 Advertise Block](#advertise-block)
-  - [20.2.2 Caller Controls](#caller-controls)
-  - [20.2.3 Profile Parameters](#profile-parameters)
-  - [20.2.4 Conference Flags](#conference-flags)
-  - [20.2.5 Member Flags (Profile)](#member-flags-profile)
-- [20.3 Bundled Profiles](#bundled-profiles)
-- [20.4 Video Layouts](#video-layouts)
-  - [20.4.1 Layout Definitions](#layout-definitions)
-  - [20.4.2 Layout Groups](#layout-groups)
-- [20.5 The conference Dialplan Application](#the-conference-dialplan-application)
-  - [20.5.1 Argument Syntax](#argument-syntax)
-  - [20.5.2 Member Flags at Join Time](#member-flags-at-join-time)
-  - [20.5.3 Bridge Mode](#bridge-mode)
-- [20.6 Default Dialplan Conference Extensions](#default-dialplan-conference-extensions)
-- [20.7 The conference API](#the-conference-api)
-  - [20.7.1 Membership, Mute, and State](#api-membership-mute)
-  - [20.7.2 Audio: Energy, AGC, and Volume](#api-audio-energy)
-  - [20.7.3 Sounds and Playback](#api-sounds-playback)
-  - [20.7.4 Video](#api-video)
-  - [20.7.5 Recording](#api-recording)
-  - [20.7.6 Outbound Dial](#api-outbound-dial)
-  - [20.7.7 Locking, PIN, and Vars](#api-locking-pin-vars)
-  - [20.7.8 Listing and Status](#api-listing-status)
+- [Conference Model](#conference-model)
+- [conference.conf.xml](#conference-conf-xml)
+  - [Advertise Block](#advertise-block)
+  - [Caller Controls](#caller-controls)
+  - [Profile Parameters](#profile-parameters)
+  - [Conference Flags](#conference-flags)
+  - [Member Flags (Profile)](#member-flags-profile)
+- [Bundled Profiles](#bundled-profiles)
+- [Video Layouts](#video-layouts)
+  - [Layout Definitions](#layout-definitions)
+  - [Layout Groups](#layout-groups)
+- [The conference Dialplan Application](#the-conference-dialplan-application)
+  - [Argument Syntax](#argument-syntax)
+  - [Member Flags at Join Time](#member-flags-at-join-time)
+  - [Bridge Mode](#bridge-mode)
+- [Default Dialplan Conference Extensions](#default-dialplan-conference-extensions)
+- [The conference API](#the-conference-api)
+  - [Membership, Mute, and State](#api-membership-mute)
+  - [Audio: Energy, AGC, and Volume](#api-audio-energy)
+  - [Sounds and Playback](#api-sounds-playback)
+  - [Video](#api-video)
+  - [Recording](#api-recording)
+  - [Outbound Dial](#api-outbound-dial)
+  - [Locking, PIN, and Vars](#api-locking-pin-vars)
+  - [Listing and Status](#api-listing-status)
 
 ---
 
-## 20.1 Conference Model {#conference-model}
+## Conference Model {#conference-model}
 
 A conference room is identified by a name string. When the `conference` dialplan application is invoked with `roomname@profilename`, FreeSWITCH looks up `profilename` in `conference.conf.xml` and creates the room (if it does not already exist) using that profile's parameters. Subsequent callers who dial the same room name join the existing instance.
 
@@ -54,11 +54,11 @@ Key points:
 
 ---
 
-## 20.2 conference.conf.xml {#conference-conf-xml}
+## conference.conf.xml {#conference-conf-xml}
 
 The file is loaded by `mod_conference` at startup. It contains three top-level sections: `<advertise>`, `<caller-controls>`, and `<profiles>`.
 
-### 20.2.1 Advertise Block {#advertise-block}
+### Advertise Block {#advertise-block}
 
 The optional `<advertise>` section publishes SIP presence for listed rooms at startup.
 
@@ -73,7 +73,7 @@ The optional `<advertise>` section publishes SIP presence for listed rooms at st
 | `name` | SIP AOR to advertise. Variable expansion applies. |
 | `status` | Presence status string sent to subscribers. |
 
-### 20.2.2 Caller Controls {#caller-controls}
+### Caller Controls {#caller-controls}
 
 Caller controls map DTMF digits to in-conference actions for members who are in an active room. Controls are organized into named groups. The group named `default` is used when no `caller-controls` profile parameter specifies otherwise.
 
@@ -138,7 +138,7 @@ Controls are disabled per-member when the `dist-dtmf` member flag is set; DTMF i
 
 A profile can assign a separate control group to moderators via `moderator-controls`.
 
-### 20.2.3 Profile Parameters {#profile-parameters}
+### Profile Parameters {#profile-parameters}
 
 A `<profile>` element contains `<param name="..." value="..."/>` child elements. Underscores in parameter names are interchangeable with hyphens during parsing.
 
@@ -261,7 +261,7 @@ A `<profile>` element contains `<param name="..." value="..."/>` child elements.
 | `scale-h264-canvas-bandwidth` | Bandwidth target for the scaled H.264 output. | Value with unit suffix. | None |
 | `video-codec-config-profile-name` | Named codec configuration profile to apply to MCU video encoding. | String. | None |
 
-### 20.2.4 Conference Flags {#conference-flags}
+### Conference Flags {#conference-flags}
 
 Conference flags are set in the profile via `conference-flags` (pipe-delimited) or via the `conference_flags` channel variable. They govern room-level behavior.
 
@@ -285,7 +285,7 @@ Conference flags are set in the profile via `conference-flags` (pipe-delimited) 
 | `ded-vid-layer-audio-floor` | Dedicate a video canvas layer to whichever member holds the audio floor. |
 | `breakable` | Allow the conference to be interrupted by a transfer or other channel application. |
 
-### 20.2.5 Member Flags (Profile) {#member-flags-profile}
+### Member Flags (Profile) {#member-flags-profile}
 
 The `member-flags` profile parameter sets default per-member flags for all members joining via that profile. The same flags can be set per-call at join time (see [Member Flags at Join Time](#member-flags-at-join-time)).
 
@@ -317,7 +317,7 @@ The `member-flags` profile parameter sets default per-member flags for all membe
 
 ---
 
-## 20.3 Bundled Profiles {#bundled-profiles}
+## Bundled Profiles {#bundled-profiles}
 
 The vanilla configuration ships the following profiles in `conference.conf.xml`:
 
@@ -366,11 +366,11 @@ They also set `video-auto-floor-msec` to `1000`.
 
 ---
 
-## 20.4 Video Layouts {#video-layouts}
+## Video Layouts {#video-layouts}
 
 Video layout configuration is in `autoload_configs/conference_layouts.conf.xml`. Layouts define how member video streams are positioned on the MCU canvas. The MCU canvas coordinate system is a normalized 360x360 unit grid, scaled to the actual canvas resolution at render time.
 
-### 20.4.1 Layout Definitions {#layout-definitions}
+### Layout Definitions {#layout-definitions}
 
 Each `<layout>` element contains one or more `<image>` child elements. Image placement attributes:
 
@@ -407,7 +407,7 @@ Each `<layout>` element contains one or more `<image>` child elements. Image pla
 </layout>
 ```
 
-### 20.4.2 Layout Groups {#layout-groups}
+### Layout Groups {#layout-groups}
 
 Groups allow the MCU to automatically promote to a larger layout as membership grows. When a profile sets `video-layout-name` to `group:groupname`, the MCU selects the smallest layout in the group that accommodates the current member count.
 
@@ -444,11 +444,11 @@ Referencing a group in a profile:
 
 ---
 
-## 20.5 The conference Dialplan Application {#the-conference-dialplan-application}
+## The conference Dialplan Application {#the-conference-dialplan-application}
 
 The `conference` application places a channel into a conference room; it is also summarized in the [dptools reference](../dialplan/dptools-reference.mdx).
 
-### 20.5.1 Argument Syntax {#argument-syntax}
+### Argument Syntax {#argument-syntax}
 
 ```
 conference <roomname>[@<profile>][+<pin>][+flags{<flag>|<flag>...}]
@@ -473,7 +473,7 @@ Joining with a PIN and a moderator flag:
 <action application="conference" data="3001-${domain_name}@default+54321+flags{moderator}"/>
 ```
 
-### 20.5.2 Member Flags at Join Time {#member-flags-at-join-time}
+### Member Flags at Join Time {#member-flags-at-join-time}
 
 Member flags can be set in three ways; they are merged at join time:
 
@@ -488,7 +488,7 @@ Setting flags via channel variable:
 <action application="conference" data="3001-${domain_name}@default"/>
 ```
 
-### 20.5.3 Bridge Mode {#bridge-mode}
+### Bridge Mode {#bridge-mode}
 
 The `bridge:` prefix creates a two-party conference that immediately bridges to a remote endpoint:
 
@@ -507,7 +507,7 @@ The room is created using the `default` profile unless the bridge variant specif
 
 ---
 
-## 20.6 Default Dialplan Conference Extensions {#default-dialplan-conference-extensions}
+## Default Dialplan Conference Extensions {#default-dialplan-conference-extensions}
 
 The vanilla `default` dialplan context (`dialplan/default.xml`) provides pre-built conference extensions. All audio-only extensions answer the call before entering the conference.
 
@@ -551,7 +551,7 @@ Note that the video MCU extensions (`35xx`-`38xx`) do not append `${domain_name}
 
 ---
 
-## 20.7 The conference API {#the-conference-api}
+## The conference API {#the-conference-api}
 
 `mod_conference` registers a single `conference` API command. It is invoked from the FreeSWITCH CLI (`fs_cli`), from `mod_event_socket`, or from the dialplan (via `api`/`bgapi`) to inspect and control running conferences. All control actions take the form:
 
@@ -572,7 +572,7 @@ Many member-targeted sub-commands accept a member selector in place of a numeric
 
 In the argument columns below, `\|` separates alternatives, `[ ]` marks optional arguments, and `< >` marks a placeholder.
 
-### 20.7.1 Membership, Mute, and State {#api-membership-mute}
+### Membership, Mute, and State {#api-membership-mute}
 
 | Sub-command | Purpose | Arguments |
 |-------------|---------|-----------|
@@ -597,7 +597,7 @@ In the argument columns below, `\|` separates alternatives, `[ ]` marks optional
 | `transfer` | Move one or more members to another conference. | `<conference_name> <member_id> [<member_id> ...]` |
 | `floor` | Grant the audio floor to a member. | `<member_id\|last>` |
 
-### 20.7.2 Audio: Energy, AGC, and Volume {#api-audio-energy}
+### Audio: Energy, AGC, and Volume {#api-audio-energy}
 
 | Sub-command | Purpose | Arguments |
 |-------------|---------|-----------|
@@ -611,7 +611,7 @@ In the argument columns below, `\|` separates alternatives, `[ ]` marks optional
 | `auto-3d-position` | Toggle or set automatic 3D positioning for the conference. | `[on\|off]` |
 | `file-vol` | Set the playback volume of currently playing files. | `<vol#>` |
 
-### 20.7.3 Sounds and Playback {#api-sounds-playback}
+### Sounds and Playback {#api-sounds-playback}
 
 | Sub-command | Purpose | Arguments |
 |-------------|---------|-----------|
@@ -626,7 +626,7 @@ In the argument columns below, `\|` separates alternatives, `[ ]` marks optional
 | `enter_sound` | Control the per-member enter sound. | `on\|off\|none\|file <filename>` |
 | `exit_sound` | Control the per-member exit sound. | `on\|off\|none\|file <filename>` |
 
-### 20.7.4 Video {#api-video}
+### Video {#api-video}
 
 | Sub-command | Purpose | Arguments |
 |-------------|---------|-----------|
@@ -656,7 +656,7 @@ In the argument columns below, `\|` separates alternatives, `[ ]` marks optional
 | `canvas-auto-clear` | Enable or disable automatic clearing of a canvas. | `<canvas_id> <true\|false>` |
 | `get-uuid` | Return the channel UUID of a member. | `<member_id\|last>` |
 
-### 20.7.5 Recording {#api-recording}
+### Recording {#api-recording}
 
 | Sub-command | Purpose | Arguments |
 |-------------|---------|-----------|
@@ -667,14 +667,14 @@ In the argument columns below, `\|` separates alternatives, `[ ]` marks optional
 | `resume` | Resume a paused recording. | `<filename>` |
 | `recording` | Combined recording control (start/stop/check/pause/resume). | `[start\|stop\|check\|pause\|resume] [<filename>\|all]` |
 
-### 20.7.6 Outbound Dial {#api-outbound-dial}
+### Outbound Dial {#api-outbound-dial}
 
 | Sub-command | Purpose | Arguments |
 |-------------|---------|-----------|
 | `dial` | Originate an outbound call and join the answered party to the conference (blocking). | `<endpoint_module>/<destination> <callerid_number> <callerid_name>` |
 | `bgdial` | Same as `dial` but originates in the background (non-blocking). | `<endpoint_module>/<destination> <callerid_number> <callerid_name>` |
 
-### 20.7.7 Locking, PIN, and Vars {#api-locking-pin-vars}
+### Locking, PIN, and Vars {#api-locking-pin-vars}
 
 | Sub-command | Purpose | Arguments |
 |-------------|---------|-----------|
@@ -687,7 +687,7 @@ In the argument columns below, `\|` separates alternatives, `[ ]` marks optional
 | `get` | Read a built-in conference parameter. | `<parameter-name>` |
 | `set` | Set a built-in conference parameter. | `<max_members\|sound_prefix\|caller_id_name\|caller_id_number\|endconference_grace_time> <value>` |
 
-### 20.7.8 Listing and Status {#api-listing-status}
+### Listing and Status {#api-listing-status}
 
 | Sub-command | Purpose | Arguments |
 |-------------|---------|-----------|

--- a/docs/applications/conferencing.mdx
+++ b/docs/applications/conferencing.mdx
@@ -446,7 +446,7 @@ Referencing a group in a profile:
 
 ## 20.5 The conference Dialplan Application {#the-conference-dialplan-application}
 
-The `conference` application places a channel into a conference room.
+The `conference` application places a channel into a conference room; it is also summarized in the [dptools reference](../dialplan/dptools-reference.mdx).
 
 ### 20.5.1 Argument Syntax {#argument-syntax}
 

--- a/docs/applications/conferencing.mdx
+++ b/docs/applications/conferencing.mdx
@@ -261,7 +261,6 @@ Conference flags are set in the profile via `conference-flags` (pipe-delimited) 
 | `video-mute-exit-canvas` | A video-muted member is removed from the canvas. |
 | `video-bridge-first-two` | When exactly two video members are present, bridge video directly. |
 | `video-muxing-personal-canvas` | Each member receives a personal canvas (point-to-point view). |
-| `mute-detect` | Fire events when a muted member attempts to speak. |
 | `restart-auto-record` | Restart the auto-recording when the conference is restarted. |
 | `auto-3d-position` | Enable automatic 3D positional audio assignment based on canvas layout positions. |
 | `ded-vid-layer-audio-floor` | Dedicate a video canvas layer to whichever member holds the audio floor. |
@@ -296,7 +295,6 @@ The `member-flags` profile parameter sets default per-member flags for all membe
 | `flip-video` | Flip the member's inbound video vertically before mixing. |
 | `talk-data-events` | Fire detailed talking data events for this member. |
 | `video-bridge` | Bridge video directly to this member when only two video participants are present. |
-| `waste` | Always transmit audio data to each channel even during silence. |
 
 ---
 

--- a/docs/applications/fax-t38.mdx
+++ b/docs/applications/fax-t38.mdx
@@ -13,24 +13,24 @@ FreeSWITCH delivers fax functionality through `mod_spandsp`, a module built on t
 
 ## Table of Contents
 
-- [1. Overview](#1-overview)
-- [2. Module Configuration](#2-module-configuration)
-  - [2.1 spandsp.conf.xml Structure](#21-spandspconfxml-structure)
-  - [2.2 Fax Settings Parameter Reference](#22-fax-settings-parameter-reference)
-- [3. Receiving a Fax with rxfax](#3-receiving-a-fax-with-rxfax)
-- [4. Sending a Fax with txfax](#4-sending-a-fax-with-txfax)
-- [5. T.38 Protocol Support](#5-t38-protocol-support)
-  - [5.1 T.38 Negotiation via rxfax and txfax](#51-t38-negotiation-via-rxfax-and-txfax)
-  - [5.2 T.38 Gateway Mode](#52-t38-gateway-mode)
-- [6. Channel Variable Reference](#6-channel-variable-reference)
-  - [6.1 Input Variables](#61-input-variables)
-  - [6.2 Result Variables](#62-result-variables)
-  - [6.3 Completion Hooks](#63-completion-hooks)
-- [7. Default Dialplan Examples](#7-default-dialplan-examples)
+- [Overview](#overview)
+- [Module Configuration](#module-configuration)
+  - [spandsp.conf.xml Structure](#spandspconfxml-structure)
+  - [Fax Settings Parameter Reference](#fax-settings-parameter-reference)
+- [Receiving a Fax with rxfax](#receiving-a-fax-with-rxfax)
+- [Sending a Fax with txfax](#sending-a-fax-with-txfax)
+- [T.38 Protocol Support](#t38-protocol-support)
+  - [T.38 Negotiation via rxfax and txfax](#t38-negotiation-via-rxfax-and-txfax)
+  - [T.38 Gateway Mode](#t38-gateway-mode)
+- [Channel Variable Reference](#channel-variable-reference)
+  - [Input Variables](#input-variables)
+  - [Result Variables](#result-variables)
+  - [Completion Hooks](#completion-hooks)
+- [Default Dialplan Examples](#default-dialplan-examples)
 
 ---
 
-## 1. Overview
+## Overview {#overview}
 
 `mod_spandsp` must be loaded before fax applications are available. It registers the `rxfax`, `txfax`, `stopfax`, and `t38_gateway` applications and reads its configuration from `autoload_configs/spandsp.conf.xml` at load time and on module reload.
 
@@ -40,9 +40,9 @@ Echo cancellation should be disabled before invoking a fax application. Use the 
 
 ---
 
-## 2. Module Configuration
+## Module Configuration {#module-configuration}
 
-### 2.1 spandsp.conf.xml Structure
+### spandsp.conf.xml Structure {#spandspconfxml-structure}
 
 The configuration file contains two relevant sections: `<modem-settings>` for software modem configuration and `<fax-settings>` for fax behavior. The `<descriptors>` section configures call-progress tone detection and is not part of fax document transfer.
 
@@ -62,9 +62,9 @@ The configuration file contains two relevant sections: `<modem-settings>` for so
 </configuration>
 ```
 
-### 2.2 Fax Settings Parameter Reference
+### Fax Settings Parameter Reference {#fax-settings-parameter-reference}
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `use-ecm` | Enable ITU-T T.30 Error Correction Mode | `true`, `false` | `true` |
 | `verbose` | Enable verbose SpanDSP library logging | `true`, `false` | `false` |
@@ -86,7 +86,7 @@ The configuration file contains two relevant sections: `<modem-settings>` for so
 
 ---
 
-## 3. Receiving a Fax with rxfax
+## Receiving a Fax with rxfax {#receiving-a-fax-with-rxfax}
 
 The `rxfax` application answers the call (if not already answered), switches the codec to linear PCM, and receives an incoming fax document, writing it to a TIFF file.
 
@@ -125,7 +125,7 @@ The channel variable `fax_filename` is set to the path of the written file after
 
 ---
 
-## 4. Sending a Fax with txfax
+## Sending a Fax with txfax {#sending-a-fax-with-txfax}
 
 The `txfax` application transmits a fax document from a local TIFF file to the remote endpoint. The channel must be answered or in a bridged state before `txfax` is invoked; `txfax` does not answer the channel.
 
@@ -156,11 +156,11 @@ The filename argument is required. The file must exist at the specified path. Pa
 
 ---
 
-## 5. T.38 Protocol Support
+## T.38 Protocol Support {#t38-protocol-support}
 
 T.38 is the ITU-T standard for carrying fax signals over IP networks as UDPTL packets rather than audio. `mod_spandsp` supports two T.38 operating modes: negotiated T.38 within `rxfax` and `txfax`, and a dedicated T.38 gateway mode.
 
-### 5.1 T.38 Negotiation via rxfax and txfax
+### T.38 Negotiation via rxfax and txfax {#t38-negotiation-via-rxfax-and-txfax}
 
 When `fax_enable_t38` is `true` (or `enable-t38` is set in `spandsp.conf.xml`), the fax applications will accept a T.38 re-INVITE from the remote endpoint and switch from audio to UDPTL transport mid-call. The transition occurs transparently during the fax session.
 
@@ -170,7 +170,7 @@ When `fax_enable_t38_insist` is `true`, the re-INVITE or response is sent with a
 
 The `fax_t38_status` result variable reports the outcome: `negotiated`, `requested`, `refused`, or `off`.
 
-### 5.2 T.38 Gateway Mode
+### T.38 Gateway Mode {#t38-gateway-mode}
 
 The `t38_gateway` application places a B2BUA leg into T.38 gateway mode, converting between audio fax signals on one leg and T.38 UDPTL on the other. This is used when one endpoint supports T.38 and the other does not.
 
@@ -199,11 +199,11 @@ The channel variable `t38_gateway_redundancy` sets the UDPTL redundancy level us
 
 ---
 
-## 6. Channel Variable Reference
+## Channel Variable Reference {#channel-variable-reference}
 
 Channel variables override the global defaults from `spandsp.conf.xml` on a per-session basis. Input variables are read before the fax application begins. Result variables are set by the application when it completes.
 
-### 6.1 Input Variables
+### Input Variables {#input-variables}
 
 | Variable | Purpose |
 |---|---|
@@ -236,7 +236,7 @@ Channel variables override the global defaults from `spandsp.conf.xml` on a per-
 | `t38_peer` | UUID of the peer leg used to pair the two sides of a `t38_gateway` session. Set automatically on both legs by `t38_gateway`. |
 | `t38_trace` | When `true`, traces the raw audio of a `t38_gateway` session to `<temp_dir>/<uuid>_read.raw` and `<uuid>_write.raw`. |
 
-### 6.2 Result Variables
+### Result Variables {#result-variables}
 
 The following variables are set on the channel when `rxfax` or `txfax` completes. They are available for subsequent dialplan actions or ESL event handlers.
 
@@ -269,7 +269,7 @@ The following variables are set on the channel when `rxfax` or `txfax` completes
 | `fax_remote_model` | Model string reported by the remote fax device (set at T.30 phase B negotiation; empty string if not provided) |
 | `fax_trace_file` | Full path to the per-session SpanDSP trace log file; set only when `fax_trace_dir` input variable is provided |
 
-### 6.3 Completion Hooks
+### Completion Hooks {#completion-hooks}
 
 `mod_spandsp` honors the standard `execute_on_*` and `system_on_*` channel-variable hooks at several points in the fax life cycle. The `execute_on_*` variables run a dialplan application (for example `lua fax_result.lua`); the `system_on_*` variables run a host command through `system()` after expanding channel variables. Set these as channel variables before invoking `rxfax` or `txfax`.
 
@@ -288,7 +288,7 @@ The result variables in section 6.2 are populated before these hooks run, so an 
 
 ---
 
-## 7. Default Dialplan Examples
+## Default Dialplan Examples {#default-dialplan-examples}
 
 The vanilla `conf/vanilla/dialplan/default.xml` includes two fax extensions that demonstrate minimal usage.
 

--- a/docs/applications/fax-t38.mdx
+++ b/docs/applications/fax-t38.mdx
@@ -25,6 +25,7 @@ FreeSWITCH delivers fax functionality through `mod_spandsp`, a module built on t
 - [6. Channel Variable Reference](#6-channel-variable-reference)
   - [6.1 Input Variables](#61-input-variables)
   - [6.2 Result Variables](#62-result-variables)
+  - [6.3 Completion Hooks](#63-completion-hooks)
 - [7. Default Dialplan Examples](#7-default-dialplan-examples)
 
 ---
@@ -187,7 +188,7 @@ t38_gateway [self|peer] [nocng]
 
 When `nocng` is not specified, `t38_gateway` listens for CED (2100 Hz) or V.21 preamble before activating gateway mode. The timeout for tone detection is controlled by the channel variable `t38_gateway_detect_timeout` (integer, seconds; default `20`).
 
-The channel variable `t38_gateway_redundancy` sets the UDPTL redundancy level used by the gateway (integer; affects both FEC span and FEC entries).
+The channel variable `t38_gateway_redundancy` sets the UDPTL redundancy level used by the gateway (integer; default `3`). The single value is applied to both the FEC span and the FEC entries count.
 
 **Example: inline gateway on a bridged call:**
 
@@ -230,7 +231,10 @@ Channel variables override the global defaults from `spandsp.conf.xml` on a per-
 | `fax_verbose_log_level` | FreeSWITCH log level for per-session verbose output |
 | `fax_trace_dir` | Directory path for writing a per-session SpanDSP trace log |
 | `t38_gateway_detect_timeout` | Seconds to wait for fax tone before activating `t38_gateway` (integer; default `20`) |
-| `t38_gateway_redundancy` | UDPTL redundancy level for `t38_gateway` mode (integer) |
+| `t38_leg` | Set by `t38_gateway` to record which leg gateway processing is applied to (`self` or `peer`, defaulting to `peer`). |
+| `t38_gateway_redundancy` | UDPTL redundancy level for `t38_gateway` mode (integer; default `3`). The value is applied to both the FEC span and the FEC entries count. |
+| `t38_peer` | UUID of the peer leg used to pair the two sides of a `t38_gateway` session. Set automatically on both legs by `t38_gateway`. |
+| `t38_trace` | When `true`, traces the raw audio of a `t38_gateway` session to `<temp_dir>/<uuid>_read.raw` and `<uuid>_write.raw`. |
 
 ### 6.2 Result Variables
 
@@ -264,6 +268,23 @@ The following variables are set on the channel when `rxfax` or `txfax` completes
 | `fax_remote_vendor` | Vendor string reported by the remote fax device (set at T.30 phase B negotiation; empty string if not provided) |
 | `fax_remote_model` | Model string reported by the remote fax device (set at T.30 phase B negotiation; empty string if not provided) |
 | `fax_trace_file` | Full path to the per-session SpanDSP trace log file; set only when `fax_trace_dir` input variable is provided |
+
+### 6.3 Completion Hooks
+
+`mod_spandsp` honors the standard `execute_on_*` and `system_on_*` channel-variable hooks at several points in the fax life cycle. The `execute_on_*` variables run a dialplan application (for example `lua fax_result.lua`); the `system_on_*` variables run a host command through `system()` after expanding channel variables. Set these as channel variables before invoking `rxfax` or `txfax`.
+
+| Variable | When it fires | Action type |
+|---|---|---|
+| `execute_on_fax_phase_b` | At T.30 phase B (after the initial transport negotiation, when station identifiers are exchanged) | Dialplan app |
+| `execute_on_fax_phase_d` | At T.30 phase D (after each page completes) | Dialplan app |
+| `system_on_fax_result` | When the fax session ends, regardless of outcome | `system()` command |
+| `execute_on_fax_result` | When the fax session ends, regardless of outcome (after `system_on_fax_result`) | Dialplan app |
+| `system_on_fax_success` | When the fax session ends with a successful result | `system()` command |
+| `execute_on_fax_success` | When the fax session ends with a successful result (after `system_on_fax_success`) | Dialplan app |
+| `system_on_fax_failure` | When the fax session ends with an error result | `system()` command |
+| `execute_on_fax_failure` | When the fax session ends with an error result (after `system_on_fax_failure`) | Dialplan app |
+
+The result variables in section 6.2 are populated before these hooks run, so an `execute_on_fax_result` handler can read `fax_success`, `fax_result_code`, `fax_document_transferred_pages`, and `fax_filename` directly.
 
 ---
 

--- a/docs/applications/fax-t38.mdx
+++ b/docs/applications/fax-t38.mdx
@@ -36,7 +36,7 @@ FreeSWITCH delivers fax functionality through `mod_spandsp`, a module built on t
 
 Fax sessions begin in audio mode using G.711. If T.38 is enabled and the remote endpoint supports it, the module issues or accepts a re-INVITE to switch to UDPTL transport mid-call. The jitter buffer is disabled automatically when a fax application is invoked.
 
-Echo cancellation should be disabled before invoking a fax application. Use the `disable_ec` application in the dialplan before calling `rxfax` or `txfax`.
+Echo cancellation should be disabled before invoking a fax application. Use the `disable_ec` application in the dialplan before calling `rxfax` or `txfax`. The supporting dialplan applications used in the examples below (`set`, `answer`, `playback`, `hangup`) are documented in the [dptools reference](../dialplan/dptools-reference.mdx).
 
 ---
 

--- a/docs/applications/index.mdx
+++ b/docs/applications/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Part 6: Applications and Features"
 slug: /applications
-description: The bundled dialplan applications and features.
+description: "The bundled dialplan applications and features."
 ---
 
 import DocCardList from '@theme/DocCardList';

--- a/docs/applications/ivr-menus.mdx
+++ b/docs/applications/ivr-menus.mdx
@@ -13,23 +13,23 @@ The IVR menu system lets you define prompt-driven digit-collection menus in XML,
 
 ## Table of Contents
 
-- [1. IVR Menu Model](#1-ivr-menu-model)
-- [2. Configuration File](#2-configuration-file)
-- [3. Menu Definition: the `<menu>` Element](#3-menu-definition-the-menu-element)
-  - [3.1 `<menu>` Attribute Reference](#31-menu-attribute-reference)
-  - [3.2 Sound and TTS Prefixes](#32-sound-and-tts-prefixes)
-  - [3.3 PIN Protection](#33-pin-protection)
-  - [3.4 Callbacks on Failure and Timeout](#34-callbacks-on-failure-and-timeout)
-- [4. Entries: the `<entry>` Element](#4-entries-the-entry-element)
-  - [4.1 `<entry>` Action Reference](#41-entry-action-reference)
-  - [4.2 Digit Patterns and Regular Expressions](#42-digit-patterns-and-regular-expressions)
-- [5. Nesting Submenus](#5-nesting-submenus)
-- [6. Invoking a Menu from the Dialplan](#6-invoking-a-menu-from-the-dialplan)
-- [7. The Bundled Demo IVR](#7-the-bundled-demo-ivr)
+- [IVR Menu Model](#ivr-menu-model)
+- [Configuration File](#configuration-file)
+- [Menu Definition: the `<menu>` Element](#menu-definition-the-menu-element)
+  - [`<menu>` Attribute Reference](#menu-attribute-reference)
+  - [Sound and TTS Prefixes](#sound-and-tts-prefixes)
+  - [PIN Protection](#pin-protection)
+  - [Callbacks on Failure and Timeout](#callbacks-on-failure-and-timeout)
+- [Entries: the `<entry>` Element](#entries-the-entry-element)
+  - [`<entry>` Action Reference](#entry-action-reference)
+  - [Digit Patterns and Regular Expressions](#digit-patterns-and-regular-expressions)
+- [Nesting Submenus](#nesting-submenus)
+- [Invoking a Menu from the Dialplan](#invoking-a-menu-from-the-dialplan)
+- [The Bundled Demo IVR](#the-bundled-demo-ivr)
 
 ---
 
-## 1. IVR Menu Model
+## IVR Menu Model {#ivr-menu-model}
 
 An IVR menu is a named XML element that specifies:
 
@@ -43,7 +43,7 @@ The engine collects digits until `digit-len` digits have been received or no dig
 
 ---
 
-## 2. Configuration File
+## Configuration File {#configuration-file}
 
 `ivr.conf.xml` is the module configuration file loaded by `mod_dptools`. Its only job is to aggregate menu files via an `X-PRE-PROCESS` include directive.
 
@@ -60,7 +60,7 @@ Every `*.xml` file under `conf/ivr_menus/` is loaded at startup. Each of those f
 
 ---
 
-## 3. Menu Definition: the `<menu>` Element
+## Menu Definition: the `<menu>` Element {#menu-definition-the-menu-element}
 
 A menu file holds one `<include>` wrapper containing one or more `<menu>` elements. The `name` attribute on each `<menu>` is the identifier used both by the `ivr` dialplan application and by `menu-sub` entries.
 
@@ -85,7 +85,7 @@ A menu file holds one `<include>` wrapper containing one or more `<menu>` elemen
 </include>
 ```
 
-### 3.1 `<menu>` Attribute Reference
+### `<menu>` Attribute Reference {#menu-attribute-reference}
 
 | Attribute | Purpose | Accepted Values | Default |
 |---|---|---|---|
@@ -111,7 +111,7 @@ A menu file holds one `<include>` wrapper containing one or more `<menu>` elemen
 | `exec-on-max-failures` | Dialplan application string executed when `max-failures` is reached. | `app arg` string | (none) |
 | `exec-on-max-timeouts` | Dialplan application string executed when `max-timeouts` is reached. | `app arg` string | (none) |
 
-### 3.2 Sound and TTS Prefixes
+### Sound and TTS Prefixes {#sound-and-tts-prefixes}
 
 All sound attributes (`greet-long`, `greet-short`, `invalid-sound`, `exit-sound`, `transfer-sound`) accept three forms:
 
@@ -121,7 +121,7 @@ All sound attributes (`greet-long`, `greet-short`, `invalid-sound`, `exit-sound`
 | `phrase:` prefix | `phrase:main_menu_greeting` | Executes the named phrase macro. |
 | `say:` prefix | `say:Press 1 for sales` | Synthesizes speech using `tts-engine` and `tts-voice`. |
 
-### 3.3 PIN Protection
+### PIN Protection {#pin-protection}
 
 When `pin` is set on a menu, the engine prompts the caller with `pin-file` before playing the greeting. If the caller enters the correct PIN, the menu proceeds normally. If the PIN does not match, `bad-pin-file` plays. The engine allows exactly 3 PIN attempts; this value is hardcoded and is not controlled by any `<menu>` attribute.
 
@@ -144,7 +144,7 @@ When `pin` is set on a menu, the engine prompts the caller with `pin-file` befor
 </menu>
 ```
 
-### 3.4 Callbacks on Failure and Timeout
+### Callbacks on Failure and Timeout {#callbacks-on-failure-and-timeout}
 
 `exec-on-max-failures` and `exec-on-max-timeouts` each accept a dialplan application invocation in the form `application argument`. When the respective counter is reached the engine executes the application before exiting the menu. This is the correct hook for sending the caller to a voicemail extension or a live-agent queue when they fail to interact with the menu.
 
@@ -167,7 +167,7 @@ When `pin` is set on a menu, the engine prompts the caller with `pin-file` befor
 
 ---
 
-## 4. Entries: the `<entry>` Element
+## Entries: the `<entry>` Element {#entries-the-entry-element}
 
 Each `<entry>` element inside a `<menu>` maps one digit string or regular expression to one action. Attributes:
 
@@ -175,7 +175,7 @@ Each `<entry>` element inside a `<menu>` maps one digit string or regular expres
 - `digits` - the digit string or regex to match (required)
 - `param` - additional argument to the action (required for actions that take one, not used by `menu-top` or `menu-back`)
 
-### 4.1 `<entry>` Action Reference
+### `<entry>` Action Reference {#entry-action-reference}
 
 | Action | Effect |
 |---|---|
@@ -186,7 +186,7 @@ Each `<entry>` element inside a `<menu>` maps one digit string or regular expres
 | `menu-play-sound` | Plays the audio or TTS value in `param` without leaving the menu. |
 | `menu-exit` | Exits the menu immediately, playing `exit-sound`. |
 
-### 4.2 Digit Patterns and Regular Expressions
+### Digit Patterns and Regular Expressions {#digit-patterns-and-regular-expressions}
 
 The `digits` attribute accepts either a literal string or a PCRE regular expression enclosed in `/` delimiters. When a regex is used, any capture groups are exposed as `$1`, `$2`, and so on, within the `param` value of a `menu-exec-app` entry. This enables variable-length extension dialing directly from an IVR menu.
 
@@ -202,7 +202,7 @@ Multiple `<entry>` elements may use different regex patterns. Entries are evalua
 
 ---
 
-## 5. Nesting Submenus
+## Nesting Submenus {#nesting-submenus}
 
 A submenu is an ordinary `<menu>` element referenced by name from a `menu-sub` entry. All menus referenced within a single file (or across files loaded into the same `<menus>` block) share the same namespace. The engine resolves submenu names at runtime from the loaded stack.
 
@@ -250,7 +250,7 @@ In this example, pressing `*` in `sales_menu` invokes `menu-back`, returning the
 
 ---
 
-## 6. Invoking a Menu from the Dialplan
+## Invoking a Menu from the Dialplan {#invoking-a-menu-from-the-dialplan}
 
 The `ivr` dialplan application takes a single argument: the `name` of the top-level menu to enter. The call must already be answered before `ivr` is invoked. The application is also summarized in the [dptools reference](../dialplan/dptools-reference.mdx).
 
@@ -270,7 +270,7 @@ When `ivr` returns, control passes to the next action in the dialplan extension.
 
 ---
 
-## 7. The Bundled Demo IVR
+## The Bundled Demo IVR {#the-bundled-demo-ivr}
 
 The vanilla FreeSWITCH configuration ships a working demo IVR reachable at extension `5000` in the `default` dialplan context. The dialplan extension in `conf/dialplan/default.xml` is:
 

--- a/docs/applications/ivr-menus.mdx
+++ b/docs/applications/ivr-menus.mdx
@@ -252,7 +252,7 @@ In this example, pressing `*` in `sales_menu` invokes `menu-back`, returning the
 
 ## 6. Invoking a Menu from the Dialplan
 
-The `ivr` dialplan application takes a single argument: the `name` of the top-level menu to enter. The call must already be answered before `ivr` is invoked.
+The `ivr` dialplan application takes a single argument: the `name` of the top-level menu to enter. The call must already be answered before `ivr` is invoked. The application is also summarized in the [dptools reference](../dialplan/dptools-reference.mdx).
 
 ```xml
 <extension name="main_ivr">

--- a/docs/applications/queues-fifo-callcenter.mdx
+++ b/docs/applications/queues-fifo-callcenter.mdx
@@ -13,33 +13,33 @@ FreeSWITCH provides two distinct mechanisms for queuing inbound calls: `mod_fifo
 
 ## Table of Contents
 
-- [1. Choosing Between FIFO and Call Center](#1-choosing-between-fifo-and-call-center)
-- [2. mod_fifo: Configuration and the fifo Application](#2-mod_fifo-configuration-and-the-fifo-application)
-  - [2.1 fifo.conf.xml Settings](#21-fifoconfxml-settings)
-  - [2.2 Declaring a FIFO Node](#22-declaring-a-fifo-node)
-  - [2.3 Outbound Members](#23-outbound-members)
-  - [2.4 The fifo Dialplan Application](#24-the-fifo-dialplan-application)
-  - [2.5 FIFO Channel Variables](#25-fifo-channel-variables)
-  - [2.6 The fifo_track_call Application](#26-the-fifo_track_call-application)
-  - [2.7 mod_fifo API Commands](#27-mod_fifo-api-commands)
-- [3. mod_callcenter: Concepts and Loading](#3-mod_callcenter-concepts-and-loading)
-- [4. Call Center Queue Configuration](#4-call-center-queue-configuration)
-  - [4.1 Queue Parameter Reference](#41-queue-parameter-reference)
-- [5. Agent Configuration](#5-agent-configuration)
-  - [5.1 Agent Parameter Reference](#51-agent-parameter-reference)
-- [6. Tier Assignment](#6-tier-assignment)
-  - [6.1 Tier Parameter Reference](#61-tier-parameter-reference)
-- [7. The callcenter Dialplan Application](#7-the-callcenter-dialplan-application)
-- [8. Global Settings for mod_callcenter](#8-global-settings-for-mod_callcenter)
-- [9. mod_callcenter API Commands](#9-mod_callcenter-api-commands)
-  - [9.1 callcenter_config agent](#91-callcenter_config-agent)
-  - [9.2 callcenter_config tier](#92-callcenter_config-tier)
-  - [9.3 callcenter_config queue](#93-callcenter_config-queue)
-  - [9.4 callcenter_break](#94-callcenter_break)
+- [Choosing Between FIFO and Call Center](#choosing-between-fifo-and-call-center)
+- [mod_fifo: Configuration and the fifo Application](#mod_fifo-configuration-and-the-fifo-application)
+  - [fifo.conf.xml Settings](#fifoconfxml-settings)
+  - [Declaring a FIFO Node](#declaring-a-fifo-node)
+  - [Outbound Members](#outbound-members)
+  - [The fifo Dialplan Application](#the-fifo-dialplan-application)
+  - [FIFO Channel Variables](#fifo-channel-variables)
+  - [The fifo_track_call Application](#the-fifo_track_call-application)
+  - [mod_fifo API Commands](#mod_fifo-api-commands)
+- [mod_callcenter: Concepts and Loading](#mod_callcenter-concepts-and-loading)
+- [Call Center Queue Configuration](#call-center-queue-configuration)
+  - [Queue Parameter Reference](#queue-parameter-reference)
+- [Agent Configuration](#agent-configuration)
+  - [Agent Parameter Reference](#agent-parameter-reference)
+- [Tier Assignment](#tier-assignment)
+  - [Tier Parameter Reference](#tier-parameter-reference)
+- [The callcenter Dialplan Application](#the-callcenter-dialplan-application)
+- [Global Settings for mod_callcenter](#global-settings-for-mod_callcenter)
+- [mod_callcenter API Commands](#mod_callcenter-api-commands)
+  - [callcenter_config agent](#callcenter_config-agent)
+  - [callcenter_config tier](#callcenter_config-tier)
+  - [callcenter_config queue](#callcenter_config-queue)
+  - [callcenter_break](#callcenter_break)
 
 ---
 
-## 1. Choosing Between FIFO and Call Center
+## Choosing Between FIFO and Call Center {#choosing-between-fifo-and-call-center}
 
 | Capability | `mod_fifo` | `mod_callcenter` |
 |---|---|---|
@@ -54,11 +54,11 @@ Use `mod_fifo` when you need a simple holding queue with minimal configuration. 
 
 ---
 
-## 2. mod_fifo: Configuration and the fifo Application
+## mod_fifo: Configuration and the fifo Application {#mod_fifo-configuration-and-the-fifo-application}
 
 `mod_fifo` is loaded by default. Its configuration file is `autoload_configs/fifo.conf.xml`.
 
-### 2.1 fifo.conf.xml Settings
+### fifo.conf.xml Settings {#fifoconfxml-settings}
 
 The `<settings>` block contains global options for the module.
 
@@ -71,7 +71,7 @@ The `<settings>` block contains global options for the module.
 </configuration>
 ```
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `delete-all-outbound-member-on-startup` | Remove all outbound member records from the database when the module loads. | `true`, `false` | `false` |
 | `outbound-strategy` | Default outbound strategy applied to all FIFO nodes that do not specify their own `outbound_strategy` attribute. | `ringall`, `enterprise` | `ringall` |
@@ -84,7 +84,7 @@ The `<settings>` block contains global options for the module.
 | `db-inner-pre-trans-execute` | SQL statement run immediately before each inner (batched) transaction begins. | SQL string | None |
 | `db-inner-post-trans-execute` | SQL statement run immediately after each inner (batched) transaction completes. | SQL string | None |
 
-### 2.2 Declaring a FIFO Node
+### Declaring a FIFO Node {#declaring-a-fifo-node}
 
 FIFO nodes are declared under the `<fifos>` element. Each `<fifo>` element defines one named queue.
 
@@ -97,7 +97,7 @@ FIFO nodes are declared under the `<fifos>` element. Each `<fifo>` element defin
 
 **`<fifo>` Attributes**
 
-| Attribute | Purpose | Values | Default |
+| Attribute | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `name` | Unique name for the queue; typically `name@domain`. | String | Required |
 | `importance` | Priority of this FIFO relative to others when a consumer selects from multiple. Higher values are served first, overriding wait-time ordering. | Integer `>= 0` | `0` |
@@ -110,7 +110,7 @@ FIFO nodes are declared under the `<fifos>` element. Each `<fifo>` element defin
 | `outbound_name` | Caller ID name prefix presented to outbound members. | String | None |
 | `retry_delay` | Seconds to wait before retrying a failed outbound attempt. | Integer `>= 0` | `0` |
 
-### 2.3 Outbound Members
+### Outbound Members {#outbound-members}
 
 Static outbound members are defined as `<member>` children of a `<fifo>` node. The module stores them in its internal database on load.
 
@@ -122,7 +122,7 @@ Static outbound members are defined as `<member>` children of a `<fifo>` node. T
 
 **`<member>` Attributes**
 
-| Attribute | Purpose | Values | Default |
+| Attribute | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `timeout` | Ring timeout in seconds for this member. Minimum 10; values below 10 fall back to the node `outbound_ring_timeout`. | Integer | Node `outbound_ring_timeout` (default `60`) |
 | `simo` | Maximum simultaneous calls to this member. | Integer `>= 1` | `1` |
@@ -131,7 +131,7 @@ Static outbound members are defined as `<member>` children of a `<fifo>` node. T
 
 The member text body is the originate string. The channel variable `member_wait` (set as a channel pre-dial variable in the originate string) controls what the member does after answering: `wait` holds the call until a caller is available; `nowait` bridges immediately if a caller is already waiting and hangs up otherwise.
 
-### 2.4 The fifo Dialplan Application
+### The fifo Dialplan Application {#the-fifo-dialplan-application}
 
 The `fifo` application places a channel into a named FIFO as either a caller (inbound, `in` mode) or a consumer/agent (outbound, `out` mode); it is also summarized in the [dptools reference](../dialplan/dptools-reference.mdx).
 
@@ -171,7 +171,7 @@ The channel variables `fifo_music` and `fifo_announce` set the hold music and an
 
 ---
 
-### 2.5 FIFO Channel Variables
+### FIFO Channel Variables {#fifo-channel-variables}
 
 Channel variables control per-call behavior within `mod_fifo`. Set them on the caller or consumer channel before invoking the `fifo` application.
 
@@ -209,7 +209,7 @@ Channel variables control per-call behavior within `mod_fifo`. Set them on the c
 
 ---
 
-### 2.6 The fifo_track_call Application
+### The fifo_track_call Application {#the-fifo_track_call-application}
 
 The `fifo_track_call` application registers a call against an outbound member record so that a bridge established outside of `mod_fifo` is still counted in the module's manual-call statistics. The call is added to the internal `manual_calls` queue and the member's use count is incremented; the count is decremented automatically when the channel hangs up.
 
@@ -227,7 +227,7 @@ The single argument is the outbound member UUID (the `fifo_outbound_uuid` value,
 
 ---
 
-### 2.7 mod_fifo API Commands
+### mod_fifo API Commands {#mod_fifo-api-commands}
 
 `mod_fifo` registers four API commands, usable from `fs_cli`, the event socket, or `api`/`bgapi` dialplan applications.
 
@@ -291,7 +291,7 @@ Returns `true` if the given channel UUID or outbound member ID is part of an act
 
 ---
 
-## 3. mod_callcenter: Concepts and Loading
+## mod_callcenter: Concepts and Loading {#mod_callcenter-concepts-and-loading}
 
 `mod_callcenter` is **not loaded by default**. To enable it, uncomment the relevant line in `autoload_configs/modules.conf.xml`:
 
@@ -313,7 +313,7 @@ The XML configuration (`callcenter.conf.xml`) defines queues, agents, and tiers 
 
 ---
 
-## 4. Call Center Queue Configuration
+## Call Center Queue Configuration {#call-center-queue-configuration}
 
 Queues are defined under the `<queues>` element of `callcenter.conf.xml`.
 
@@ -338,9 +338,9 @@ Queues are defined under the `<queues>` element of `callcenter.conf.xml`.
 
 The `name` attribute on `<queue>` is required. The conventional format is `name@context` (for example, `support@default`), matching the agent name format.
 
-### 4.1 Queue Parameter Reference
+### Queue Parameter Reference {#queue-parameter-reference}
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `strategy` | Agent selection algorithm. | See table below | `longest-idle-agent` |
 | `moh-sound` | Hold music played to waiting callers. | File path or stream | None |
@@ -376,7 +376,7 @@ The `name` attribute on `<queue>` is required. The conventional format is `name@
 
 ---
 
-## 5. Agent Configuration
+## Agent Configuration {#agent-configuration}
 
 Agents are defined under the `<agents>` element of `callcenter.conf.xml`. XML agent configuration is applied to the database on restart; any runtime changes made via the API are overwritten.
 
@@ -395,9 +395,9 @@ Agents are defined under the `<agents>` element of `callcenter.conf.xml`. XML ag
 
 The `name` attribute is required and typically follows the format `extension@context`.
 
-### 5.1 Agent Parameter Reference
+### Agent Parameter Reference {#agent-parameter-reference}
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `type` | How the module reaches the agent. `Callback` originates an outbound call to `contact`; `uuid-standby` bridges to an existing channel UUID specified in `contact`. | `Callback`, `uuid-standby` | Required |
 | `contact` | Originate string (`Callback` type) or channel UUID (`uuid-standby` type) for the agent leg. Channel variables may be set in square brackets. | String | Required |
@@ -420,7 +420,7 @@ The `name` attribute is required and typically follows the format `extension@con
 
 ---
 
-## 6. Tier Assignment
+## Tier Assignment {#tier-assignment}
 
 Tiers link an agent to a queue and define the agent's priority within that queue. Agents with a lower `level` number are offered calls before those with a higher number. Within the same level, `position` determines order.
 
@@ -435,9 +435,9 @@ Tiers are defined under the `<tiers>` element of `callcenter.conf.xml`.
 
 If `level` or `position` is omitted, it defaults to `1`. When tier configuration is applied on restart, supplied values overwrite any runtime changes to `level` and `position`. Omitting both attributes preserves existing database values.
 
-### 6.1 Tier Parameter Reference
+### Tier Parameter Reference {#tier-parameter-reference}
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `agent` | Agent name, matching an entry in `<agents>`. | String | Required |
 | `queue` | Queue name, matching an entry in `<queues>`. | String | Required |
@@ -448,7 +448,7 @@ If `level` or `position` is omitted, it defaults to `1`. When tier configuration
 
 ---
 
-## 7. The callcenter Dialplan Application
+## The callcenter Dialplan Application {#the-callcenter-dialplan-application}
 
 The `callcenter` dialplan application places an inbound call into a named queue. The call waits until an available agent is found and the agent leg is bridged.
 
@@ -475,7 +475,7 @@ A companion application, `callcenter_track`, registers an externally originated 
 
 ---
 
-## 8. Global Settings for mod_callcenter
+## Global Settings for mod_callcenter {#global-settings-for-mod_callcenter}
 
 The `<settings>` block in `callcenter.conf.xml` configures module-wide options.
 
@@ -487,7 +487,7 @@ The `<settings>` block in `callcenter.conf.xml` configures module-wide options.
 </settings>
 ```
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `odbc-dsn` | ODBC connection string for external database storage. When set, the module uses ODBC instead of the internal SQLite database. Format: `dsn:user:pass`. | String | None (SQLite used) |
 | `dbname` | Path or name of the SQLite database file. | File path | `callcenter` |
@@ -501,7 +501,7 @@ The `<settings>` block in `callcenter.conf.xml` configures module-wide options.
 
 ---
 
-## 9. mod_callcenter API Commands
+## mod_callcenter API Commands {#mod_callcenter-api-commands}
 
 `mod_callcenter` exposes runtime management through the `callcenter_config` API and a separate `callcenter_break` API. Both are usable from `fs_cli`, the event socket, and `api`/`bgapi` dialplan applications. `callcenter_config` is also registered as a JSON API. Commands return `+OK` on success or a `-ERR <reason>` line on failure; `get`, `list`, and `count` commands return data instead.
 
@@ -513,7 +513,7 @@ callcenter_config <section> <action> <args>
 
 Sections are `agent`, `tier`, and `queue`.
 
-### 9.1 callcenter_config agent
+### callcenter_config agent {#callcenter_config-agent}
 
 | Command | Purpose |
 |---|---|
@@ -532,7 +532,7 @@ Sections are `agent`, `tier`, and `queue`.
 | `agent get uuid <agent_name>` | Return the agent's current channel UUID. |
 | `agent list [<agent_name>]` | List all agents, or one named agent, as pipe-delimited rows. |
 
-### 9.2 callcenter_config tier
+### callcenter_config tier {#callcenter_config-tier}
 
 | Command | Purpose |
 |---|---|
@@ -544,7 +544,7 @@ Sections are `agent`, `tier`, and `queue`.
 | `tier reload <queue_name> <agent_name>` | Reload the tier from XML. Pass `all` as the queue name to reload every tier. |
 | `tier list` | List all tiers ordered by level then position. |
 
-### 9.3 callcenter_config queue
+### callcenter_config queue {#callcenter_config-queue}
 
 | Command | Purpose |
 |---|---|
@@ -560,7 +560,7 @@ Sections are `agent`, `tier`, and `queue`.
 | `queue count members <queue_name>` | Count waiting callers in a queue. |
 | `queue count tiers <queue_name>` | Count the tiers in a queue. |
 
-### 9.4 callcenter_break
+### callcenter_break {#callcenter_break}
 
 `callcenter_break` stops the module from watching a channel UUID and releases the associated agent. It is used to break an agent out of a call that the module is tracking.
 

--- a/docs/applications/queues-fifo-callcenter.mdx
+++ b/docs/applications/queues-fifo-callcenter.mdx
@@ -20,6 +20,8 @@ FreeSWITCH provides two distinct mechanisms for queuing inbound calls: `mod_fifo
   - [2.3 Outbound Members](#23-outbound-members)
   - [2.4 The fifo Dialplan Application](#24-the-fifo-dialplan-application)
   - [2.5 FIFO Channel Variables](#25-fifo-channel-variables)
+  - [2.6 The fifo_track_call Application](#26-the-fifo_track_call-application)
+  - [2.7 mod_fifo API Commands](#27-mod_fifo-api-commands)
 - [3. mod_callcenter: Concepts and Loading](#3-mod_callcenter-concepts-and-loading)
 - [4. Call Center Queue Configuration](#4-call-center-queue-configuration)
   - [4.1 Queue Parameter Reference](#41-queue-parameter-reference)
@@ -29,6 +31,11 @@ FreeSWITCH provides two distinct mechanisms for queuing inbound calls: `mod_fifo
   - [6.1 Tier Parameter Reference](#61-tier-parameter-reference)
 - [7. The callcenter Dialplan Application](#7-the-callcenter-dialplan-application)
 - [8. Global Settings for mod_callcenter](#8-global-settings-for-mod_callcenter)
+- [9. mod_callcenter API Commands](#9-mod_callcenter-api-commands)
+  - [9.1 callcenter_config agent](#91-callcenter_config-agent)
+  - [9.2 callcenter_config tier](#92-callcenter_config-tier)
+  - [9.3 callcenter_config queue](#93-callcenter_config-queue)
+  - [9.4 callcenter_break](#94-callcenter_break)
 
 ---
 
@@ -72,6 +79,10 @@ The `<settings>` block contains global options for the module.
 | `dbname` | Name or path of the SQLite database file. | File path | `fifo` |
 | `allow-transcoding` | When `true`, allows transcoding between the caller and consumer legs. | `true`, `false` | `false` |
 | `disable-dtmf-moh-key` | When `true`, disables the `0` DTMF soft-hold feature for consumers. | `true`, `false` | `false` |
+| `db-pre-trans-execute` | SQL statement run by the database queue manager immediately before the outer transaction begins. Used to apply per-connection pragmas or tuning. | SQL string | None |
+| `db-post-trans-execute` | SQL statement run immediately after the outer transaction completes. | SQL string | None |
+| `db-inner-pre-trans-execute` | SQL statement run immediately before each inner (batched) transaction begins. | SQL string | None |
+| `db-inner-post-trans-execute` | SQL statement run immediately after each inner (batched) transaction completes. | SQL string | None |
 
 ### 2.2 Declaring a FIFO Node
 
@@ -116,6 +127,7 @@ Static outbound members are defined as `<member>` children of a `<fifo>` node. T
 | `timeout` | Ring timeout in seconds for this member. Minimum 10; values below 10 fall back to the node `outbound_ring_timeout`. | Integer | Node `outbound_ring_timeout` (default `60`) |
 | `simo` | Maximum simultaneous calls to this member. | Integer `>= 1` | `1` |
 | `lag` | Seconds before the member is available again after a call ends. Negative values fall back to the node `outbound_default_lag`. | Integer | `10` (node `outbound_default_lag` used only when a negative value is given) |
+| `taking_calls` | Whether this member currently accepts calls. Values below `1` are clamped to `1`. Set to a higher value or toggle at runtime to control whether the member is dialed. | Integer `>= 1` | `1` |
 
 The member text body is the originate string. The channel variable `member_wait` (set as a channel pre-dial variable in the originate string) controls what the member does after answering: `wait` holds the call until a caller is available; `nowait` bridges immediately if a caller is already waiting and hangs up otherwise.
 
@@ -194,6 +206,88 @@ Channel variables control per-call behavior within `mod_fifo`. Set them on the c
 | `fifo_record_template` | Path template for recording a bridged call. Supports channel variables and `strftime` tokens. | String | Not set by default. |
 | `fifo_outbound_announce` | Audio file played to the consumer before bridging to a caller that was an outbound callback (dial-url mode). | File path | Not set by default. |
 | `fifo_override_announce` | Set on the caller's channel. When present, overrides the consumer's announce file for that specific bridge. | File path | Not set by default. |
+
+---
+
+### 2.6 The fifo_track_call Application
+
+The `fifo_track_call` application registers a call against an outbound member record so that a bridge established outside of `mod_fifo` is still counted in the module's manual-call statistics. The call is added to the internal `manual_calls` queue and the member's use count is incremented; the count is decremented automatically when the channel hangs up.
+
+**Syntax:**
+
+```
+fifo_track_call <fifo_outbound_uuid>
+```
+
+The single argument is the outbound member UUID (the `fifo_outbound_uuid` value, the same identifier returned for static and dynamically added outbound members). Outbound channels increment `manual_calls_in_count`; inbound channels increment `manual_calls_out_count`. Calling the application twice on the same channel is a no-op and logs a warning.
+
+```xml
+<action application="fifo_track_call" data="$${outbound_member_uuid}"/>
+```
+
+---
+
+### 2.7 mod_fifo API Commands
+
+`mod_fifo` registers four API commands, usable from `fs_cli`, the event socket, or `api`/`bgapi` dialplan applications.
+
+**`fifo`** — Inspect FIFO node state.
+
+**Syntax:**
+
+```
+fifo list|list_verbose|count|debug|status|has_outbound|importance [<fifo name>]|reparse [del_all]
+```
+
+| Sub-command | Purpose |
+|---|---|
+| `list [<fifo name>]` | XML report of one node, or all nodes when no name is given. |
+| `list_verbose [<fifo name>]` | As `list` but includes per-caller and per-consumer detail. |
+| `count [<fifo name>]` | Counters for one or all nodes, formatted `name:consumer_count:caller_count:member_count:ring_consumer_count:idle_consumers`. |
+| `debug [<level>]` | Show or set the module debug level. A negative level is clamped to `0`. |
+| `status` | Dump full module state, including the caller-originate, consumer-originate, and bridge hashes. |
+| `has_outbound [<fifo name>]` | Report whether one or all nodes have outbound members, formatted `name:0\|1`. |
+| `importance <fifo name> [<value>]` | Show or set the importance of a node. A negative value is clamped to `0`. |
+| `reparse [del_all]` | Reload the configuration. With `del_all`, also deletes all outbound member records first. |
+
+**`fifo_member`** — Add or remove a dynamic outbound member at runtime.
+
+**Syntax:**
+
+```
+fifo_member add <fifo_name> <originate_string> [<simo_count>] [<timeout>] [<lag>] [<expires>] [<taking_calls>]
+fifo_member del <fifo_name> <originate_string>
+```
+
+| Argument | Purpose | Default |
+|---|---|---|
+| `<fifo_name>` | Target FIFO node. | Required |
+| `<originate_string>` | Member dial string. | Required |
+| `<simo_count>` | Maximum simultaneous calls; values below `0` reset to `1`. | `1` |
+| `<timeout>` | Ring timeout in seconds; values below `0` reset to `60`. | `60` |
+| `<lag>` | Seconds before the member is available again; values below `0` reset to `5`. | `5` |
+| `<expires>` | Seconds from now after which the dynamic member record expires. | `0` (no expiry) |
+| `<taking_calls>` | Whether the member accepts calls; values below `1` are clamped to `1`. | `1` |
+
+**`fifo_add_outbound`** — Push a one-shot outbound call request onto a node at the given priority slot.
+
+**Syntax:**
+
+```
+fifo_add_outbound <node> <url> [<priority>]
+```
+
+The `<url>` is dialed as a `dial-url` outbound request. `<priority>` is a slot number; values at or above the maximum are clamped to the highest valid slot, and a non-positive or absent value uses slot `0`. The command returns the resulting queue depth of that priority slot (`0` on failure).
+
+**`fifo_check_bridge`** — Test whether a UUID or outbound member ID is currently in a FIFO bridge.
+
+**Syntax:**
+
+```
+fifo_check_bridge <uuid>|<outbound_id>
+```
+
+Returns `true` if the given channel UUID or outbound member ID is part of an active bridge, otherwise `false`.
 
 ---
 
@@ -398,3 +492,82 @@ The `<settings>` block in `callcenter.conf.xml` configures module-wide options.
 | `odbc-dsn` | ODBC connection string for external database storage. When set, the module uses ODBC instead of the internal SQLite database. Format: `dsn:user:pass`. | String | None (SQLite used) |
 | `dbname` | Path or name of the SQLite database file. | File path | `callcenter` |
 | `cc-instance-id` | Instance identifier used to namespace database rows. Relevant in deployments where multiple FreeSWITCH instances share a database. | String | `single_box` |
+| `debug` | Debug verbosity level. Higher values log more detail. | Integer | `0` |
+| `reserve-agents` | When `true`, an agent is reserved (state set to `Reserved`) before a call is offered, preventing the same agent from being offered to two callers simultaneously. | `true`, `false` | `false` |
+| `truncate-tiers-on-load` | When `true`, the `tiers` table is emptied on module load before XML tiers are applied. | `true`, `false` | `false` |
+| `truncate-agents-on-load` | When `true`, the `agents` table is emptied on module load before XML agents are applied. | `true`, `false` | `false` |
+| `global-database-lock` | When `true`, the module serializes database access with a global lock. Set to `false` to allow finer-grained locking. | `true`, `false` | `true` |
+| `agent-originate-timeout` | Seconds to wait for an agent's `Callback`-type leg to answer when originating. A value of `0` falls back to the default. | Integer (seconds) | `60` |
+
+---
+
+## 9. mod_callcenter API Commands
+
+`mod_callcenter` exposes runtime management through the `callcenter_config` API and a separate `callcenter_break` API. Both are usable from `fs_cli`, the event socket, and `api`/`bgapi` dialplan applications. `callcenter_config` is also registered as a JSON API. Commands return `+OK` on success or a `-ERR <reason>` line on failure; `get`, `list`, and `count` commands return data instead.
+
+The general form is:
+
+```
+callcenter_config <section> <action> <args>
+```
+
+Sections are `agent`, `tier`, and `queue`.
+
+### 9.1 callcenter_config agent
+
+| Command | Purpose |
+|---|---|
+| `agent add <name> <type>` | Create an agent. `type` is `callback` or `uuid-standby`. |
+| `agent del <name>` | Delete an agent. |
+| `agent reload <name>` | Reload the agent's definition from XML. |
+| `agent set status <agent_name> <status>` | Set agent status (`Logged Out`, `Available`, `Available (On Demand)`, `On Break`). Setting `Available` resets talk time, answered-call count, and no-answer count. |
+| `agent set state <agent_name> <state>` | Set agent state (`Waiting`, `Receiving`, `In a queue call`, `Idle`, `Reserved`). |
+| `agent set contact <agent_name> <contact>` | Set the agent's originate string or standby UUID. |
+| `agent set ready_time <agent_name> <epoch>` | Hold the agent unavailable until the given Unix epoch time. |
+| `agent set reject_delay_time <agent_name> <seconds>` | Set the delay before re-offering after a rejected call. |
+| `agent set busy_delay_time <agent_name> <seconds>` | Set the delay before re-offering after a busy result. |
+| `agent set no_answer_delay_time <agent_name> <seconds>` | Set the delay before re-offering after a no-answer. |
+| `agent get status <agent_name>` | Return the agent's current status. |
+| `agent get state <agent_name>` | Return the agent's current state. |
+| `agent get uuid <agent_name>` | Return the agent's current channel UUID. |
+| `agent list [<agent_name>]` | List all agents, or one named agent, as pipe-delimited rows. |
+
+### 9.2 callcenter_config tier
+
+| Command | Purpose |
+|---|---|
+| `tier add <queue_name> <agent_name> [<level>] [<position>]` | Assign an agent to a queue. `level` and `position` default to `1`. |
+| `tier set state <queue_name> <agent_name> <state>` | Set the tier state (`Ready`, `No Answer`, `Offering`, `Active Inbound`, `Standby`). |
+| `tier set level <queue_name> <agent_name> <level>` | Set the tier's priority level. |
+| `tier set position <queue_name> <agent_name> <position>` | Set the tier's position within its level. |
+| `tier del <queue_name> <agent_name>` | Remove the agent from the queue. |
+| `tier reload <queue_name> <agent_name>` | Reload the tier from XML. Pass `all` as the queue name to reload every tier. |
+| `tier list` | List all tiers ordered by level then position. |
+
+### 9.3 callcenter_config queue
+
+| Command | Purpose |
+|---|---|
+| `queue load <queue_name>` | Load a queue definition into memory. |
+| `queue unload <queue_name>` | Remove a queue from memory. |
+| `queue reload <queue_name>` | Unload then reload a queue. |
+| `queue list` | List all loaded queues as pipe-delimited rows. |
+| `queue list agents <queue_name> [<status>] [<state>]` | List agents in a queue, optionally filtered by status and then state. |
+| `queue list members <queue_name>` | List waiting callers in a queue, ordered by score (longest-waiting first). |
+| `queue list tiers <queue_name>` | List the tiers configured for a queue. |
+| `queue count` | Return the number of loaded queues. |
+| `queue count agents <queue_name> [<status>] [<state>]` | Count agents in a queue, optionally filtered by status and then state. |
+| `queue count members <queue_name>` | Count waiting callers in a queue. |
+| `queue count tiers <queue_name>` | Count the tiers in a queue. |
+
+### 9.4 callcenter_break
+
+`callcenter_break` stops the module from watching a channel UUID and releases the associated agent. It is used to break an agent out of a call that the module is tracking.
+
+**Syntax:**
+
+```
+callcenter_break agent <uuid>
+```
+
+The `<uuid>` is the channel UUID to stop watching. The command flags the channel so that `mod_callcenter` ends its supervision on the next pass, freeing the agent.

--- a/docs/applications/queues-fifo-callcenter.mdx
+++ b/docs/applications/queues-fifo-callcenter.mdx
@@ -133,7 +133,7 @@ The member text body is the originate string. The channel variable `member_wait`
 
 ### 2.4 The fifo Dialplan Application
 
-The `fifo` application places a channel into a named FIFO as either a caller (inbound, `in` mode) or a consumer/agent (outbound, `out` mode).
+The `fifo` application places a channel into a named FIFO as either a caller (inbound, `in` mode) or a consumer/agent (outbound, `out` mode); it is also summarized in the [dptools reference](../dialplan/dptools-reference.mdx).
 
 **Syntax:**
 

--- a/docs/applications/utility-applications.mdx
+++ b/docs/applications/utility-applications.mdx
@@ -13,17 +13,17 @@ This chapter documents the operator-facing utility modules that ship with FreeSW
 
 ## Table of Contents
 
-- [23.1 mod_db: Persistent Key-Value Store and Call Limiting](#231-mod_db-persistent-key-value-store-and-call-limiting)
-- [23.2 mod_hash: In-Memory Shared State and limit_hash Backend](#232-mod_hash-in-memory-shared-state-and-limit_hash-backend)
-- [23.3 mod_limit: Backward-Compatibility Shim](#233-mod_limit-backward-compatibility-shim)
-- [23.4 mod_valet_parking: Valet Call Parking](#234-mod_valet_parking-valet-call-parking)
-- [23.5 mod_esf: Multicast Paging](#235-mod_esf-multicast-paging)
-- [23.6 mod_fsv: Video File Recording and Playback](#236-mod_fsv-video-file-recording-and-playback)
-- [23.7 mod_spy: User Call Monitoring](#237-mod_spy-user-call-monitoring)
+- [mod_db: Persistent Key-Value Store and Call Limiting](#mod_db-persistent-key-value-store-and-call-limiting)
+- [mod_hash: In-Memory Shared State and limit_hash Backend](#mod_hash-in-memory-shared-state-and-limit_hash-backend)
+- [mod_limit: Backward-Compatibility Shim](#mod_limit-backward-compatibility-shim)
+- [mod_valet_parking: Valet Call Parking](#mod_valet_parking-valet-call-parking)
+- [mod_esf: Multicast Paging](#mod_esf-multicast-paging)
+- [mod_fsv: Video File Recording and Playback](#mod_fsv-video-file-recording-and-playback)
+- [mod_spy: User Call Monitoring](#mod_spy-user-call-monitoring)
 
 ---
 
-## 23.1 mod_db: Persistent Key-Value Store and Call Limiting
+## mod_db: Persistent Key-Value Store and Call Limiting {#mod_db-persistent-key-value-store-and-call-limiting}
 
 `mod_db` provides two distinct services: a persistent SQL-backed key-value store accessible from the dialplan via the `db` application, and the `db` backend for the core `limit` subsystem. Data survives a module reload but is cleared on process restart (records belonging to the local hostname are deleted at startup).
 
@@ -165,7 +165,7 @@ group call:salesgroup:order
 
 ---
 
-## 23.2 mod_hash: In-Memory Shared State and limit_hash Backend
+## mod_hash: In-Memory Shared State and limit_hash Backend {#mod_hash-in-memory-shared-state-and-limit_hash-backend}
 
 `mod_hash` maintains two in-memory hash tables: one used as the `hash` backend for the core `limit` subsystem (tracking concurrent call counts and call rates), and one used as a general-purpose in-process key-value store accessed via the `hash` application. Because data lives in process memory, it is lost on process restart.
 
@@ -289,7 +289,7 @@ hash_remote list|kill [name]|rescan
 
 ---
 
-## 23.3 mod_limit: Backward-Compatibility Shim
+## mod_limit: Backward-Compatibility Shim {#mod_limit-backward-compatibility-shim}
 
 `mod_limit` is a deprecated compatibility module. It registers no applications of its own. When loaded, it attempts to load `mod_hash` and `mod_db` if they are not already present, and sets the internal variable `switch_limit_backwards_compat_flag` to `true` to allow legacy dialplan that referenced `mod_limit` directly to continue working.
 
@@ -297,7 +297,7 @@ New installations should load `mod_hash` and `mod_db` directly and omit `mod_lim
 
 ---
 
-## 23.4 mod_valet_parking: Valet Call Parking
+## mod_valet_parking: Valet Call Parking {#mod_valet_parking-valet-call-parking}
 
 `mod_valet_parking` implements a named-lot call parking system. A call is parked in a named lot at a specific extension number, which is either specified explicitly, entered by the caller via DTMF, or assigned automatically from a numeric range. Any channel that dials the same lot and extension retrieves the parked call and bridges to it. Lot state is held in memory; it is lost on process restart.
 
@@ -393,7 +393,7 @@ The bundled `valet_parking.xml` provides two ready-to-use extensions:
 
 ---
 
-## 23.5 mod_esf: Multicast Paging
+## mod_esf: Multicast Paging {#mod_esf-multicast-paging}
 
 `mod_esf` (Extra SIP Functionality) implements RTP multicast paging. The `esf_page_group` application answers the inbound call, then simultaneously broadcasts the caller's audio to a multicast group. It also sends Polycom-compatible paging protocol packets so that Polycom IP phones in the multicast group can display the caller ID and alert the user. The application blocks until the caller hangs up.
 
@@ -447,7 +447,7 @@ From `conf/vanilla/dialplan/default.xml`:
 
 ---
 
-## 23.6 mod_fsv: Video File Recording and Playback
+## mod_fsv: Video File Recording and Playback {#mod_fsv-video-file-recording-and-playback}
 
 `mod_fsv` implements the FreeSWITCH Video (`.fsv`) file format and provides applications to record and play back audio-video calls to and from `.fsv` files. The `.fsv` format is a proprietary container that stores raw RTP video packets and L16 audio interleaved with length-prefixed frames. It also registers a file interface so `.fsv` files can be used wherever FreeSWITCH accepts a file path (for example, as a `playback` argument).
 
@@ -497,7 +497,7 @@ The application reads the file header to determine the video codec and audio sam
 
 ---
 
-## 23.7 mod_spy: User Call Monitoring
+## mod_spy: User Call Monitoring {#mod_spy-user-call-monitoring}
 
 `mod_spy` provides persistent user-level call monitoring. The `userspy` application registers a watch on a `user@domain` target and parks the spy channel. When the watched user bridges a call, the spy channel is automatically connected via eavesdrop. Multiple spy channels can watch the same target simultaneously.
 

--- a/docs/applications/utility-applications.mdx
+++ b/docs/applications/utility-applications.mdx
@@ -9,7 +9,7 @@ sidebar_label: "23. Utility Applications"
 
 # Chapter 23: Utility Applications
 
-This chapter documents the operator-facing utility modules that ship with FreeSWITCH. Each module is treated as a self-contained unit: its configuration file (where one exists), the dialplan applications it registers, the API commands it exposes, and the parameters or arguments those applications accept.
+This chapter documents the operator-facing utility modules that ship with FreeSWITCH. Each module is treated as a self-contained unit: its configuration file (where one exists), the dialplan applications it registers, the API commands it exposes, and the parameters or arguments those applications accept. The dialplan applications introduced here (`db`, `hash`, `limit`, `valet_park`, and others) are also summarized in the [dptools reference](../dialplan/dptools-reference.mdx).
 
 ## Table of Contents
 

--- a/docs/applications/voicemail.mdx
+++ b/docs/applications/voicemail.mdx
@@ -13,26 +13,26 @@ The `mod_voicemail` module provides integrated voicemail for FreeSWITCH, support
 
 ## Table of Contents
 
-- [19.1 Getting Started](#191-getting-started)
-- [19.2 Profile Configuration](#192-profile-configuration)
-  - [19.2.1 Profile Parameter Reference](#1921-profile-parameter-reference)
-  - [19.2.2 DTMF Key Bindings](#1922-dtmf-key-bindings)
-  - [19.2.3 Email Sub-element](#1923-email-sub-element)
-  - [19.2.4 Storage and Database Options](#1924-storage-and-database-options)
-- [19.3 User Directory Integration](#193-user-directory-integration)
-  - [19.3.1 Per-User Parameters](#1931-per-user-parameters)
-- [19.4 The voicemail Dialplan Application](#194-the-voicemail-dialplan-application)
-  - [19.4.1 Leave-Message Mode](#1941-leave-message-mode)
-  - [19.4.2 Check-Mailbox Mode](#1942-check-mailbox-mode)
-  - [19.4.3 Channel Variables](#1943-channel-variables)
-- [19.5 Email Notification](#195-email-notification)
-  - [19.5.1 Email Template Variables](#1951-email-template-variables)
-- [19.6 Default Dialplan Entries](#196-default-dialplan-entries)
-- [19.7 Global Settings](#197-global-settings)
+- [Getting Started](#getting-started)
+- [Profile Configuration](#profile-configuration)
+  - [Profile Parameter Reference](#profile-parameter-reference)
+  - [DTMF Key Bindings](#dtmf-key-bindings)
+  - [Email Sub-element](#email-sub-element)
+  - [Storage and Database Options](#storage-and-database-options)
+- [User Directory Integration](#user-directory-integration)
+  - [Per-User Parameters](#per-user-parameters)
+- [The voicemail Dialplan Application](#the-voicemail-dialplan-application)
+  - [Leave-Message Mode](#leave-message-mode)
+  - [Check-Mailbox Mode](#check-mailbox-mode)
+  - [Channel Variables](#channel-variables)
+- [Email Notification](#email-notification)
+  - [Email Template Variables](#email-template-variables)
+- [Default Dialplan Entries](#default-dialplan-entries)
+- [Global Settings](#global-settings)
 
 ---
 
-## 19.1 Getting Started
+## Getting Started {#getting-started}
 
 **Prerequisites:** `mod_voicemail` must be loaded. Confirm it appears in `autoload_configs/modules.conf.xml`. The module reads its configuration from `autoload_configs/voicemail.conf.xml`.
 
@@ -53,7 +53,7 @@ This invokes the `voicemail` application in leave-message mode for the mailbox m
 
 ---
 
-## 19.2 Profile Configuration
+## Profile Configuration {#profile-configuration}
 
 Profiles are defined in `autoload_configs/voicemail.conf.xml`. Each profile is a named collection of parameters that governs recording behavior, DTMF menus, storage paths, and email delivery. Multiple profiles can coexist; each invocation of the `voicemail` dialplan application specifies which profile to use.
 
@@ -119,11 +119,11 @@ Profiles are defined in `autoload_configs/voicemail.conf.xml`. Each profile is a
 </configuration>
 ```
 
-### 19.2.1 Profile Parameter Reference
+### Profile Parameter Reference {#profile-parameter-reference}
 
 **Recording and audio format:**
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `file-extension` | Audio format for recorded messages and greetings | Any format string supported by the installed codec modules, e.g. `wav`, `mp3` | `wav` |
 | `terminator-key` | DTMF digit that ends a recording | Single DTMF digit | `#` |
@@ -142,7 +142,7 @@ Profiles are defined in `autoload_configs/voicemail.conf.xml`. Each profile is a
 
 **Session and menu behavior:**
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `digit-timeout` | Milliseconds to wait for a DTMF digit during menu navigation | Integer (ms) | `10000` |
 | `max-login-attempts` | Number of failed PIN attempts allowed before the mailbox check session is terminated | Integer | `3` |
@@ -155,7 +155,7 @@ Profiles are defined in `autoload_configs/voicemail.conf.xml`. Each profile is a
 
 **Callback and transfer destinations:**
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `callback-dialplan` | Dialplan type used when a subscriber presses the callback key during message playback | `XML`, `ENUM`, or other configured dialplan type | `XML` |
 | `callback-context` | Dialplan context used for the callback call | Context name string | `default` |
@@ -166,7 +166,7 @@ Profiles are defined in `autoload_configs/voicemail.conf.xml`. Each profile is a
 
 **Storage and database:**
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `storage-dir` | Base directory for storing voicemail message files; when empty, messages are stored under the global FreeSWITCH storage directory | Absolute path | (empty; uses global storage dir) |
 | `storage-dir-shared` | When `true`, mailbox directories under `storage-dir` include a `voicemail/` segment in the path, enabling a shared storage root across domains | `true`, `false` | `false` |
@@ -175,24 +175,24 @@ Profiles are defined in `autoload_configs/voicemail.conf.xml`. Each profile is a
 
 **MWI (Message Waiting Indicator):**
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `send-full-vm-header` | When `true`, the MWI `Voice-Message` SIP header includes urgent message counts in the format `new/saved (new-urgent/saved-urgent)` instead of the abbreviated `new/saved` form | `true`, `false` | `false` |
 
 **Email delivery (inline profile params, not inside `<email>`):**
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `notify-email-body` | Literal body text for notification-only emails when no template file is used; set as a `<param>` in the profile (outside `<email>`) | String | (none) |
 | `notify-email-headers` | Literal RFC 2822 headers for notification-only emails; set as a `<param>` in the profile (outside `<email>`) | String | (none) |
 
 **Web interface:**
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `web-template-file` | Path to a template file used to generate a web-based voicemail interface response | Filename relative to the FreeSWITCH config directory | `web-vm.tpl` |
 
-### 19.2.2 DTMF Key Bindings
+### DTMF Key Bindings {#dtmf-key-bindings}
 
 These parameters assign DTMF digits to menu actions. Each accepts a single DTMF digit (`0`-`9`, `*`, `#`).
 
@@ -252,7 +252,7 @@ These parameters assign DTMF digits to menu actions. Each accepts a single DTMF 
 | `listen-file-key` | Listen to recording | `1` |
 | `save-file-key` | Save the recording | `2` |
 
-### 19.2.3 Email Sub-element
+### Email Sub-element {#email-sub-element}
 
 Email delivery parameters are nested inside an `<email>` child element within the profile. The `<email>` block supports `<param>` elements and two special raw-text children, `<body>` and `<headers>`:
 
@@ -270,7 +270,7 @@ Email delivery parameters are nested inside an `<email>` child element within th
 
 **`<email>` `<param>` reference:**
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `template-file` | Template file for the email sent with an attached message audio file | Filename relative to the FreeSWITCH config directory | `voicemail.tpl` |
 | `notify-template-file` | Template file for the notification-only email (no audio attachment) | Filename relative to the FreeSWITCH config directory | `notify-voicemail.tpl` |
@@ -288,7 +288,7 @@ When `<body>` is present, it overrides the `template-file` for the delivery emai
 
 Template files are located in the FreeSWITCH configuration root (the same directory as `voicemail.conf.xml`). The vanilla configuration ships `voicemail.tpl` (message delivery with attachment) and `notify-voicemail.tpl` (notification only, no attachment). Both are RFC 2822 formatted MIME multipart documents with plain text and HTML parts.
 
-### 19.2.4 Storage and Database Options
+### Storage and Database Options {#storage-and-database-options}
 
 By default, `mod_voicemail` uses an SQLite database to store message metadata and places recorded audio files under the global FreeSWITCH storage directory in a `voicemail/` subdirectory, organized as `voicemail/<domain>/<mailbox-id>/`.
 
@@ -310,7 +310,7 @@ Per-user storage overrides are available via the user directory parameters `vm-s
 
 ---
 
-## 19.3 User Directory Integration
+## User Directory Integration {#user-directory-integration}
 
 Each voicemail mailbox corresponds to a user entry in the FreeSWITCH XML user directory (typically under `directory/default/`). The mailbox ID is the user's `id` attribute. The `vm-password` param in the user's `<params>` block sets the PIN required to authenticate during mailbox check.
 
@@ -325,7 +325,7 @@ Each voicemail mailbox corresponds to a user entry in the FreeSWITCH XML user di
 
 When `db-password-override` is `false` in the profile (the default), the directory `vm-password` is authoritative. When set to `true`, a password stored in the voicemail database (set by the subscriber via the change-password menu) takes precedence.
 
-### 19.3.1 Per-User Parameters
+### Per-User Parameters {#per-user-parameters}
 
 The following `<param>` entries in a user's directory entry override profile-level behavior for that mailbox:
 
@@ -354,7 +354,7 @@ The following `<param>` entries in a user's directory entry override profile-lev
 
 ---
 
-## 19.4 The voicemail Dialplan Application
+## The voicemail Dialplan Application {#the-voicemail-dialplan-application}
 
 The application name is `voicemail`; it is also summarized in the [dptools reference](../dialplan/dptools-reference.mdx). The full argument syntax is:
 
@@ -366,7 +366,7 @@ The application name is `voicemail`; it is also summarized in the [dptools refer
 
 The optional keywords `check`, `auth`, and `auth_only` are parsed in order before the positional arguments. They are case-insensitive. Multiple keywords can appear together (e.g., `check auth`).
 
-### 19.4.1 Leave-Message Mode
+### Leave-Message Mode {#leave-message-mode}
 
 When neither `check` nor `auth_only` is specified, the application runs in leave-message mode: it plays the mailbox owner's greeting, records a message from the caller, and stores the recording.
 
@@ -382,7 +382,7 @@ A typical use is as a post-bridge fallback when a called extension is unavailabl
 <action application="voicemail" data="default ${domain_name} 1001"/>
 ```
 
-### 19.4.2 Check-Mailbox Mode
+### Check-Mailbox Mode {#check-mailbox-mode}
 
 When `check` is present, the application enters mailbox check mode: the subscriber is prompted to enter their mailbox ID (if not supplied in the argument) and PIN, then presented with the message playback menu.
 
@@ -408,7 +408,7 @@ The `auth_only` keyword causes the session to enter check mode and exit immediat
 
 The optional `uuid` positional argument (after the mailbox `id`) is only meaningful in check mode. When supplied, it opens a specific message directly by UUID.
 
-### 19.4.3 Channel Variables
+### Channel Variables {#channel-variables}
 
 **Input variables (read before or during execution):**
 
@@ -452,7 +452,7 @@ The optional `uuid` positional argument (after the mailbox `id`) is only meaning
 
 ---
 
-## 19.5 Email Notification
+## Email Notification {#email-notification}
 
 When a new message is left and the user directory has `vm-mailto` or `vm-notify-mailto` configured, `mod_voicemail` generates and sends an email using FreeSWITCH's internal `switch_simple_email` function. The host must have a working MTA (such as `sendmail` or `postfix`) installed and accessible from the default PATH.
 
@@ -465,7 +465,7 @@ Setting `vm-notify-email-all-messages true` on the user triggers a notification 
 
 Audio format conversion before attachment is available via `vm-convert-cmd` and `vm-convert-ext` (or the profile-level equivalents `convert-cmd` and `convert-ext`). The convert command is called as a shell command with the source file path; the resulting file with the new extension is attached.
 
-### 19.5.1 Email Template Variables
+### Email Template Variables {#email-template-variables}
 
 Templates are plain RFC 2822 text files with FreeSWITCH variable substitution (`${variable}`). The following variables are populated by the module for use in template files:
 
@@ -490,7 +490,7 @@ The default `voicemail.tpl` produces a `multipart/alternative` message with plai
 
 ---
 
-## 19.6 Default Dialplan Entries
+## Default Dialplan Entries {#default-dialplan-entries}
 
 The vanilla `dialplan/default.xml` ships with two voicemail-related extension patterns.
 
@@ -522,7 +522,7 @@ To restrict mailbox check to a subscriber's own extension (pre-authenticated), s
 
 ---
 
-## 19.7 Global Settings
+## Global Settings {#global-settings}
 
 The `<settings>` block at the top level of `voicemail.conf.xml` (outside any profile) accepts module-wide parameters:
 
@@ -532,7 +532,7 @@ The `<settings>` block at the top level of `voicemail.conf.xml` (outside any pro
 </settings>
 ```
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `message-query-exact-match` | When `true`, the `vm_count` API and related queries match the domain field exactly. Operators who use distinct domain names per tenant must enable this and define a dedicated profile per domain. | `true`, `false` | `false` |
 | `debug` | Enables additional debug logging for the module | Integer (0 = off) | `0` |

--- a/docs/applications/voicemail.mdx
+++ b/docs/applications/voicemail.mdx
@@ -356,7 +356,7 @@ The following `<param>` entries in a user's directory entry override profile-lev
 
 ## 19.4 The voicemail Dialplan Application
 
-The application name is `voicemail`. The full argument syntax is:
+The application name is `voicemail`; it is also summarized in the [dptools reference](../dialplan/dptools-reference.mdx). The full argument syntax is:
 
 ```
 [check] [auth] [auth_only] <profile_name> <domain_name> [<id>] [uuid]

--- a/docs/configuration-system/index.mdx
+++ b/docs/configuration-system/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Part 2: The Configuration System"
 slug: /configuration
-description: How FreeSWITCH is configured through its XML configuration system.
+description: "How FreeSWITCH is configured through its XML configuration system."
 ---
 
 import DocCardList from '@theme/DocCardList';

--- a/docs/configuration-system/module-loading.mdx
+++ b/docs/configuration-system/module-loading.mdx
@@ -187,14 +187,14 @@ the channel variables it uses.
 
 **Loggers**
 
-| Module | When to enable |
+| Module | Role |
 | --- | --- |
 | `mod_graylog2` | Centralized log shipping to a Graylog2 GELF endpoint |
 | `mod_syslog` | Send log output to the system syslog daemon |
 
 **XML Interfaces**
 
-| Module | When to enable |
+| Module | Role |
 | --- | --- |
 | `mod_xml_rpc` | Exposes an HTTP/XML-RPC management interface; used by some web admin panels |
 | `mod_xml_curl` | Fetches dialplan, directory, and configuration XML from an HTTP server at runtime |
@@ -203,7 +203,7 @@ the channel variables it uses.
 
 **Event Handlers**
 
-| Module | When to enable |
+| Module | Role |
 | --- | --- |
 | `mod_amqp` | Publishes events to an AMQP broker (RabbitMQ) |
 | `mod_cdr_sqlite` | Writes CDR records to a local SQLite database |
@@ -214,13 +214,13 @@ the channel variables it uses.
 
 **Directory Interfaces**
 
-| Module | When to enable |
+| Module | Role |
 | --- | --- |
 | `mod_ldap` | Authenticates and looks up users from an LDAP directory |
 
 **Endpoints**
 
-| Module | When to enable |
+| Module | Role |
 | --- | --- |
 | `mod_alsa` | ALSA audio endpoint for local sound card access on Linux |
 | `mod_skinny` | Cisco SCCP (Skinny) endpoint for Cisco desk phones |
@@ -230,7 +230,7 @@ the channel variables it uses.
 
 **Applications**
 
-| Module | When to enable |
+| Module | Role |
 | --- | --- |
 | `mod_curl` | Makes HTTP requests from dialplan; fetches or posts data to web services |
 | `mod_directory` | Company directory application with DTMF name search |
@@ -242,26 +242,24 @@ the channel variables it uses.
 | `mod_sms` | SMS message routing and handling application |
 | `mod_random` | Generates random numbers for use in dialplan variables |
 | `mod_translate` | Number translation using regular expression or database rules |
-| `mod_callcenter` | Full-featured ACD call center queue engine |
-| `mod_nibblebill` | Real-time billing and credit deduction for active calls |
 | `mod_mongo` | MongoDB integration for dialplan and data storage |
 
 **Dialplan Interfaces**
 
-| Module | When to enable |
+| Module | Role |
 | --- | --- |
 | `mod_dialplan_directory` | Looks up dialplan routing from the user directory |
 
 **Codec Interfaces**
 
-| Module | When to enable |
+| Module | Role |
 | --- | --- |
 | `mod_ilbc` | iLBC narrowband codec (13.3 kbps and 15.2 kbps) |
 | `mod_siren` | G.722.1 (Siren) wideband codec for Polycom interoperability |
 
 **File Format Interfaces**
 
-| Module | When to enable |
+| Module | Role |
 | --- | --- |
 | `mod_opusfile` | Reads Ogg Opus files for playback |
 | `mod_shout` | Reads and writes MP3 streams and files via libshout and libmp3lame; Icecast source |
@@ -269,14 +267,14 @@ the channel variables it uses.
 
 **Timers**
 
-| Module | When to enable |
+| Module | Role |
 | --- | --- |
 | `mod_timerfd` | High-resolution timer using Linux `timerfd` kernel interface |
 | `mod_posix_timer` | POSIX interval timer as an alternative timing source |
 
 **Languages**
 
-| Module | When to enable |
+| Module | Role |
 | --- | --- |
 | `mod_v8` | Embeds the V8 JavaScript engine for dialplan scripting |
 | `mod_perl` | Embeds the Perl runtime for dialplan scripts |
@@ -285,7 +283,7 @@ the channel variables it uses.
 
 **ASR/TTS**
 
-| Module | When to enable |
+| Module | Role |
 | --- | --- |
 | `mod_flite` | Text-to-speech using the CMU Flite engine |
 | `mod_pocketsphinx` | Automatic speech recognition using the PocketSphinx engine |
@@ -293,7 +291,7 @@ the channel variables it uses.
 
 **Say**
 
-| Module | When to enable |
+| Module | Role |
 | --- | --- |
 | `mod_say_ru` | Russian language phrase rendering |
 | `mod_say_zh` | Chinese language phrase rendering |
@@ -307,7 +305,7 @@ Additional say modules available in the build system (not listed in the default
 
 **Third-party Applications**
 
-| Module | When to enable |
+| Module | Role |
 | --- | --- |
 | `mod_nibblebill` | Real-time per-leg billing with configurable deduction intervals |
 | `mod_callcenter` | ACD queue with agent skill routing, wrap-up, and reporting |
@@ -339,12 +337,13 @@ Each file uses identical `<load module="..."/>` syntax.
 (including core subsystems) may open database connections during their own
 initialization, the database driver must be available before the main load
 sequence begins. `mod_mariadb` is a commented-out alternative for MariaDB or
-MySQL backends; enable it in place of or alongside `mod_pgsql` as needed.
+MySQL backends; enable it instead of `mod_pgsql` to use a MariaDB or MySQL
+backend, or alongside it to use both.
 
-`mod_xml_curl` is another common candidate for early loading: when FreeSWITCH
-fetches configuration, directory, and dialplan documents from an HTTP server,
-that XML interface must be registered before the modules that consume those
-documents initialize.
+Enable `mod_xml_curl` here when FreeSWITCH fetches configuration, directory, and
+dialplan documents from an HTTP server: the XML interface must be registered
+before the modules that consume those documents initialize, which requires early
+loading.
 
 **`post_load_modules.conf.xml`** -- Empty by default. Use it for modules that
 depend on the full module set being initialized first. No shipped modules

--- a/docs/configuration-system/variables-and-core-settings.mdx
+++ b/docs/configuration-system/variables-and-core-settings.mdx
@@ -117,7 +117,7 @@ parameter explicitly set, that value is noted in parentheses.
 
 ### Session and Call Control
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 | --- | --- | --- | --- |
 | `max-sessions` | Maximum simultaneous sessions | integer | `1000` |
 | `sessions-per-second` | Maximum new sessions created per second | integer | `30` |
@@ -129,7 +129,7 @@ parameter explicitly set, that value is noted in parentheses.
 
 ### Logging
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 | --- | --- | --- | --- |
 | `loglevel` | Global log level | `debug`, `info`, `notice`, `warning`, `err`, `crit`, `alert` | `debug` |
 | `debug-level` | Core debug verbosity level | `0`-`10` | `0` |
@@ -139,7 +139,7 @@ parameter explicitly set, that value is noted in parentheses.
 
 ### Database
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 | --- | --- | --- | --- |
 | `max-db-handles` | Maximum simultaneous core database handles; must be between 5 and 5000 | integer | `50` |
 | `db-handle-timeout` | Seconds to wait for a database handle before failing; must be between 1 and 5000 | integer | `5` (vanilla config ships `10`) |
@@ -167,7 +167,7 @@ dsn:username:password
 
 ### RTP
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 | --- | --- | --- | --- |
 | `rtp-start-port` | Lowest UDP port allocated for RTP | port number | `16384` |
 | `rtp-end-port` | Highest UDP port allocated for RTP | port number | `32768` |
@@ -177,7 +177,7 @@ dsn:username:password
 
 ### DTMF
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 | --- | --- | --- | --- |
 | `min-dtmf-duration` | Minimum DTMF event duration in samples; events shorter than this are padded; cannot be set below `400` | integer | `400` |
 | `max-dtmf-duration` | Maximum DTMF event duration in samples; events longer than this are truncated; cannot exceed `192000` | integer | `192000` |
@@ -185,7 +185,7 @@ dsn:username:password
 
 ### Timing
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 | --- | --- | --- | --- |
 | `1ms-timer` | Run the core timer at 1 ms resolution instead of the default 20 ms | `true` | `false` |
 | `enable-monotonic-timing` | Use monotonic clock for timing | `true`, `false` | `false` |
@@ -198,7 +198,7 @@ dsn:username:password
 
 ### System Execution
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 | --- | --- | --- | --- |
 | `threaded-system-exec` | Run `system()` calls in a dedicated thread; not supported on Windows | `true`, `false` | `true` (non-Windows) |
 | `spawn-instead-of-system` | Use `posix_spawn` instead of `system()` for external commands; not supported on Windows | `true`, `false` | `false` |
@@ -206,7 +206,7 @@ dsn:username:password
 
 ### Events
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 | --- | --- | --- | --- |
 | `event-heartbeat-interval` | Interval in seconds between `HEARTBEAT` events | integer | `20` |
 | `events-use-dispatch` | Route events through a dispatch thread pool | `true`, `false` | `true` |
@@ -219,14 +219,14 @@ dsn:username:password
 
 ### Identity
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 | --- | --- | --- | --- |
 | `switchname` | Override the system hostname for database and CURL identity; useful in HA clusters where nodes share a config but must present different identities | string | system hostname |
 | `uuid-version` | UUID version used for channel IDs | `4`, `7` | `4` |
 
 ### Miscellaneous
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 | --- | --- | --- | --- |
 | `mailer-app` | Program used to send voicemail email | program name | `sendmail` |
 | `mailer-app-args` | Arguments passed to `mailer-app` | string | `-t` |
@@ -305,7 +305,7 @@ records to the loggers; each logger then applies its own filter.
 
 #### Settings
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 | --- | --- | --- | --- |
 | `colorize` | Emit ANSI color codes to distinguish log levels | `true`, `false` | `false` |
 | `loglevel` | Maximum level this logger accepts; records above this level are suppressed | `console`, `alert`, `crit`, `err`, `warning`, `notice`, `info`, `debug` | `debug` |
@@ -368,13 +368,13 @@ policy, and level filter.
 
 #### Global Settings
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 | --- | --- | --- | --- |
 | `rotate-on-hup` | When FreeSWITCH receives SIGHUP, rotate the log file instead of closing and reopening it | `true`, `false` | `false` |
 
 #### Profile Settings
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 | --- | --- | --- | --- |
 | `logfile` | Absolute path to the log file | path string | `$${log_dir}/freeswitch.log` |
 | `rollover` | Size in bytes at which the log file is rotated; `0` disables size-based rotation | integer | `10485760` (about 10 MB; vanilla ships `1048576000`) |
@@ -438,7 +438,7 @@ configured in `syslog.conf.xml` and is not loaded by default.
 
 #### Settings
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 | --- | --- | --- | --- |
 | `ident` | The identity string passed to `openlog()`; appears as the program name in syslog entries | string | `freeswitch` |
 | `facility` | The syslog facility | `auth`, `cron`, `daemon`, `kern`, `local0`-`local7`, `lpr`, `mail`, `news`, `syslog`, `user`, `uucp` (and `authpriv`, `ftp` where available) | `user` |

--- a/docs/dialplan/dptools-reference.mdx
+++ b/docs/dialplan/dptools-reference.mdx
@@ -9,7 +9,7 @@ sidebar_label: "14. Dialplan Application Reference"
 
 # Chapter 14: Dialplan Application Reference
 
-This chapter is a reference for every operator-facing dialplan application you invoke with `<action application="..." data="..."/>` inside an extension condition. The primary source is `mod_dptools`, which provides the core call-control, audio, DTMF, variable, and logging applications. Applications provided by companion modules (`mod_conference`, `mod_voicemail`, `mod_fifo`, `mod_valet_parking`, `mod_hash`, `mod_db`, `mod_lua`, `mod_spy`, `mod_esf`, `mod_fsv`) are covered in the Feature Applications section; those modules must be loaded before the applications become available.
+This chapter is a reference for the dialplan applications you invoke with `<action application="..." data="..."/>` inside an extension condition. It covers every application registered by `mod_dptools`, which provides the core call-control, audio, DTMF, variable, and logging applications. A handful of these are advanced or internal helpers (for example `park_state`, `acknowledge_call`, `recovery_refresh`, `reuse_caller_profile`, `set_media_stats`, `capture_text`, `vad_test`, and the `video_*` overlay apps) that operators rarely call directly; they are included here for completeness and noted as such. Applications provided by companion modules (`mod_conference`, `mod_voicemail`, `mod_fifo`, `mod_valet_parking`, `mod_hash`, `mod_db`, `mod_lua`, `mod_spy`, `mod_esf`, `mod_fsv`) are covered in the Feature Applications section; those modules must be loaded before the applications become available.
 
 ## Table of Contents
 
@@ -58,6 +58,11 @@ These applications establish, route, and tear down call legs. They operate direc
 | `blind_transfer_ack` | Acknowledge or reject a blind transfer request on the channel. | `[true\|false]` |
 | `page` | Page a list of channels simultaneously by dialing them and playing a file. The file path and optional variables are passed before the channel list. | `[<var1=val1,var2=val2>]<chan1>[:_:<chanN>]` |
 | `park_state` | Trigger the park state machine on the channel, used internally after the `park` application. | None |
+| `acknowledge_call` | Indicate that the call has been acknowledged (used by endpoints that signal call acknowledgement separately from ringing or answer). | None |
+| `break` | Set the break flag on the channel, interrupting any in-progress playback or digit collection. If a broadcast is active it is stopped instead. Pass `all` to also flush queued private events. | `[all]` |
+| `recovery_refresh` | Send a recovery-refresh indication to the channel, used during call recovery to re-sync endpoint state. | None |
+| `reuse_caller_profile` | Set the channel flag that causes the existing caller profile to be reused rather than rebuilt, typically before a `transfer` or `execute_extension`. | None |
+| `set_media_stats` | Snapshot the current RTP media statistics into channel variables (`rtp_audio_*`, etc.) for the current state of the media. | None |
 
 ### Scheduling Applications
 
@@ -97,7 +102,7 @@ These applications play, record, and generate audio on the channel. They require
 | `record_session_resume` | Resume a paused session recording. | `<path>` |
 | `displace_session` | Replace the channel's audio input with audio from a file or stream. | `<path> [<flags>] [+<time_limit_ms>]` |
 | `stop_displace_session` | Stop a displace session started by `displace_session`. | `<path>` |
-| `detect_speech` | Start ASR speech detection on the channel using a grammar and ASR engine. | `<mod_name> <gram_name> <gram_path> [<addr>]` or control keywords: `grammar`, `nogrammar`, `pause`, `resume`, `stop`, `param` |
+| `detect_speech` | Start ASR speech detection on the channel using a grammar and ASR engine, or send a control keyword to an already-running detector. | `<mod_name> <gram_name> <gram_path> [<addr>]` to start, or one of the control keywords: `grammar <name> [<path>]`, `nogrammar <name>`, `grammaron <name>`, `grammaroff <name>`, `grammarsalloff`, `pause`, `resume`, `start-input-timers`, `init <name> <path>`, `stop`, `param <name> <value>` |
 | `play_and_detect_speech` | Play a prompt while simultaneously running ASR speech detection. | `<file> detect:<engine> {<params>}<grammar>` |
 | `echo` | Echo audio back to the caller; used for latency testing. | None |
 | `delay_echo` | Echo audio back to the caller with a configurable delay in milliseconds. | `<delay_ms>` |
@@ -109,6 +114,9 @@ These applications play, record, and generate audio on the channel. They require
 | `detect_silence` | Block until audio energy drops below a threshold for a number of consecutive frames. | `<threshold> <silence_hits> <timeout_ms> [<file>]` |
 | `preprocess` | Apply a DSP pre-processing filter to the channel's read audio. | `<filter_string>` |
 | `sound_test` | Run an audio analysis pass on the channel and log the results. | None |
+| `clear_speech_cache` | Clear the cached TTS/ASR speech handles on the channel, forcing the next `speak` or `detect_speech` to re-initialize its engine. | None |
+| `capture_text` | Capture inbound text (T.140/MSRP real-time text) on the channel into the channel's text buffer. Pass a truthy value to enable capture. | `[true\|false]` |
+| `vad_test` | Run the Voice Activity Detector against the channel's read audio and log talk/silence transitions, for tuning VAD parameters. The mode selects sensitivity. The `vad_debug`, `vad_silence_ms`, and related channel variables tune behavior. | `[<mode>]` -- `-1` (default), `0`, `1`, `2`, or `3` |
 
 ---
 
@@ -285,6 +293,10 @@ The second argument selects which leg detects the keypress (`a`, `b`, or `ab`). 
 | `filter_codecs` | Remove codecs from the current SDP that do not match a filter pattern. | See source for full syntax. |
 | `jitterbuffer` | Enable or configure the RTP jitter buffer on the session. | `<msec>[:max_msec[:max_drift]]` or `off` |
 | `novideo` | Refuse or strip inbound video from the session. | None |
+| `video_refresh` | Request a video keyframe refresh from the remote party, or switch the refresh mode. With no argument it sends an immediate refresh request; `manual` suppresses automatic refreshes, `auto` restores them. | `[manual\|auto]` |
+| `video_decode` | Enable or disable full decoding of the inbound video stream (needed for media bugs such as overlays). `on` enables decoding, `wait` enables decoding and blocks until input video parameters are known, `off` disables it. | `[[on\|wait]\|off]` |
+| `video_write_overlay` | Overlay a static image (e.g., a PNG with alpha) onto the channel's outbound video stream. Requires the video stream to be decoded. | `<path> [<pos>] [<alpha>]` -- `<pos>` is an image position keyword (e.g., `left-bot`); `<alpha>` is `1`-`255` |
+| `stop_video_write_overlay` | Remove a video overlay previously applied with `video_write_overlay`. | `<path>` |
 | `set_audio_level` | Adjust the read or write audio level on the channel. | `[read\|write] <level>` |
 | `set_mute` | Mute or unmute the read or write leg of the channel. | `[read\|write] [true\|false\|toggle]` |
 | `remove_bugs` | Remove all or a named set of media bugs from the channel. | `[<function>]` |

--- a/docs/dialplan/dptools-reference.mdx
+++ b/docs/dialplan/dptools-reference.mdx
@@ -152,6 +152,8 @@ These applications are registered by companion modules. Each module must be load
 
 ### Conferencing (`mod_conference`)
 
+The `conference` application and its configuration are covered in detail in the [Conferencing chapter](../applications/conferencing.mdx).
+
 | Application | Purpose | Arguments |
 |---|---|---|
 | `conference` | Place the channel into a named conference room. The room is created if it does not exist; it is destroyed when the last participant leaves. | `<room_name>[@<profile>][+flags{<flag1>\|<flag2>}]` |
@@ -159,17 +161,23 @@ These applications are registered by companion modules. Each module must be load
 
 ### Voicemail (`mod_voicemail`)
 
+The `voicemail` application and its configuration are covered in detail in the [Voicemail chapter](../applications/voicemail.mdx).
+
 | Application | Purpose | Arguments |
 |---|---|---|
 | `voicemail` | Deliver a call to a voicemail box, or enter the mailbox check menu. | `[check] [auth] <profile_name> <domain_name> [<id>] [uuid]` |
 
 ### FIFO Queuing (`mod_fifo`)
 
+The `fifo` application and its configuration are covered in detail in the [Queues: FIFO and Call Center chapter](../applications/queues-fifo-callcenter.mdx).
+
 | Application | Purpose | Arguments |
 |---|---|---|
 | `fifo` | Place an inbound call into a named FIFO queue (`in`) or connect an agent to the next waiting caller (`out`). | `<fifo_name>[!<importance>] [in [<announce>\|undef] [<music>\|undef] [early\|noans] \| out [wait\|nowait] [<announce>\|undef] [<music>\|undef]]` |
 
 ### Valet Parking (`mod_valet_parking`)
+
+The `valet_park` application and its configuration are covered in detail in the [Utility Applications chapter](../applications/utility-applications.mdx).
 
 | Application | Purpose | Arguments |
 |---|---|---|

--- a/docs/dialplan/dptools-reference.mdx
+++ b/docs/dialplan/dptools-reference.mdx
@@ -13,18 +13,18 @@ This chapter is a reference for the dialplan applications you invoke with `<acti
 
 ## Table of Contents
 
-1. [Call Control](#1-call-control)
-2. [Audio and Prompts](#2-audio-and-prompts)
-3. [DTMF and Signaling](#3-dtmf-and-signaling)
-4. [Feature Applications](#4-feature-applications)
-5. [Variables, Logging, and Meta-binding](#5-variables-logging-and-meta-binding)
-6. [Examples](#6-examples)
-7. [Dial Strings and Call Origination](#7-dial-strings-and-call-origination)
-8. [Call Transfers and Feature Codes](#8-call-transfers-and-feature-codes)
+1. [Call Control](#call-control)
+2. [Audio and Prompts](#audio-and-prompts)
+3. [DTMF and Signaling](#dtmf-and-signaling)
+4. [Feature Applications](#feature-applications)
+5. [Variables, Logging, and Meta-binding](#variables-logging-and-meta-binding)
+6. [Examples](#examples)
+7. [Dial Strings and Call Origination](#dial-strings-and-call-origination)
+8. [Call Transfers and Feature Codes](#call-transfers-and-feature-codes)
 
 ---
 
-## 1. Call Control
+## Call Control {#call-control}
 
 These applications establish, route, and tear down call legs. They operate directly on the signaling and media state of the channel.
 
@@ -78,7 +78,7 @@ These schedule deferred actions on the channel.
 
 ---
 
-## 2. Audio and Prompts
+## Audio and Prompts {#audio-and-prompts}
 
 These applications play, record, and generate audio on the channel. They require an answered (or at minimum early-media) channel unless stated otherwise.
 
@@ -120,7 +120,7 @@ These applications play, record, and generate audio on the channel. They require
 
 ---
 
-## 3. DTMF and Signaling
+## DTMF and Signaling {#dtmf-and-signaling}
 
 These applications control how DTMF is detected, generated, and transmitted. Inband detection (`start_dtmf`) is required when the endpoint does not send RFC 2833 telephone-event packets.
 
@@ -146,7 +146,7 @@ These applications control how DTMF is detected, generated, and transmitted. Inb
 
 ---
 
-## 4. Feature Applications
+## Feature Applications {#feature-applications}
 
 These applications are registered by companion modules. Each module must be loaded in `modules.conf.xml` for the application to be available.
 
@@ -245,7 +245,7 @@ The `valet_park` application and its configuration are covered in detail in the 
 
 ---
 
-## 5. Variables, Logging, and Meta-binding
+## Variables, Logging, and Meta-binding {#variables-logging-and-meta-binding}
 
 These applications read and write channel variables, write to the log, and bind DTMF keys to mid-call actions.
 
@@ -319,7 +319,7 @@ The second argument selects which leg detects the keypress (`a`, `b`, or `ab`). 
 
 ---
 
-## 6. Examples
+## Examples {#examples}
 
 The following examples are drawn from the vanilla FreeSWITCH dialplan (`default.xml` and `features.xml`).
 
@@ -446,11 +446,11 @@ The following examples are drawn from the vanilla FreeSWITCH dialplan (`default.
 
 ---
 
-## 7. Dial Strings and Call Origination
+## Dial Strings and Call Origination {#dial-strings-and-call-origination}
 
 A dial string is the argument passed to `bridge`, `originate`, and gateway destination fields. It describes one or more outbound legs to create, using endpoint prefixes, optional per-leg or global channel variables, and multi-leg separators. The parsing logic resides in `switch_ivr_originate.c`.
 
-### 7.1 Endpoint Prefixes
+### Endpoint Prefixes {#endpoint-prefixes}
 
 Every leg in a dial string begins with an endpoint prefix that selects the channel driver. The prefix is separated from the address by a forward slash.
 
@@ -464,7 +464,7 @@ Every leg in a dial string begins with an endpoint prefix that selects the chann
 | `error/<cause>` | Immediately return the named Q.850 hangup cause without placing any call. Useful as a fallback leg. | `error/USER_BUSY` |
 | `pickup/<key>` | Register the originating call into a named pickup group and wait. Any party that runs the `pickup` app with the same key will intercept the call. | `pickup/sales` |
 
-### 7.2 Multi-leg Separators
+### Multi-leg Separators {#multi-leg-separators}
 
 A single dial string argument may describe multiple legs. Two separators control how those legs are dialed.
 
@@ -476,7 +476,7 @@ A single dial string argument may describe multiple legs. Two separators control
 
 **Precedence.** The string is first tested for `:_:`. If found, the enterprise originate path handles it. Otherwise the string is split by the pipe character into sequential groups, and each group is split by commas into simultaneous legs.
 
-### 7.3 Channel Variable Syntax
+### Channel Variable Syntax {#channel-variable-syntax}
 
 Variables can be injected into a dial string at two scopes.
 
@@ -500,7 +500,7 @@ Multiple `[...]` blocks may precede a single leg address; they are merged left t
 {call_timeout=30}[leg_timeout=10]sofia/internal/1001@pbx,[leg_timeout=20]sofia/internal/1002@pbx
 ```
 
-### 7.4 Worked `bridge` Examples
+### Worked `bridge` Examples {#worked-bridge-examples}
 
 #### Failover: gateway first, then voicemail
 
@@ -538,9 +538,9 @@ Ring 1001 and 1002 simultaneously. If both fail, try the gateway. The pipe chara
 
 ---
 
-## 8. Call Transfers and Feature Codes
+## Call Transfers and Feature Codes {#call-transfers-and-feature-codes}
 
-### 8.1 Blind Transfer: the `transfer` Application
+### Blind Transfer: the `transfer` Application {#blind-transfer-the-transfer-application}
 
 `transfer` immediately redirects the current channel to a new dialplan extension without consulting the destination first. The caller is transferred and the current dialplan execution ends.
 
@@ -555,7 +555,7 @@ Optional flags modify which leg is transferred:
 
 These flags are verified in `transfer_function` in `mod_dptools.c`.
 
-### 8.2 Attended Transfer: `att_xfer`
+### Attended Transfer: `att_xfer` {#attended-transfer-att_xfer}
 
 `att_xfer` initiates an attended transfer. It puts the current B-leg on soft hold, dials the transfer target, bridges the operator to the target for consultation, and then completes the transfer when the operator hangs up.
 
@@ -589,7 +589,7 @@ Set these on the channel before calling `att_xfer`, or set them on the transfer 
 </extension>
 ```
 
-### 8.3 Three-way Calling: `three_way`
+### Three-way Calling: `three_way` {#three-way-calling-three_way}
 
 `three_way` bridges a third party UUID into the current call, creating a three-way audio mix using the existing bridged legs plus the channel identified by UUID. All three parties hear each other.
 
@@ -599,7 +599,7 @@ Set these on the channel before calling `att_xfer`, or set them on the transfer 
 
 The UUID must be an active session. The application is registered in `mod_dptools.c`.
 
-### 8.4 Call Pickup
+### Call Pickup {#call-pickup}
 
 **Pickup groups** allow a ringing call to be answered by any party in a group. The mechanism uses two sides:
 
@@ -624,7 +624,7 @@ The UUID must be an active session. The application is registered in `mod_dptool
 
 The `-bleg` flag intercepts the B-leg of the identified session rather than the A-leg. The `intercept:` prefix is also used internally by `mod_sofia` when handling SIP REFER with `Replaces` headers, routing calls as `answer,intercept:<uuid>`.
 
-### 8.5 In-call Feature Codes via `bind_meta_app`
+### In-call Feature Codes via `bind_meta_app` {#in-call-feature-codes-via-bind_meta_app}
 
 `bind_meta_app` binds a single DTMF digit (pressed as `*<digit>` during a bridge) to a dialplan application without interrupting the media stream. Bindings are set before the `bridge` call and remain active for the duration of the bridge.
 
@@ -648,7 +648,7 @@ bind_meta_app <key> [a|b|ab] [a|b|o|s|i|1] <app>[::args]
 
 All four use `b s` (B-leg detects, same-leg executes).
 
-### 8.6 Worked Example: Bridged Call with Feature Codes
+### Worked Example: Bridged Call with Feature Codes {#worked-example-bridged-call-with-feature-codes}
 
 The following extension replicates the vanilla `Local_Extension` pattern. It binds four in-call feature codes, then bridges to the dialed user. On failure it falls through to voicemail.
 

--- a/docs/dialplan/index.mdx
+++ b/docs/dialplan/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Part 4: Call Routing and the Dialplan"
 slug: /dialplan
-description: Route calls with the XML dialplan, contexts, and dptools.
+description: "Route calls with the XML dialplan, contexts, and dptools."
 ---
 
 import DocCardList from '@theme/DocCardList';

--- a/docs/dialplan/time-and-condition-routing.mdx
+++ b/docs/dialplan/time-and-condition-routing.mdx
@@ -13,19 +13,19 @@ The FreeSWITCH XML dialplan evaluates `<condition>` elements against the current
 
 ## Table of Contents
 
-- [15.1 How Time Conditions Work](#151-how-time-conditions-work)
-- [15.2 Time Attribute Reference](#152-time-attribute-reference)
-- [15.3 Ranges and Lists in Time Attributes](#153-ranges-and-lists-in-time-attributes)
-- [15.4 Timezone Selection](#154-timezone-selection)
-- [15.5 Business-Hours Example (tod_example)](#155-business-hours-example-tod_example)
-- [15.6 Holiday Schedule Example](#156-holiday-schedule-example)
-- [15.7 Nested Conditions](#157-nested-conditions)
-- [15.8 Combining Time Conditions with Field Conditions](#158-combining-time-conditions-with-field-conditions)
-- [15.9 Restricting Calls with toll_allow](#159-restricting-calls-with-toll_allow)
+- [How Time Conditions Work](#how-time-conditions-work)
+- [Time Attribute Reference](#time-attribute-reference)
+- [Ranges and Lists in Time Attributes](#ranges-and-lists-in-time-attributes)
+- [Timezone Selection](#timezone-selection)
+- [Business-Hours Example (tod_example)](#business-hours-example-tod_example)
+- [Holiday Schedule Example](#holiday-schedule-example)
+- [Nested Conditions](#nested-conditions)
+- [Combining Time Conditions with Field Conditions](#combining-time-conditions-with-field-conditions)
+- [Restricting Calls with toll_allow](#restricting-calls-with-toll_allow)
 
 ---
 
-## 15.1 How Time Conditions Work
+## How Time Conditions Work {#how-time-conditions-work}
 
 A `<condition>` element becomes a time condition when it carries one or more time attributes (`year`, `mon`, `mday`, `wday`, etc.). The dialplan evaluator checks these attributes against the server clock at the moment the call enters the extension. All time attributes on a single `<condition>` must match simultaneously; the relationship between attributes is logical AND.
 
@@ -35,7 +35,7 @@ A `<condition>` that has no time attributes and no `field` attribute is an absol
 
 ---
 
-## 15.2 Time Attribute Reference
+## Time Attribute Reference {#time-attribute-reference}
 
 All attributes listed below are parsed by `switch_xml_std_datetime_check` in `src/switch_xml.c`. Any subset may appear on a single `<condition>`; unused attributes are not evaluated.
 
@@ -66,7 +66,7 @@ All attributes listed below are parsed by `switch_xml_std_datetime_check` in `sr
 
 ---
 
-## 15.3 Ranges and Lists in Time Attributes
+## Ranges and Lists in Time Attributes {#ranges-and-lists-in-time-attributes}
 
 Most numeric time attributes (`year`, `yday`, `mon`, `mday`, `week`, `mweek`, `hour`, `minute`, `minute-of-day`) accept values parsed by `switch_number_cmp`. Note that `switch_number_cmp` operates strictly on integers; decimal values are not supported.
 
@@ -89,7 +89,7 @@ The `date-time` attribute is parsed by `switch_fulldate_cmp` and accepts comma-s
 
 ---
 
-## 15.4 Timezone Selection
+## Timezone Selection {#timezone-selection}
 
 By default the server's local timezone governs time condition evaluation. Two channel variables override this on a per-call basis:
 
@@ -108,7 +108,7 @@ The `tz-offset` attribute on a `<condition>` element is separate: it requires th
 
 ---
 
-## 15.5 Business-Hours Example (tod_example)
+## Business-Hours Example (tod_example) {#business-hours-example-tod_example}
 
 The vanilla configuration ships an extension named `tod_example` that demonstrates the most common time condition pattern: set a channel variable to signal whether the office is open, then read that variable in downstream extensions.
 
@@ -138,7 +138,7 @@ Using `minute-of-day` is an alternative that eliminates ambiguity about which mi
 
 ---
 
-## 15.6 Holiday Schedule Example
+## Holiday Schedule Example {#holiday-schedule-example}
 
 The vanilla configuration ships a `holiday_example` extension that covers US federal holidays. Each holiday is a separate `<condition>` within the same extension. Because the extension carries `continue="true"`, every condition is evaluated, and the last one to match wins.
 
@@ -193,7 +193,7 @@ Place the `holiday_example` extension before `tod_example` in the dialplan so ho
 
 ---
 
-## 15.7 Nested Conditions
+## Nested Conditions {#nested-conditions}
 
 A `<condition>` element may contain child `<condition>` elements. The dialplan evaluator processes nested conditions only when the parent condition matches. This allows a multi-level gate: the outer condition qualifies the call broadly, and inner conditions apply finer routing decisions without repeating the outer attributes.
 
@@ -216,7 +216,7 @@ The `require-nested` attribute on an extension controls whether a failed nested 
 
 ---
 
-## 15.8 Combining Time Conditions with Field Conditions
+## Combining Time Conditions with Field Conditions {#combining-time-conditions-with-field-conditions}
 
 A `<condition>` element that carries both time attributes and a `field` attribute evaluates both. The time check runs first; if the time does not match, the field regex is not evaluated and the condition is treated as failed regardless of the field value.
 
@@ -245,7 +245,7 @@ The `break="never"` on the first condition prevents dialplan processing from sto
 
 ---
 
-## 15.9 Restricting Calls with toll_allow
+## Restricting Calls with toll_allow {#restricting-calls-with-toll_allow}
 
 The `toll_allow` user directory variable controls which classes of outbound dialing an authenticated user may place. It is not a time attribute, but it is commonly combined with time conditions and `<condition field>` checks to enforce per-user calling restrictions.
 

--- a/docs/dialplan/time-and-condition-routing.mdx
+++ b/docs/dialplan/time-and-condition-routing.mdx
@@ -29,7 +29,7 @@ The FreeSWITCH XML dialplan evaluates `<condition>` elements against the current
 
 A `<condition>` element becomes a time condition when it carries one or more time attributes (`year`, `mon`, `mday`, `wday`, etc.). The dialplan evaluator checks these attributes against the server clock at the moment the call enters the extension. All time attributes on a single `<condition>` must match simultaneously; the relationship between attributes is logical AND.
 
-When the time condition matches, the `<action>` children execute. When it does not match, the `<anti-action>` children execute (if present). The `break` attribute on the condition governs whether dialplan processing continues to the next condition after a match or non-match; see the XML Dialplan chapter for full `break` semantics.
+When the time condition matches, the `<action>` children execute. When it does not match, the `<anti-action>` children execute (if present). The `break` attribute on the condition governs whether dialplan processing continues to the next condition after a match or non-match; see the [XML Dialplan chapter](./xml-dialplan.mdx) for full `break` semantics.
 
 A `<condition>` that has no time attributes and no `field` attribute is an absolute condition that always matches.
 

--- a/docs/foundations/index.mdx
+++ b/docs/foundations/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Part 1: Foundations"
 slug: /foundations
-description: Core concepts and how to get a FreeSWITCH instance running.
+description: "Core concepts and how to get a FreeSWITCH instance running."
 ---
 
 import DocCardList from '@theme/DocCardList';

--- a/docs/integration/access-control-lists.mdx
+++ b/docs/integration/access-control-lists.mdx
@@ -13,19 +13,19 @@ An Access Control List (ACL) in FreeSWITCH is a named network list that evaluate
 
 ## Table of Contents
 
-- [29.1 Configuration File](#291-configuration-file)
-- [29.2 List Structure](#292-list-structure)
-- [29.3 Node Attributes](#293-node-attributes)
-- [29.4 Evaluation Order and Default Behavior](#294-evaluation-order-and-default-behavior)
-- [29.5 Automatic Built-in Lists](#295-automatic-built-in-lists)
-- [29.6 The domains List](#296-the-domains-list)
-- [29.7 Applying ACLs in a Sofia SIP Profile](#297-applying-acls-in-a-sofia-sip-profile)
-- [29.8 Applying ACLs in the Event Socket](#298-applying-acls-in-the-event-socket)
-- [29.9 Reloading ACLs](#299-reloading-acls)
+- [Configuration File](#configuration-file)
+- [List Structure](#list-structure)
+- [Node Attributes](#node-attributes)
+- [Evaluation Order and Default Behavior](#evaluation-order-and-default-behavior)
+- [Automatic Built-in Lists](#automatic-built-in-lists)
+- [The domains List](#the-domains-list)
+- [Applying ACLs in a Sofia SIP Profile](#applying-acls-in-a-sofia-sip-profile)
+- [Applying ACLs in the Event Socket](#applying-acls-in-the-event-socket)
+- [Reloading ACLs](#reloading-acls)
 
 ---
 
-## 29.1 Configuration File
+## Configuration File {#configuration-file}
 
 ACLs are defined in `conf/autoload_configs/acl.conf.xml`. The file is read by the FreeSWITCH core on startup and on an explicit reload. Its root element is `<configuration name="acl.conf">`, which contains a single `<network-lists>` parent holding one or more `<list>` elements.
 
@@ -48,11 +48,11 @@ ACLs are defined in `conf/autoload_configs/acl.conf.xml`. The file is read by th
 
 ---
 
-## 29.2 List Structure
+## List Structure {#list-structure}
 
 Each `<list>` element defines one named ACL. The attributes are:
 
-| Attribute | Purpose | Values | Default |
+| Attribute | Purpose | Accepted Values | Default |
 |-----------|---------|--------|---------|
 | `name` | Unique identifier for the list; referenced by name wherever an ACL is applied. | Any string | Required; no default |
 | `default` | Decision returned when no node matches the candidate IP. | `allow`, `deny` | `allow` |
@@ -61,7 +61,7 @@ A list may contain zero or more `<node>` child elements. When a list contains no
 
 ---
 
-## 29.3 Node Attributes
+## Node Attributes {#node-attributes}
 
 Each `<node>` element specifies one rule. The `type` attribute controls the decision the node produces when it matches. The match criterion is provided by `cidr`, by `host` and `mask` together, or by `domain`. Exactly one of these forms must be used per node.
 
@@ -69,7 +69,7 @@ Port-based filtering attributes (`port`, `ports`, `port-min`, `port-max`) are op
 
 ### Match attributes
 
-| Attribute | Purpose | Values | Notes |
+| Attribute | Purpose | Accepted Values | Notes |
 |-----------|---------|--------|-------|
 | `type` | Decision when this node matches. | `allow`, `deny` | Defaults to the list `default` when omitted. |
 | `cidr` | IPv4 or IPv6 prefix in CIDR notation. Matches any address within the prefix. | e.g. `192.168.0.0/16`, `2001:db8::/32` | Mutually exclusive with `host`/`mask` and `domain`. |
@@ -79,7 +79,7 @@ Port-based filtering attributes (`port`, `ports`, `port-min`, `port-max`) are op
 
 ### Port filter attributes
 
-| Attribute | Purpose | Values |
+| Attribute | Purpose | Accepted Values |
 |-----------|---------|--------|
 | `port` | Match only when the source port equals this value. | Integer port number |
 | `ports` | Match only when the source port is one of the comma-separated values. | e.g. `5060,5061` |
@@ -109,7 +109,7 @@ Port filtering applies only when the calling subsystem passes a non-zero port to
 
 ---
 
-## 29.4 Evaluation Order and Default Behavior
+## Evaluation Order and Default Behavior {#evaluation-order-and-default-behavior}
 
 FreeSWITCH evaluates nodes in document order (top to bottom). When a node matches the candidate IP, that node's `type` is returned immediately and no further nodes are checked. If no node matches, the list's `default` attribute determines the outcome.
 
@@ -137,7 +137,7 @@ Now `192.168.42.42` matches the first node and is allowed; all other addresses i
 
 ---
 
-## 29.5 Automatic Built-in Lists
+## Automatic Built-in Lists {#automatic-built-in-lists}
 
 FreeSWITCH creates the following lists automatically at startup, before `acl.conf.xml` is processed. They are available for use in any configuration that accepts an ACL name. Defining a `<list>` in `acl.conf.xml` with one of these names replaces the auto-built list.
 
@@ -172,7 +172,7 @@ FreeSWITCH creates the following lists automatically at startup, before `acl.con
 
 ---
 
-## 29.6 The domains List
+## The domains List {#the-domains-list}
 
 The `domains` list included in the vanilla `acl.conf.xml` is a convention, not a built-in. It uses the `domain` node form to build its membership dynamically from the FreeSWITCH directory at load time.
 
@@ -193,7 +193,7 @@ The list is populated at ACL load time (startup or `reloadacl`). Changes to user
 
 ---
 
-## 29.7 Applying ACLs in a Sofia SIP Profile
+## Applying ACLs in a Sofia SIP Profile {#applying-acls-in-a-sofia-sip-profile}
 
 Sofia SIP profiles accept multiple ACL parameters inside the `<settings>` block. Multiple entries of the same parameter name accumulate up to a limit of 100 entries. Setting a parameter's value to `none` clears all previously accumulated entries for that parameter.
 
@@ -223,7 +223,7 @@ When `apply-inbound-acl` evaluation fails for a source IP, Sofia checks whether 
 
 ### Additional profile parameters related to ACL
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |-----------|---------|--------|---------|
 | `apply-inbound-acl-x-token` | SIP header name to read an ACL token from when the inbound ACL matches but no token is present in the list. | Header name string | None |
 | `apply-proxy-acl-x-token` | SIP header name to read an ACL token from when the source IP passes the proxy ACL. The token is accepted and the call is authorized without further IP checking. | Header name string | None |
@@ -247,7 +247,7 @@ For full Sofia profile configuration, see the [Sofia SIP Profile chapter](../use
 
 ---
 
-## 29.8 Applying ACLs in the Event Socket
+## Applying ACLs in the Event Socket {#applying-acls-in-the-event-socket}
 
 The Event Socket module (`mod_event_socket`) reads its configuration from `conf/autoload_configs/event_socket.conf.xml`. The `apply-inbound-acl` parameter restricts which IP addresses may connect to the socket.
 
@@ -268,7 +268,7 @@ When no `apply-inbound-acl` parameter is configured, the module defaults to `loo
 
 ---
 
-## 29.9 Reloading ACLs
+## Reloading ACLs {#reloading-acls}
 
 ACLs can be reloaded without restarting FreeSWITCH by issuing the following API command from `fs_cli` or the Event Socket:
 

--- a/docs/integration/access-control-lists.mdx
+++ b/docs/integration/access-control-lists.mdx
@@ -243,7 +243,7 @@ When `apply-inbound-acl` evaluation fails for a source IP, Sofia checks whether 
 </profile>
 ```
 
-For full Sofia profile configuration, see the Sofia SIP Profile chapter.
+For full Sofia profile configuration, see the [Sofia SIP Profile chapter](../users-endpoints/sip-profiles-sofia.mdx).
 
 ---
 
@@ -264,7 +264,7 @@ The Event Socket module (`mod_event_socket`) reads its configuration from `conf/
 
 When one or more `apply-inbound-acl` entries are present, each connecting IP is checked against every named list in order. If the IP fails any list, the connection is rejected immediately with a `text/rude-rejection` response and closed; remaining lists are not checked.
 
-When no `apply-inbound-acl` parameter is configured, the module defaults to `loopback.auto`, restricting connections to the loopback interface. Multiple `apply-inbound-acl` parameters accumulate. For full Event Socket configuration, see the Event Socket chapter.
+When no `apply-inbound-acl` parameter is configured, the module defaults to `loopback.auto`, restricting connections to the loopback interface. Multiple `apply-inbound-acl` parameters accumulate. For full Event Socket configuration, see the [Event Socket chapter](./event-socket.mdx).
 
 ---
 

--- a/docs/integration/call-detail-records.mdx
+++ b/docs/integration/call-detail-records.mdx
@@ -13,28 +13,28 @@ FreeSWITCH generates one Call Detail Record (CDR) per call leg at hangup. This c
 
 ## Table of Contents
 
-- [1. How CDRs Are Produced](#1-how-cdrs-are-produced)
-- [2. mod_cdr_csv](#2-mod_cdr_csv)
-  - [2.1 Configuration Parameters](#21-configuration-parameters)
-  - [2.2 Templates](#22-templates)
-  - [2.3 The Built-in Default Template](#23-the-built-in-default-template)
-  - [2.4 File Output](#24-file-output)
-  - [2.5 Log Rotation](#25-log-rotation)
-  - [2.6 Custom CSV Template Example](#26-custom-csv-template-example)
-- [3. mod_xml_cdr](#3-mod_xml_cdr)
-  - [3.1 Configuration Parameters](#31-configuration-parameters)
-  - [3.2 TLS and Authentication Parameters](#32-tls-and-authentication-parameters)
-  - [3.3 Example URL Binding](#33-example-url-binding)
-- [4. mod_cdr_sqlite](#4-mod_cdr_sqlite)
-  - [4.1 Configuration Parameters](#41-configuration-parameters)
-  - [4.2 Default Table Schema](#42-default-table-schema)
-  - [4.3 Templates](#43-templates)
-- [5. Module Load Status](#5-module-load-status)
+- [How CDRs Are Produced](#how-cdrs-are-produced)
+- [mod_cdr_csv](#mod_cdr_csv)
+  - [Configuration Parameters](#configuration-parameters)
+  - [Templates](#templates)
+  - [The Built-in Default Template](#the-built-in-default-template)
+  - [File Output](#file-output)
+  - [Log Rotation](#log-rotation)
+  - [Custom CSV Template Example](#custom-csv-template-example)
+- [mod_xml_cdr](#mod_xml_cdr)
+  - [Configuration Parameters](#configuration-parameters)
+  - [TLS and Authentication Parameters](#tls-and-authentication-parameters)
+  - [Example URL Binding](#example-url-binding)
+- [mod_cdr_sqlite](#mod_cdr_sqlite)
+  - [Configuration Parameters](#configuration-parameters)
+  - [Default Table Schema](#default-table-schema)
+  - [Templates](#templates)
+- [Module Load Status](#module-load-status)
 - [Other CDR Backends](#other-cdr-backends)
 
 ---
 
-## 1. How CDRs Are Produced
+## How CDRs Are Produced {#how-cdrs-are-produced}
 
 CDR generation is triggered by the `on_reporting` state-handler callback that each CDR module registers. The callback fires once per call leg at the moment the channel transitions to the reporting state, which occurs immediately after hangup processing completes.
 
@@ -44,15 +44,15 @@ Channel variables are expanded at record time. Any channel variable accessible o
 
 ---
 
-## 2. mod_cdr_csv
+## mod_cdr_csv {#mod_cdr_csv}
 
 `mod_cdr_csv` appends one line per call leg to flat CSV files. It is loaded by default in the vanilla configuration.
 
 Configuration file: `conf/autoload_configs/cdr_csv.conf.xml`
 
-### 2.1 Configuration Parameters
+### Configuration Parameters {#configuration-parameters}
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `log-base` | Parent directory for CDR output. The string `cdr-csv` is always appended to form the actual directory path. | Absolute path | FreeSWITCH log directory |
 | `default-template` | Name of the template to use for all records that do not match an account-code-specific template. | Any named template | `default` |
@@ -61,7 +61,7 @@ Configuration file: `conf/autoload_configs/cdr_csv.conf.xml`
 | `master-file-only` | When `true`, suppress per-account-code CSV files; write only to `Master.csv`. | `true`, `false` | `false` |
 | `debug` | Log the full channel variable set to the FreeSWITCH log at INFO level for each CDR event. | `true`, `false` | `false` |
 
-### 2.2 Templates
+### Templates {#templates}
 
 A template is a string in which channel variables are referenced as `${variable_name}`. At call teardown the module expands all variables against the live channel and appends the resulting line to the output file.
 
@@ -88,7 +88,7 @@ The vanilla configuration ships these named templates:
 | `asterisk` | Field-compatible with Asterisk CDR output |
 | `opencdrrate` | OpenCDRate billing system format |
 
-### 2.3 The Built-in Default Template
+### The Built-in Default Template {#the-built-in-default-template}
 
 At module startup, the module pre-registers one template into the template hash under the key `default`:
 
@@ -108,7 +108,7 @@ This 18-field Asterisk-compatible template is used only when the named template 
 
 The vanilla configuration sets `default-template` to `example`, so by default the `example` template from `cdr_csv.conf.xml` is active, not either compiled-in fallback.
 
-### 2.4 File Output
+### File Output {#file-output}
 
 The module writes two categories of files into the `log-base`/`cdr-csv` directory:
 
@@ -117,13 +117,13 @@ The module writes two categories of files into the `log-base`/`cdr-csv` director
 
 The channel variable `cdr_csv_base` overrides the global `log-base` on a per-channel basis. When `cdr_csv_base` is set on a session, all CDR files for that call are written to the specified directory instead of the global `log-base`/`cdr-csv` path.
 
-### 2.5 Log Rotation
+### Log Rotation {#log-rotation}
 
 When `rotate-on-hup` is `true`, sending SIGHUP to the FreeSWITCH process renames each open file by appending a timestamp suffix in the format `YYYY-MM-DD-HH-MM-SS`, then reopens a fresh file at the original path. The API command `cdr_csv rotate` triggers the same rotation without a signal.
 
 When `rotate-on-hup` is `false`, a SIGHUP causes the files to be closed and reopened in place (useful when an external log management tool has already moved them).
 
-### 2.6 Custom CSV Template Example
+### Custom CSV Template Example {#custom-csv-template-example}
 
 ```xml
 <configuration name="cdr_csv.conf" description="CDR CSV Format">
@@ -143,7 +143,7 @@ With this configuration, `mod_cdr_csv` writes to `/var/log/freeswitch/cdr-csv/Ma
 
 ---
 
-## 3. mod_xml_cdr
+## mod_xml_cdr {#mod_xml_cdr}
 
 `mod_xml_cdr` generates a structured XML document for each call leg and delivers it via HTTP POST to one or more configured URLs. When no URL is configured, or as a fallback on POST failure, it writes the XML to disk. `mod_xml_cdr` is not loaded by default; enable it in `conf/autoload_configs/modules.conf.xml`.
 
@@ -151,9 +151,9 @@ Configuration file: `conf/autoload_configs/xml_cdr.conf.xml`
 
 The module is located under `src/mod/xml_int/mod_xml_cdr` (not `event_handlers`).
 
-### 3.1 Configuration Parameters
+### Configuration Parameters {#configuration-parameters}
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `url` | HTTP or HTTPS endpoint to POST records to. Up to 20 URLs may be specified; the module cycles through them on failure. Omitting this parameter disables HTTP delivery. | URL string | None |
 | `cred` | HTTP credentials in `user:password` form. | String | None |
@@ -171,9 +171,9 @@ The module is located under `src/mod/xml_int/mod_xml_cdr` (not `event_handlers`)
 | `auth-scheme` | HTTP authentication scheme for credential delivery. | `basic`, `digest`, `NTLM`, `GSS-NEGOTIATE`, `any` | `basic` |
 | `cookie-file` | Path to a file used for cookie persistence across requests. | Absolute path | None |
 
-### 3.2 TLS and Authentication Parameters
+### TLS and Authentication Parameters {#tls-and-authentication-parameters}
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `enable-cacert-check` | Instruct libcurl to verify the server certificate against the system CA bundle. Disabled by default. | `true`, `false` | `false` |
 | `enable-ssl-verifyhost` | Verify that the server hostname matches the certificate CN. | `true`, `false` | `false` |
@@ -183,7 +183,7 @@ The module is located under `src/mod/xml_int/mod_xml_cdr` (not `event_handlers`)
 | `ssl-version` | Force a specific SSL/TLS version. | `SSLv3`, `TLSv1` | libcurl auto-negotiates |
 | `ssl-cacert-file` | Path to a custom PEM CA certificate for peer verification. Meaningful only when `enable-cacert-check` is `true`. | Absolute path | None |
 
-### 3.3 Example URL Binding
+### Example URL Binding {#example-url-binding}
 
 ```xml
 <configuration name="xml_cdr.conf" description="XML CDR CURL logger">
@@ -213,15 +213,15 @@ The channel variable `xml_cdr_base` on the session overrides the global `log-dir
 
 ---
 
-## 4. mod_cdr_sqlite
+## mod_cdr_sqlite {#mod_cdr_sqlite}
 
 `mod_cdr_sqlite` inserts one row per call leg into a SQLite database table. The database file is created automatically if it does not exist; the table is created automatically if it does not exist, using the default schema. `mod_cdr_sqlite` is not loaded by default; enable it in `conf/autoload_configs/modules.conf.xml`.
 
 Configuration file: `conf/autoload_configs/cdr_sqlite.conf.xml`
 
-### 4.1 Configuration Parameters
+### Configuration Parameters {#configuration-parameters}
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `db-name` | Base name of the SQLite database file. The `.db` suffix is appended automatically by the FreeSWITCH DSN layer. | String | `cdr` |
 | `db-table` | Name of the table within the database that receives CDR rows. | String | `cdr` |
@@ -229,7 +229,7 @@ Configuration file: `conf/autoload_configs/cdr_sqlite.conf.xml`
 | `default-template` | Name of the template used to generate the VALUES clause of each INSERT statement. | Any named template | `default` |
 | `debug` | Log the full channel variable set to the FreeSWITCH log at INFO level for each CDR event. | `true`, `false` | `false` |
 
-### 4.2 Default Table Schema
+### Default Table Schema {#default-table-schema}
 
 When the configured table does not exist at startup, the module creates it with the following schema:
 
@@ -255,7 +255,7 @@ The table name substituted for `cdr` is the value of `db-table`. The module exec
 
 Note that the auto-created schema names the last column `account_code` (with an underscore), while the channel variable referenced in the built-in default template is `${accountcode}` (no underscore). These refer to the same call data; the discrepancy is in the column name vs the channel variable name.
 
-### 4.3 Templates
+### Templates {#templates}
 
 Templates for `mod_cdr_sqlite` follow the same `${variable_name}` expansion syntax as `mod_cdr_csv`, but the output is used as the VALUES clause of an SQL INSERT, not as a CSV line. Numeric fields (`duration`, `billsec`) must not be quoted in the template; string fields must be quoted.
 
@@ -285,7 +285,7 @@ Custom templates are defined in the `<templates>` block and referenced by name w
 
 ---
 
-## 5. Module Load Status
+## Module Load Status {#module-load-status}
 
 | Module | Loaded by default (vanilla conf) |
 |---|---|

--- a/docs/integration/call-detail-records.mdx
+++ b/docs/integration/call-detail-records.mdx
@@ -9,7 +9,7 @@ sidebar_label: "27. Call Detail Records"
 
 # Chapter 27: Call Detail Records
 
-FreeSWITCH generates one Call Detail Record (CDR) per call leg at hangup. Three modules are available to capture and deliver those records: `mod_cdr_csv` writes delimited text files, `mod_xml_cdr` HTTP-POSTs an XML document to a remote endpoint, and `mod_cdr_sqlite` inserts rows into a local SQLite database. Each module is configured independently and can be loaded alongside the others.
+FreeSWITCH generates one Call Detail Record (CDR) per call leg at hangup. This chapter covers the three CDR modules most commonly deployed: `mod_cdr_csv` writes delimited text files, `mod_xml_cdr` HTTP-POSTs an XML document to a remote endpoint, and `mod_cdr_sqlite` inserts rows into a local SQLite database. Each module is configured independently and can be loaded alongside the others. Several additional bundled CDR backends are documented in Part 9 (see [Other CDR Backends](#other-cdr-backends) below).
 
 ## Table of Contents
 
@@ -30,6 +30,7 @@ FreeSWITCH generates one Call Detail Record (CDR) per call leg at hangup. Three 
   - [4.2 Default Table Schema](#42-default-table-schema)
   - [4.3 Templates](#43-templates)
 - [5. Module Load Status](#5-module-load-status)
+- [Other CDR Backends](#other-cdr-backends)
 
 ---
 
@@ -293,3 +294,14 @@ Custom templates are defined in the `<templates>` block and referenced by name w
 | `mod_cdr_sqlite` | No |
 
 To enable a module that is not loaded by default, uncomment or add its `<load module="..."/>` entry in `conf/autoload_configs/modules.conf.xml` and reload or restart FreeSWITCH. Multiple CDR modules may be active simultaneously; each fires its own `on_reporting` callback independently.
+
+---
+
+## Other CDR Backends
+
+Beyond the three modules covered above, FreeSWITCH bundles additional CDR backends that target other storage and delivery mechanisms. These are documented in the Part 9 Module Reference:
+
+- [`mod_json_cdr`](/module-reference/event-handlers/mod_json_cdr) - posts each CDR as a JSON document over HTTP.
+- [`mod_format_cdr`](/module-reference/event-handlers/mod_format_cdr) - emits CDRs in a configurable format (JSON or XML) with HTTP posting options.
+- [`mod_odbc_cdr`](/module-reference/event-handlers/mod_odbc_cdr) - inserts CDR rows into a database via ODBC.
+- [`mod_cdr_pg_csv`](/module-reference/event-handlers/mod_cdr_pg_csv) - writes CDRs directly to PostgreSQL.

--- a/docs/integration/event-socket.mdx
+++ b/docs/integration/event-socket.mdx
@@ -461,7 +461,7 @@ User-Data: <string>
 
 The `apply-inbound-acl` parameter names an ACL defined in `acl.conf.xml`. When set, FreeSWITCH evaluates the connecting client's source IP against the named list before sending the authentication challenge. Connections from addresses not permitted by the ACL receive a `Content-Type: text/rude-rejection` response and the socket is closed.
 
-When `apply-inbound-acl` is absent from `event_socket.conf.xml`, the module applies `loopback.auto` by default, which permits only connections from `127.0.0.1` and `::1`. To accept connections from remote hosts, define an appropriate ACL in `acl.conf.xml`, then reference it with `apply-inbound-acl`. ACL configuration is covered in the ACL chapter of this manual.
+When `apply-inbound-acl` is absent from `event_socket.conf.xml`, the module applies `loopback.auto` by default, which permits only connections from `127.0.0.1` and `::1`. To accept connections from remote hosts, define an appropriate ACL in `acl.conf.xml`, then reference it with `apply-inbound-acl`. ACL configuration is covered in the [ACL chapter](./access-control-lists.mdx) of this manual.
 
 Multiple `apply-inbound-acl` entries can be added; up to 100 ACL names are accepted. A connection is permitted only if the source IP is permitted by every listed ACL. If the IP fails the check for any single ACL entry, the connection is rejected.
 

--- a/docs/integration/event-socket.mdx
+++ b/docs/integration/event-socket.mdx
@@ -13,27 +13,27 @@ The Event Socket is a TCP-based interface that exposes FreeSWITCH call control, 
 
 ## Table of Contents
 
-- [25.1 What the Event Socket Provides](#251-what-the-event-socket-provides)
-- [25.2 Module and Configuration File](#252-module-and-configuration-file)
-- [25.3 Parameter Reference](#253-parameter-reference)
-- [25.4 Inbound Mode](#254-inbound-mode)
-  - [25.4.1 Connection Lifecycle](#2541-connection-lifecycle)
-  - [25.4.2 Worked Session Example](#2542-worked-session-example)
-- [25.5 Outbound Mode](#255-outbound-mode)
-  - [25.5.1 Connection Handshake](#2551-connection-handshake)
-  - [25.5.2 async vs Blocking](#2552-async-vs-blocking)
-  - [25.5.3 Worked Outbound Session Example](#2553-worked-outbound-session-example)
-- [25.6 Command Reference](#256-command-reference)
-- [25.7 Event Subscription and Formats](#257-event-subscription-and-formats)
-  - [25.7.1 Selecting a Format](#2571-selecting-a-format)
-  - [25.7.2 Subscribing to Events](#2572-subscribing-to-events)
-  - [25.7.3 Event Delivery on the Wire](#2573-event-delivery-on-the-wire)
-- [25.8 Restricting Access with ACLs](#258-restricting-access-with-acls)
-- [25.9 Relationship to fs_cli](#259-relationship-to-fs_cli)
+- [What the Event Socket Provides](#what-the-event-socket-provides)
+- [Module and Configuration File](#module-and-configuration-file)
+- [Parameter Reference](#parameter-reference)
+- [Inbound Mode](#inbound-mode)
+  - [Connection Lifecycle](#connection-lifecycle)
+  - [Worked Session Example](#worked-session-example)
+- [Outbound Mode](#outbound-mode)
+  - [Connection Handshake](#connection-handshake)
+  - [async vs Blocking](#async-vs-blocking)
+  - [Worked Outbound Session Example](#worked-outbound-session-example)
+- [Command Reference](#command-reference)
+- [Event Subscription and Formats](#event-subscription-and-formats)
+  - [Selecting a Format](#selecting-a-format)
+  - [Subscribing to Events](#subscribing-to-events)
+  - [Event Delivery on the Wire](#event-delivery-on-the-wire)
+- [Restricting Access with ACLs](#restricting-access-with-acls)
+- [Relationship to fs_cli](#relationship-to-fs_cli)
 
 ---
 
-## 25.1 What the Event Socket Provides
+## What the Event Socket Provides {#what-the-event-socket-provides}
 
 The Event Socket listens on a TCP port and accepts connections from clients that speak the ESL (Event Socket Library) protocol. Once authenticated, a client can:
 
@@ -46,7 +46,7 @@ In outbound mode, the socket interface is invoked mid-call from the dialplan. Fr
 
 ---
 
-## 25.2 Module and Configuration File
+## Module and Configuration File {#module-and-configuration-file}
 
 The Event Socket is provided by `mod_event_socket`. It must be loaded at startup, typically via `modules.conf.xml`.
 
@@ -69,9 +69,9 @@ Note: The vanilla configuration sets `listen-ip` to `::` (all interfaces, dual-s
 
 ---
 
-## 25.3 Parameter Reference
+## Parameter Reference {#parameter-reference}
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `listen-ip` | IP address the socket binds to | Any valid IP address or `::` for all interfaces | `127.0.0.1` (code default when omitted) |
 | `listen-port` | TCP port the socket listens on | Any valid port number | `8021` |
@@ -89,11 +89,11 @@ Note: The vanilla configuration sets `listen-ip` to `::` (all interfaces, dual-s
 
 ---
 
-## 25.4 Inbound Mode
+## Inbound Mode {#inbound-mode}
 
 In inbound mode, `mod_event_socket` binds to `listen-ip`:`listen-port` at module load time and accepts incoming TCP connections.
 
-### 25.4.1 Connection Lifecycle
+### Connection Lifecycle {#connection-lifecycle}
 
 1. The client opens a TCP connection to `listen-ip`:`listen-port`.
 2. If `apply-inbound-acl` is configured and the source IP is not permitted, FreeSWITCH sends `Content-Type: text/rude-rejection` and closes the socket.
@@ -119,7 +119,7 @@ auth ClueCon
 
 To change the listening address or port, edit `event_socket.conf.xml` and reload or restart the module. Setting `listen-ip` to `127.0.0.1` restricts connections to the local host. Setting it to `0.0.0.0` or `::` accepts connections on all interfaces; in that case, use `apply-inbound-acl` to control which source addresses are permitted.
 
-### 25.4.2 Worked Session Example
+### Worked Session Example {#worked-session-example}
 
 The following shows the raw byte exchange for a session that authenticates, runs one API command in the foreground, one in the background, subscribes to heartbeat events, and then disconnects. Lines sent by the client are prefixed with `>`. Lines received from FreeSWITCH are prefixed with `<`. Blank lines that terminate each block are shown explicitly.
 
@@ -190,7 +190,7 @@ The following shows the raw byte exchange for a session that authenticates, runs
 
 ---
 
-## 25.5 Outbound Mode
+## Outbound Mode {#outbound-mode}
 
 In outbound mode, the dialplan routes a call to the `socket` application. FreeSWITCH initiates a TCP connection to the specified host and port, then hands control of the call leg to the remote process.
 
@@ -218,7 +218,7 @@ socket <host>[:<port>][/<path>] [full] [async]
 
 No `event_socket.conf.xml` parameters govern outbound mode. The listen address and port in that file apply only to inbound connections.
 
-### 25.5.1 Connection Handshake
+### Connection Handshake {#connection-handshake}
 
 The outbound connection handshake differs from the inbound lifecycle. FreeSWITCH is the TCP client; the remote process is the TCP server.
 
@@ -236,13 +236,13 @@ connect
 6. After receiving the connect reply, the remote process typically sends `myevents` to subscribe to events for this channel, then issues `sendmsg` commands to execute dialplan applications on the channel.
 7. When the remote process closes the TCP connection, control returns to the dialplan at the action after the `socket` application.
 
-### 25.5.2 async vs Blocking
+### async vs Blocking {#async-vs-blocking}
 
 Without `async`, the `socket` application occupies the dialplan thread for the duration of the TCP connection. The channel is fully under remote control and the dialplan does not advance.
 
 With `async`, FreeSWITCH parks the channel and spins up a separate thread for the ESL listener. The dialplan thread is released immediately after the park. When the remote process issues `resume` (or the channel variable `socket_resume` is set to `true`), FreeSWITCH transitions the channel to the execute state and continues the dialplan from the next action after the `socket` application. If the remote process closes the socket without sending `resume`, the channel remains parked until it is hungup or otherwise disposed of.
 
-### 25.5.3 Worked Outbound Session Example
+### Worked Outbound Session Example {#worked-outbound-session-example}
 
 The following shows the exchange for an outbound connection. The remote server is listening on port 8084. Lines sent by FreeSWITCH are prefixed with `<`. Lines sent by the remote process are prefixed with `>`.
 
@@ -306,7 +306,7 @@ The following shows the exchange for an outbound connection. The remote server i
 
 ---
 
-## 25.6 Command Reference
+## Command Reference {#command-reference}
 
 All commands are sent as plain text terminated by a blank line (two consecutive newlines). The parser reads until it sees `\r\n\r\n` or `\n\n`. Multi-line commands (such as `sendmsg`) include additional headers between the command line and the final blank line.
 
@@ -363,9 +363,9 @@ hangup-cause: NORMAL_CLEARING
 
 ---
 
-## 25.7 Event Subscription and Formats
+## Event Subscription and Formats {#event-subscription-and-formats}
 
-### 25.7.1 Selecting a Format
+### Selecting a Format {#selecting-a-format}
 
 The `event` command takes a format as its first argument. The format applies to all events delivered on the connection for the duration of the session (or until a new `event` command changes it).
 
@@ -375,7 +375,7 @@ The `event` command takes a format as its first argument. The format applies to 
 | `json` | The event serialized as a JSON object. |
 | `xml` | The event serialized as an XML document. |
 
-### 25.7.2 Subscribing to Events
+### Subscribing to Events {#subscribing-to-events}
 
 ```text
 event plain HEARTBEAT CHANNEL_HANGUP_COMPLETE BACKGROUND_JOB
@@ -423,7 +423,7 @@ filter Unique-ID b7f1e2a0-1234-5678-abcd-000000000001
 
 Multiple filters may be active simultaneously. For an event to be delivered, all active filters must match (logical AND). Values prefixed with `-` exclude matching events; values beginning with `/` are treated as regular expressions matched against the header value.
 
-### 25.7.3 Event Delivery on the Wire
+### Event Delivery on the Wire {#event-delivery-on-the-wire}
 
 Each event is delivered as a framed block:
 
@@ -457,7 +457,7 @@ User-Data: <string>
 
 ---
 
-## 25.8 Restricting Access with ACLs
+## Restricting Access with ACLs {#restricting-access-with-acls}
 
 The `apply-inbound-acl` parameter names an ACL defined in `acl.conf.xml`. When set, FreeSWITCH evaluates the connecting client's source IP against the named list before sending the authentication challenge. Connections from addresses not permitted by the ACL receive a `Content-Type: text/rude-rejection` response and the socket is closed.
 
@@ -469,7 +469,7 @@ For deployments where the Event Socket must be reachable from non-loopback addre
 
 ---
 
-## 25.9 Relationship to fs_cli
+## Relationship to fs_cli {#relationship-to-fs_cli}
 
 `fs_cli` is the standard FreeSWITCH interactive console. It connects to the Event Socket in inbound mode using the same ESL protocol as any other client. By default it connects to `127.0.0.1:8021` with the password `ClueCon`.
 

--- a/docs/integration/index.mdx
+++ b/docs/integration/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Part 7: Integration and Control"
 slug: /integration
-description: Control and integrate FreeSWITCH with external systems.
+description: "Control and integrate FreeSWITCH with external systems."
 ---
 
 import DocCardList from '@theme/DocCardList';

--- a/docs/integration/scripting.mdx
+++ b/docs/integration/scripting.mdx
@@ -13,23 +13,23 @@ FreeSWITCH embeds scripting language runtimes directly inside the switch process
 
 ## Table of Contents
 
-- [1. Embedded Scripting Overview](#1-embedded-scripting-overview)
-- [2. Script Directory](#2-script-directory)
-- [3. lua.conf.xml Reference](#3-luaconfxml-reference)
-  - [3.1 Parameter Table](#31-parameter-table)
-  - [3.2 Configuration Example](#32-configuration-example)
-- [4. Invoking Scripts from the Dialplan](#4-invoking-scripts-from-the-dialplan)
-- [5. Running Scripts from the Console](#5-running-scripts-from-the-console)
-- [6. Lua as an XML Handler](#6-lua-as-an-xml-handler)
-  - [6.1 Wiring the Handler](#61-wiring-the-handler)
-  - [6.2 Binding Targets](#62-binding-targets)
-- [7. Event Hooks](#7-event-hooks)
-- [8. Startup Scripts](#8-startup-scripts)
-- [9. Other Language Modules](#9-other-language-modules)
+- [Embedded Scripting Overview](#embedded-scripting-overview)
+- [Script Directory](#script-directory)
+- [lua.conf.xml Reference](#luaconfxml-reference)
+  - [Parameter Table](#parameter-table)
+  - [Configuration Example](#configuration-example)
+- [Invoking Scripts from the Dialplan](#invoking-scripts-from-the-dialplan)
+- [Running Scripts from the Console](#running-scripts-from-the-console)
+- [Lua as an XML Handler](#lua-as-an-xml-handler)
+  - [Wiring the Handler](#wiring-the-handler)
+  - [Binding Targets](#binding-targets)
+- [Event Hooks](#event-hooks)
+- [Startup Scripts](#startup-scripts)
+- [Other Language Modules](#other-language-modules)
 
 ---
 
-## 1. Embedded Scripting Overview
+## Embedded Scripting Overview {#embedded-scripting-overview}
 
 Language modules run inside the FreeSWITCH process. A script executes in a dedicated Lua state (or equivalent) with full access to the FreeSWITCH C API surface through the module's SWIG bindings. Scripts are not external processes and do not require IPC.
 
@@ -44,7 +44,7 @@ Each language module registers the same set of integration points:
 
 ---
 
-## 2. Script Directory
+## Script Directory {#script-directory}
 
 FreeSWITCH resolves relative script paths against the built-in `$${script_dir}` preprocessor variable. This variable is set at compile time and typically resolves to `/usr/local/freeswitch/scripts` on a standard installation. Its current value can be confirmed at the `fs_cli` prompt:
 
@@ -56,13 +56,13 @@ When a script name passed to the `lua` application or `luarun` API command does 
 
 ---
 
-## 3. lua.conf.xml Reference
+## lua.conf.xml Reference {#luaconfxml-reference}
 
 `lua.conf.xml` is located in `$${conf_dir}/autoload_configs/`. It is read once at module load time. A reload is triggered by `reload mod_lua` at the `fs_cli` prompt.
 
-### 3.1 Parameter Table
+### Parameter Table {#parameter-table}
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `script-directory` | Prepends a path to the Lua `LUA_PATH` environment variable so that `require` can locate `.lua` modules. Use the `?.lua` glob pattern. Multiple entries are allowed. | Path string with `?` glob, e.g. `$${script_dir}/?.lua` | None |
 | `module-directory` | Prepends a path to the Lua `LUA_CPATH` environment variable for native C extension modules (`.so` or `.dll`). Multiple entries are allowed. | Path string with `?` glob, e.g. `/usr/lib/lua/5.1/?.so` | None |
@@ -70,9 +70,9 @@ When a script name passed to the `lua` application or `luarun` API command does 
 | `xml-handler-bindings` | Registers `xml-handler-script` as the XML fetch handler for one or more configuration sections. Requires `xml-handler-script` to be set first in the same `<settings>` block. | `dialplan`, `directory`, `configuration`, `phrases`, or a space-separated combination | None |
 | `startup-script` | Launches a Lua script in a detached background thread when the module loads. Multiple entries are allowed, one script per `<param>`. | Script filename (resolved against `$${script_dir}`) | None |
 
-The `hook` element (a sibling of `<param>` inside `<settings>`) binds a Lua script to a FreeSWITCH event. See [Section 7](#7-event-hooks).
+The `hook` element (a sibling of `<param>` inside `<settings>`) binds a Lua script to a FreeSWITCH event. See [Event Hooks](#event-hooks).
 
-### 3.2 Configuration Example
+### Configuration Example {#configuration-example}
 
 ```xml
 <configuration name="lua.conf" description="LUA Configuration">
@@ -100,7 +100,7 @@ The `hook` element (a sibling of `<param>` inside `<settings>`) binds a Lua scri
 
 ---
 
-## 4. Invoking Scripts from the Dialplan
+## Invoking Scripts from the Dialplan {#invoking-scripts-from-the-dialplan}
 
 The `lua` dialplan application executes a script synchronously within a call leg. The call is held for the duration of the script. The `session` object is automatically available to the script as a global variable named `session`.
 
@@ -128,7 +128,7 @@ The `lua` application is registered with the `SAF_SUPPORT_NOMEDIA`, `SAF_ROUTING
 
 ---
 
-## 5. Running Scripts from the Console
+## Running Scripts from the Console {#running-scripts-from-the-console}
 
 Two API commands are available from `fs_cli` or the ESL API surface.
 
@@ -152,11 +152,11 @@ Neither command blocks the console for `luarun`; `lua` blocks until the script c
 
 ---
 
-## 6. Lua as an XML Handler
+## Lua as an XML Handler {#lua-as-an-xml-handler}
 
 FreeSWITCH consults registered XML handlers whenever it needs to resolve a configuration section. A Lua script can serve XML for the `dialplan`, `directory`, `configuration`, or `phrases` sections, replacing or supplementing static files.
 
-### 6.1 Wiring the Handler
+### Wiring the Handler {#wiring-the-handler}
 
 Two parameters in `lua.conf.xml` wire the handler. They must appear in order: `xml-handler-script` before `xml-handler-bindings`.
 
@@ -188,7 +188,7 @@ XML_STRING = [[
 ]]
 ```
 
-### 6.2 Binding Targets
+### Binding Targets {#binding-targets}
 
 The `xml-handler-bindings` value is passed to the internal `switch_xml_parse_section_string` function. Recognized values are:
 
@@ -203,7 +203,7 @@ Multiple bindings may be specified by listing them space-separated in a single `
 
 ---
 
-## 7. Event Hooks
+## Event Hooks {#event-hooks}
 
 The `<hook>` element inside `<settings>` binds a Lua script to a FreeSWITCH event. The script is executed in a dedicated thread each time the event fires.
 
@@ -221,7 +221,7 @@ Inside the script, the event is available as the global `event` object. Multiple
 
 ---
 
-## 8. Startup Scripts
+## Startup Scripts {#startup-scripts}
 
 The `startup-script` parameter launches a Lua script in a background thread when `mod_lua` loads. The script runs for as long as it needs to, including indefinitely. Multiple `startup-script` parameters are processed in order, with a 10-millisecond yield between each to avoid Lua initialization contention.
 
@@ -234,7 +234,7 @@ Startup scripts have no associated call session. They are useful for persistent 
 
 ---
 
-## 9. Other Language Modules
+## Other Language Modules {#other-language-modules}
 
 `mod_perl`, `mod_python3`, `mod_v8`, and `mod_java` provide equivalent integration points through their own configuration files and registered dialplan applications. None of these modules is loaded in the default configuration; each must be uncommented in `modules.conf.xml` and have its corresponding `autoload_configs` file present.
 
@@ -251,7 +251,7 @@ Each module registers two distinct API commands that mirror the behavior of Lua'
 
 `mod_v8` additionally registers `jsmon on|off` to enable or disable its runtime performance monitor, and `jsps` to display running script process status. These have no equivalent in the other language modules.
 
-### 9.1 Per-Engine Configuration
+### Per-Engine Configuration {#per-engine-configuration}
 
 The XML handler wiring for `mod_perl`, `mod_python3`, and `mod_v8` uses the **same parameter names as Lua** -- `xml-handler-script` followed by `xml-handler-bindings` -- and the same ordering rule applies: the script must be set before the binding that consumes it. `startup-script` also behaves identically across these three engines. The engines differ in which *additional* knobs they recognize and in whether they support `<hook>`.
 
@@ -267,7 +267,7 @@ The XML handler wiring for `mod_perl`, `mod_python3`, and `mod_v8` uses the **sa
 
 Note that Perl and Python 3 recognize **only** the three shared parameters. They do not implement `script-directory` or `module-directory`, and they do not parse a `<hook>` element -- only Lua and V8 bind event hooks from configuration.
 
-### 9.2 mod_perl (`perl.conf.xml`)
+### mod_perl (`perl.conf.xml`) {#mod_perl-perlconfxml}
 
 `mod_perl` parses exactly three parameters, with the same names and semantics as their Lua counterparts:
 
@@ -289,7 +289,7 @@ Note that Perl and Python 3 recognize **only** the three shared parameters. They
 
 There is no `<hook>` support and no script- or module-directory parameter.
 
-### 9.3 mod_python3 (`python.conf.xml`)
+### mod_python3 (`python.conf.xml`) {#mod_python3-pythonconfxml}
 
 `mod_python3` recognizes the same three parameters as `mod_perl`. The `xml-handler-script` and `startup-script` values name Python *modules* (importable on the interpreter path), not file paths.
 
@@ -305,7 +305,7 @@ There is no `<hook>` support and no script- or module-directory parameter.
 
 As with Perl, there is no `<hook>` support.
 
-### 9.4 mod_v8 (`v8.conf.xml`)
+### mod_v8 (`v8.conf.xml`) {#mod_v8-v8confxml}
 
 `mod_v8` shares the three Lua parameters and adds two V8-only caching knobs, a `<modules>` block for loading native V8 extension modules, and `<hook>` support.
 
@@ -340,7 +340,7 @@ The `<modules>` block (a sibling of `<settings>`) loads native extension modules
 
 The `<hook>` element works the same way as in Lua -- `event`, optional `subclass`, and `script` attributes -- and binds the named script to fire on each matching event. Inside the script, the event is available as the global `event` object.
 
-### 9.5 mod_java (`java.conf.xml`) {#mod-java}
+### mod_java (`java.conf.xml`) {#mod-java}
 
 `mod_java` does **not** use `<param>` elements. Its configuration is a set of dedicated child elements directly under `<configuration>`:
 

--- a/docs/integration/scripting.mdx
+++ b/docs/integration/scripting.mdx
@@ -251,4 +251,117 @@ Each module registers two distinct API commands that mirror the behavior of Lua'
 
 `mod_v8` additionally registers `jsmon on|off` to enable or disable its runtime performance monitor, and `jsps` to display running script process status. These have no equivalent in the other language modules.
 
-The XML handler and event hook wiring for `mod_perl`, `mod_python3`, and `mod_v8` follows the same conceptual model as Lua: a `xml-handler-script` parameter points to the handler script, and `xml-handler-bindings` registers it for one or more XML sections. Consult each module's configuration file for the exact parameter names and syntax, as they differ from the Lua parameter names in some respects.
+### 9.1 Per-Engine Configuration
+
+The XML handler wiring for `mod_perl`, `mod_python3`, and `mod_v8` uses the **same parameter names as Lua** -- `xml-handler-script` followed by `xml-handler-bindings` -- and the same ordering rule applies: the script must be set before the binding that consumes it. `startup-script` also behaves identically across these three engines. The engines differ in which *additional* knobs they recognize and in whether they support `<hook>`.
+
+`mod_java` is the exception: it does not use `<param>` elements at all and has its own configuration schema described below.
+
+| Engine | Config file | `<param>` names recognized | `<hook>` support |
+|---|---|---|---|
+| Lua | `lua.conf.xml` | `script-directory`, `module-directory`, `xml-handler-script`, `xml-handler-bindings`, `startup-script` | Yes |
+| Perl | `perl.conf.xml` | `xml-handler-script`, `xml-handler-bindings`, `startup-script` | No |
+| Python 3 | `python.conf.xml` | `xml-handler-script`, `xml-handler-bindings`, `startup-script` | No |
+| V8 | `v8.conf.xml` | `xml-handler-script`, `xml-handler-bindings`, `startup-script`, `script-caching`, `cache-expires-sec` | Yes |
+| Java | `java.conf.xml` | none (uses `<javavm>`, `<options>`, `<startup>`, `<shutdown>` -- see [9.5](#mod-java)) | No |
+
+Note that Perl and Python 3 recognize **only** the three shared parameters. They do not implement `script-directory` or `module-directory`, and they do not parse a `<hook>` element -- only Lua and V8 bind event hooks from configuration.
+
+### 9.2 mod_perl (`perl.conf.xml`)
+
+`mod_perl` parses exactly three parameters, with the same names and semantics as their Lua counterparts:
+
+| Parameter | Purpose |
+|---|---|
+| `xml-handler-script` | Perl script invoked to serve XML for the bound section. Set before `xml-handler-bindings`. |
+| `xml-handler-bindings` | XML section(s) to bind the handler to (`dialplan`, `directory`, `configuration`, `phrases`). |
+| `startup-script` | Perl script launched in a background thread at module load. Multiple entries allowed. |
+
+```xml
+<configuration name="perl.conf" description="PERL Configuration">
+  <settings>
+    <param name="xml-handler-script" value="$${temp_dir}/xml.pl"/>
+    <param name="xml-handler-bindings" value="dialplan"/>
+    <param name="startup-script" value="startup_script_1.pl"/>
+  </settings>
+</configuration>
+```
+
+There is no `<hook>` support and no script- or module-directory parameter.
+
+### 9.3 mod_python3 (`python.conf.xml`)
+
+`mod_python3` recognizes the same three parameters as `mod_perl`. The `xml-handler-script` and `startup-script` values name Python *modules* (importable on the interpreter path), not file paths.
+
+```xml
+<configuration name="python.conf" description="PYTHON Configuration">
+  <settings>
+    <param name="xml-handler-script" value="dp"/>
+    <param name="xml-handler-bindings" value="dialplan"/>
+    <param name="startup-script" value="startup_script_1"/>
+  </settings>
+</configuration>
+```
+
+As with Perl, there is no `<hook>` support.
+
+### 9.4 mod_v8 (`v8.conf.xml`)
+
+`mod_v8` shares the three Lua parameters and adds two V8-only caching knobs, a `<modules>` block for loading native V8 extension modules, and `<hook>` support.
+
+| Parameter | Purpose | Default |
+|---|---|---|
+| `xml-handler-script` | JavaScript handler for the bound section. | None |
+| `xml-handler-bindings` | XML section(s) to bind (`dialplan`, `directory`, `configuration`, `phrases`). | None |
+| `startup-script` | JavaScript launched in a background thread at load. Multiple entries allowed. | None |
+| `script-caching` | Enables compiled-script caching (`enabled` / `disabled`). | `disabled` |
+| `cache-expires-sec` | Seconds before a cached compiled script expires; `0` means never. Only parsed when built against V8 major version 5 or newer. | `0` |
+
+The `script-caching` and `cache-expires-sec` parameters are compiled in only when `mod_v8` is built against V8 major version 5 or later; on older V8 builds they are ignored.
+
+The `<modules>` block (a sibling of `<settings>`) loads native extension modules into the V8 runtime:
+
+```xml
+<configuration name="v8.conf" description="Google V8 JavaScript Plug-Ins">
+  <settings>
+    <param name="script-caching" value="enabled"/>
+    <param name="cache-expires-sec" value="3600"/>
+    <param name="startup-script" value="startup1.js"/>
+    <param name="xml-handler-script" value="directory.js"/>
+    <param name="xml-handler-bindings" value="directory"/>
+    <hook event="CUSTOM" subclass="sofia::register" script="catch-event.js"/>
+    <hook event="CHANNEL_HANGUP" script="hangup-event.js"/>
+  </settings>
+  <modules>
+    <load module="mod_v8_skel"/>
+  </modules>
+</configuration>
+```
+
+The `<hook>` element works the same way as in Lua -- `event`, optional `subclass`, and `script` attributes -- and binds the named script to fire on each matching event. Inside the script, the event is available as the global `event` object.
+
+### 9.5 mod_java (`java.conf.xml`) {#mod-java}
+
+`mod_java` does **not** use `<param>` elements. Its configuration is a set of dedicated child elements directly under `<configuration>`:
+
+| Element | Attributes | Purpose |
+|---|---|---|
+| `<javavm>` | `path` | Filesystem path to the JVM shared library (`libjvm.so`). Required; the module fails to load if absent. |
+| `<options>` / `<option>` | `value` | Repeatable JVM options (e.g. `-Djava.class.path=...`). Each `<option value="..."/>` is passed verbatim to `JNI_CreateJavaVM`. |
+| `<startup>` | `class`, `method`, `arg` | A static Java method invoked when the module loads. `class` is a JVM-style slash-separated class name. |
+| `<shutdown>` | `class`, `method`, `arg` | A static Java method invoked when the module unloads. |
+
+```xml
+<configuration name="java.conf" description="Java Plug-Ins">
+  <javavm path="/opt/jdk1.6.0_04/jre/lib/amd64/server/libjvm.so"/>
+  <options>
+    <option value="-Djava.class.path=$${script_dir}/freeswitch.jar:$${script_dir}/example.jar"/>
+    <option value="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:8000"/>
+  </options>
+  <startup class="org/freeswitch/example/ApplicationLauncher" method="startup"/>
+</configuration>
+```
+
+The module always appends `-Djava.library.path=<mod_dir>` to the supplied JVM options so the native JNI bridge can be located.
+
+The `org.freeswitch.Launcher` class is **hardcoded in the module's C source** -- it is loaded directly by `FindClass` so that its static initializer loads the JNI library, and it is not a configuration knob. The class you configure through `<startup>` (for example `org.freeswitch.example.ApplicationLauncher` above) is your own bootstrap class and is independent of the internal `Launcher`. There is no `<hook>` support in `mod_java`.

--- a/docs/integration/signalwire.mdx
+++ b/docs/integration/signalwire.mdx
@@ -83,7 +83,7 @@ The vanilla conf file also contains a comment for `caller-id-in-from`. That para
 
 ### Parameter Reference
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `kslog` | Enables the internal KS (libks) protocol library logger, writing connection-layer messages to the FreeSWITCH log. | `on` or `off` | `off` |
 | `blade-bootstrap` | WebSocket URI of the SignalWire Blade relay endpoint. Override only in private or on-premises SignalWire deployments. | URI string | `edge.SPACE.signalwire.com/api/relay/wss` (where `SPACE` is the SignalWire space name) |

--- a/docs/integration/signalwire.mdx
+++ b/docs/integration/signalwire.mdx
@@ -9,7 +9,7 @@ sidebar_label: "30. SignalWire Connectivity"
 
 # Chapter 30: SignalWire Connectivity
 
-`mod_signalwire` connects a FreeSWITCH instance to the SignalWire platform over a persistent WebSocket session, automatically provisioning a SIP profile and gateway that enable inbound and outbound PSTN calling through your SignalWire project. The module is included in the default build and is loaded automatically from `modules.conf.xml`.
+`mod_signalwire` connects a FreeSWITCH instance to the SignalWire platform over a persistent WebSocket session, automatically provisioning a SIP profile and gateway that enable inbound and outbound PSTN calling through a SignalWire project. The module is included in the default build and is loaded automatically from `modules.conf.xml`.
 
 ## Table of Contents
 
@@ -52,15 +52,15 @@ The module monitors the connection continuously and reconnects and re-provisions
     Go to https://signalwire.com to set up your Connector now!
    ```
 
-3. Log in to your SignalWire Dashboard, navigate to the Relay / Connectors section, and enter the token to claim the FreeSWITCH instance. The module polls the adoption service and completes adoption automatically once the token is claimed.
+3. In the SignalWire Dashboard, navigate to the Relay / Connectors section and enter the token to claim the FreeSWITCH instance. The module polls the adoption service and completes adoption automatically once the token is claimed.
 4. After adoption, `mod_signalwire` connects to the platform and loads the SIP profile. Verify registration with `sofia status profile signalwire` from the FreeSWITCH console.
-5. Inbound PSTN calls will now arrive in the XML dialplan at the context specified by `override-context` (default: the context supplied by the platform profile, typically `public`).
+5. Inbound PSTN calls then arrive in the XML dialplan at the context specified by `override-context` (default: the context supplied by the platform profile, typically `public`).
 
 ---
 
 ## Configuration: signalwire.conf.xml
 
-The configuration file is located at `conf/autoload_configs/signalwire.conf.xml`. In the default vanilla installation, every parameter is commented out; the module operates entirely on compiled-in defaults. Uncomment and set only the parameters you need to override.
+The configuration file is located at `conf/autoload_configs/signalwire.conf.xml`. In the default vanilla installation, every parameter is commented out; the module operates entirely on compiled-in defaults. Only the parameters that override a compiled-in default need to be uncommented and set.
 
 ```xml
 <configuration name="signalwire.conf" description="SignalWire">
@@ -86,7 +86,7 @@ The vanilla conf file also contains a comment for `caller-id-in-from`. That para
 | Parameter | Purpose | Values | Default |
 |---|---|---|---|
 | `kslog` | Enables the internal KS (libks) protocol library logger, writing connection-layer messages to the FreeSWITCH log. | `on` or `off` | `off` |
-| `blade-bootstrap` | WebSocket URI of the SignalWire Blade relay endpoint. Override only in private or on-premises SignalWire deployments. | URI string | `edge.SPACE.signalwire.com/api/relay/wss` (where `SPACE` is your SignalWire space name) |
+| `blade-bootstrap` | WebSocket URI of the SignalWire Blade relay endpoint. Override only in private or on-premises SignalWire deployments. | URI string | `edge.SPACE.signalwire.com/api/relay/wss` (where `SPACE` is the SignalWire space name) |
 | `adoption-service` | HTTPS URL of the adoption API. Override only in private or on-premises SignalWire deployments. | URL string | `https://adopt.signalwire.com/adoption` |
 | `stun-server` | STUN server used to discover the external IP address of this FreeSWITCH instance during adoption and provisioning. Accepts `host` or `host:port` format. | Hostname or `host:port` | `stun.freeswitch.org` |
 | `ssl-verify` | Controls SSL peer and host verification for HTTPS adoption requests. Set to `false` only in controlled test environments. | Boolean (`true` or `false`) | `true` |

--- a/docs/integration/xml-curl.mdx
+++ b/docs/integration/xml-curl.mdx
@@ -4,7 +4,7 @@ id: xml-curl
 slug: /integration/xml-curl
 title: "Chapter 26: HTTP Integration: XML Curl and HTTAPI"
 description: "Drive configuration and live call control from an HTTP backend with mod_xml_curl and the mod_httapi dialplan application."
-sidebar_label: "26. HTTP Integration"
+sidebar_label: "26. XML Curl and HTTAPI"
 ---
 
 # Chapter 26: HTTP Integration: XML Curl and HTTAPI

--- a/docs/integration/xml-curl.mdx
+++ b/docs/integration/xml-curl.mdx
@@ -14,39 +14,39 @@ FreeSWITCH provides two distinct HTTP integration points. `mod_xml_curl` replace
 ## Table of Contents
 
 - [Part 1: XML Curl](#part-1-xml-curl)
-  - [1. How XML Curl Works](#1-how-xml-curl-works)
-  - [2. Enabling the Module](#2-enabling-the-module)
-  - [3. Configuration File](#3-configuration-file)
-  - [4. Bindings](#4-bindings)
-    - [4.1 The gateway-url Parameter and the bindings Attribute](#41-the-gateway-url-parameter-and-the-bindings-attribute)
-    - [4.2 Bindable Section Names](#42-bindable-section-names)
-    - [4.3 Binding Parameter Reference](#43-binding-parameter-reference)
-  - [5. The HTTP Request](#5-the-http-request)
-  - [6. The HTTP Response](#6-the-http-response)
-    - [6.1 Found Response](#61-found-response)
-    - [6.2 Not-Found Response](#62-not-found-response)
-  - [7. Loading mod_xml_curl Early](#7-loading-mod_xml_curl-early)
-  - [8. Behavior with Static Files](#8-behavior-with-static-files)
-  - [9. Debug Mode](#9-debug-mode)
+  - [How XML Curl Works](#how-xml-curl-works)
+  - [Enabling the Module](#enabling-the-module)
+  - [Configuration File](#configuration-file)
+  - [Bindings](#bindings)
+    - [The gateway-url Parameter and the bindings Attribute](#the-gateway-url-parameter-and-the-bindings-attribute)
+    - [Bindable Section Names](#bindable-section-names)
+    - [Binding Parameter Reference](#binding-parameter-reference)
+  - [The HTTP Request](#the-http-request)
+  - [The HTTP Response](#the-http-response)
+    - [Found Response](#found-response)
+    - [Not-Found Response](#not-found-response)
+  - [Loading mod_xml_curl Early](#loading-mod_xml_curl-early)
+  - [Behavior with Static Files](#behavior-with-static-files)
+  - [Debug Mode](#debug-mode)
 - [Part 2: HTTAPI](#part-2-httapi)
-  - [10. HTTAPI Overview](#10-httapi-overview)
-  - [11. Enabling mod_httapi](#11-enabling-mod_httapi)
-  - [12. httapi.conf.xml](#12-httapiconfxml)
-    - [12.1 Global Settings](#121-global-settings)
-    - [12.2 Profile Params Reference](#122-profile-params-reference)
-    - [12.3 Permissions Reference](#123-permissions-reference)
-  - [13. The httapi Dialplan Application](#13-the-httapi-dialplan-application)
-    - [13.1 Application Syntax](#131-application-syntax)
-    - [13.2 Fields Posted to the Backend](#132-fields-posted-to-the-backend)
-    - [13.3 Response Document Structure](#133-response-document-structure)
-    - [13.4 Response Verb Reference](#134-response-verb-reference)
-    - [13.5 Worked Example](#135-worked-example)
+  - [HTTAPI Overview](#httapi-overview)
+  - [Enabling mod_httapi](#enabling-mod_httapi)
+  - [httapi.conf.xml](#httapiconfxml)
+    - [Global Settings](#global-settings)
+    - [Profile Params Reference](#profile-params-reference)
+    - [Permissions Reference](#permissions-reference)
+  - [The httapi Dialplan Application](#the-httapi-dialplan-application)
+    - [Application Syntax](#application-syntax)
+    - [Fields Posted to the Backend](#fields-posted-to-the-backend)
+    - [Response Document Structure](#response-document-structure)
+    - [Response Verb Reference](#response-verb-reference)
+    - [Worked Example](#worked-example)
 
 ---
 
 ## Part 1: XML Curl
 
-## 1. How XML Curl Works
+## How XML Curl Works {#how-xml-curl-works}
 
 FreeSWITCH uses an XML registry as its runtime data store. When FreeSWITCH needs to look up a dialplan, a directory entry, or a module configuration, it queries the registry for the appropriate section. By default, the registry is served from static files on disk.
 
@@ -56,7 +56,7 @@ The binding is exclusive for the bound sections: once a section is bound to a UR
 
 ---
 
-## 2. Enabling the Module
+## Enabling the Module {#enabling-the-module}
 
 Add `mod_xml_curl` to `autoload_configs/modules.conf.xml` if it is not already present:
 
@@ -64,11 +64,11 @@ Add `mod_xml_curl` to `autoload_configs/modules.conf.xml` if it is not already p
 <load module="mod_xml_curl"/>
 ```
 
-When `mod_xml_curl` must serve configuration for modules that load at startup, it must load before those modules. See [Section 7](#7-loading-mod_xml_curl-early) for the early-load mechanism.
+When `mod_xml_curl` must serve configuration for modules that load at startup, it must load before those modules. See [Loading mod_xml_curl Early](#loading-mod_xml_curl-early) for the early-load mechanism.
 
 ---
 
-## 3. Configuration File
+## Configuration File {#configuration-file}
 
 `mod_xml_curl` reads `autoload_configs/xml_curl.conf.xml`. The root element is a `<configuration>` element containing a single `<bindings>` child. Each `<binding>` element defines one HTTP gateway.
 
@@ -89,9 +89,9 @@ Multiple `<binding>` elements are permitted. Each binding is independent and may
 
 ---
 
-## 4. Bindings
+## Bindings {#bindings}
 
-### 4.1 The gateway-url Parameter and the bindings Attribute
+### The gateway-url Parameter and the bindings Attribute {#the-gateway-url-parameter-and-the-bindings-attribute}
 
 The `gateway-url` parameter sets the HTTP endpoint for the binding. Its `bindings` XML attribute (not a child `<param>`) declares which sections this binding handles:
 
@@ -115,7 +115,7 @@ The value may also use the `file:` scheme to read from a local file path instead
 
 When a `file:` URL is used, `mod_xml_curl` reads the named file directly. The `gateway-credentials`, `method`, `timeout`, and all TLS parameters are ignored for file-scheme URLs.
 
-### 4.2 Bindable Section Names
+### Bindable Section Names {#bindable-section-names}
 
 The following section names are recognized by `switch_xml_parse_section_string` and may be used in the `bindings` attribute:
 
@@ -128,11 +128,11 @@ The following section names are recognized by `switch_xml_parse_section_string` 
 | `chatplan` | Chat routing plans |
 | `channels` | Channel variable lookups |
 
-### 4.3 Binding Parameter Reference
+### Binding Parameter Reference {#binding-parameter-reference}
 
 All parameters are child `<param>` elements of a `<binding>` element.
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `gateway-url` | Endpoint to fetch XML from. Carries a `bindings` XML attribute to declare which sections this binding serves. Also accepts a `file:` scheme path to read from a local file. | HTTP or HTTPS URL, or `file:/path/to/file`. Variable substitution in the URL is supported when `use-dynamic-url` is enabled. | None (required) |
 | `gateway-credentials` | HTTP authentication credentials. | `username:password` string | None |
@@ -155,7 +155,7 @@ All parameters are child `<param>` elements of a `<binding>` element.
 
 ---
 
-## 5. The HTTP Request
+## The HTTP Request {#the-http-request}
 
 `mod_xml_curl` uses libcurl to contact the configured `gateway-url`. By default the request is HTTP POST with `Content-Type: application/x-www-form-urlencoded`. The `User-Agent` header is `freeswitch-xml/1.0`.
 
@@ -177,9 +177,9 @@ FreeSWITCH follows up to 10 HTTP redirects.
 
 ---
 
-## 6. The HTTP Response
+## The HTTP Response {#the-http-response}
 
-### 6.1 Found Response
+### Found Response {#found-response}
 
 The backend must return HTTP `200` with a body that is a valid FreeSWITCH XML section document. The document must begin with a `<document>` root element containing a `<section>` element whose `name` attribute matches the requested section.
 
@@ -207,7 +207,7 @@ Example response for a `directory` lookup:
 
 Any HTTP status code other than `200` causes FreeSWITCH to discard the response and log an error.
 
-### 6.2 Not-Found Response
+### Not-Found Response {#not-found-response}
 
 When the backend cannot find the requested entry, it must return HTTP `200` with a not-found result document. FreeSWITCH checks for this structure and treats it as a miss, allowing the lookup to fall through:
 
@@ -224,7 +224,7 @@ Returning an empty body or a non-200 status code is not equivalent to a not-foun
 
 ---
 
-## 7. Loading mod_xml_curl Early
+## Loading mod_xml_curl Early {#loading-mod_xml_curl-early}
 
 `mod_xml_curl` loads in the normal module load sequence defined by `autoload_configs/modules.conf.xml`. If `mod_xml_curl` is bound to the `config` section and another module that loads at startup reads its configuration from that section, a race condition occurs: the module loads before `mod_xml_curl` is ready to serve its configuration.
 
@@ -242,7 +242,7 @@ Modules listed in `pre_load_modules.conf.xml` are loaded before the main module 
 
 ---
 
-## 8. Behavior with Static Files
+## Behavior with Static Files {#behavior-with-static-files}
 
 A binding to a section completely replaces static-file lookup for that section. FreeSWITCH does not fall back to disk files when `mod_xml_curl` returns a valid not-found document. The backend is the sole authority for every lookup in a bound section.
 
@@ -250,7 +250,7 @@ Sections not listed in any binding's `bindings` attribute continue to be served 
 
 ---
 
-## 9. Debug Mode
+## Debug Mode {#debug-mode}
 
 `mod_xml_curl` exposes an API command to retain temporary response files on disk for inspection instead of deleting them after each fetch:
 
@@ -265,7 +265,7 @@ When debug mode is on, each response is written to a `.tmp.xml` file in the Free
 
 ## Part 2: HTTAPI
 
-## 10. HTTAPI Overview
+## HTTAPI Overview {#httapi-overview}
 
 `mod_httapi` is a dialplan application. Instead of statically configuring call flow in the dialplan, the operator points a call at the `httapi` application with a URL. For each step of the call, FreeSWITCH POSTs the current session state to that URL and expects an XML document in response. The document contains a `<work>` element whose child elements are verbs that instruct FreeSWITCH what to do next: play a file, collect digits, transfer the call, hang up, and so on. When the verb completes, FreeSWITCH POSTs again, creating a request-response loop until the call ends.
 
@@ -275,7 +275,7 @@ This is distinct from XML Curl. XML Curl serves static configuration and directo
 
 ---
 
-## 11. Enabling mod_httapi
+## Enabling mod_httapi {#enabling-mod_httapi}
 
 Confirm that `mod_httapi` is listed in `autoload_configs/modules.conf.xml`:
 
@@ -287,7 +287,7 @@ The module reads its configuration from `autoload_configs/httapi.conf.xml` on lo
 
 ---
 
-## 12. httapi.conf.xml
+## httapi.conf.xml {#httapiconfxml}
 
 The configuration file has three top-level sections under the `<configuration>` root: `<settings>` for global parameters, `<profiles>` containing one or more `<profile>` elements, and within each profile: a `<params>` block for HTTP connection settings, a `<permissions>` block controlling what the backend is allowed to do, and optional `<conference>` and `<dial>` blocks for defaults used by those verbs.
 
@@ -326,22 +326,22 @@ The configuration file has three top-level sections under the `<configuration>` 
 </configuration>
 ```
 
-### 12.1 Global Settings
+### Global Settings {#global-settings}
 
 These parameters appear in the `<settings>` element and apply to all profiles.
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `debug` | Print the full XML response to the console on every request. | `true`, `false` | `true` (in sample config; use `false` in production) |
 | `file-cache-ttl` | Seconds before re-checking the HTTP server to see whether a remotely fetched audio file has changed. | Non-negative integer | `300` |
 | `abs-file-cache-ttl` | Absolute maximum seconds a cached file is kept regardless of server headers. | Non-negative integer | `0` (disabled) |
 | `file-not-found-expires` | Seconds to cache a 404 response for a remote audio file before retrying. Set to `-1` to cache indefinitely. | Integer | `300` |
 
-### 12.2 Profile Params Reference
+### Profile Params Reference {#profile-params-reference}
 
 Parameters inside a profile's `<params>` block configure the HTTP connection used when contacting the backend for call control. All are optional except `gateway-url`.
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `gateway-url` | URL that FreeSWITCH POSTs call state to. Can be overridden per-call by passing a URL as application data. | HTTP or HTTPS URL | None (required) |
 | `gateway-credentials` | HTTP authentication credentials. | `username:password` string | None |
@@ -362,7 +362,7 @@ Parameters inside a profile's `<params>` block configure the HTTP connection use
 | `enable-post-var` | Restricts which POST fields are sent. Each instance names one variable to include. Without any `enable-post-var` params, all available fields are sent. | Variable name string | All fields sent |
 | `user-agent` | HTTP `User-Agent` header value. | String | `mod_httapi/1.0` |
 
-### 12.3 Permissions Reference
+### Permissions Reference {#permissions-reference}
 
 Permissions are child `<permission>` elements of the `<permissions>` block inside a profile. They control what actions the HTTP backend is allowed to request. Setting `name="all" value="true"` enables everything; `name="none" value="true"` disables everything. Individual permissions override `all`/`none` when listed after them.
 
@@ -385,9 +385,9 @@ Permissions are child `<permission>` elements of the `<permissions>` block insid
 
 ---
 
-## 13. The httapi Dialplan Application
+## The httapi Dialplan Application {#the-httapi-dialplan-application}
 
-### 13.1 Application Syntax
+### Application Syntax {#application-syntax}
 
 The `httapi` application is invoked from the dialplan like any other application:
 
@@ -403,7 +403,7 @@ The `data` field accepts:
 
 The profile can also be selected by setting the channel variable `httapi_profile` before invoking the application.
 
-### 13.2 Fields Posted to the Backend
+### Fields Posted to the Backend {#fields-posted-to-the-backend}
 
 FreeSWITCH sends an HTTP POST with `Content-Type: application/x-www-form-urlencoded` to the configured URL. The following fields are always present:
 
@@ -420,7 +420,7 @@ Parameters set by the backend in a `<params>` response block (see Section 13.3) 
 
 When `enable-post-var` entries are configured in the profile, only the named variables (plus the core fields above) are included.
 
-### 13.3 Response Document Structure
+### Response Document Structure {#response-document-structure}
 
 The backend must return HTTP `200` with `Content-Type: text/xml`. The document envelope is:
 
@@ -449,7 +449,7 @@ Verbs inside `<work>` are processed in document order. Processing stops when a v
 
 Most verbs accept an `action` attribute that redirects subsequent requests to a different URL for that step, and a `temp-action` attribute that redirects only the immediately following request.
 
-### 13.4 Response Verb Reference
+### Response Verb Reference {#response-verb-reference}
 
 | Verb | Effect | Key Attributes |
 |---|---|---|
@@ -473,7 +473,7 @@ Most verbs accept an `action` attribute that redirects subsequent requests to a 
 | `<continue>` | No-op. Continues to the next verb or re-requests the current URL. | None |
 | `<break>` | Stops processing the current `<work>` block without hanging up. | None |
 
-### 13.5 Worked Example
+### Worked Example {#worked-example}
 
 The following dialplan extension routes an inbound call to the HTTAPI application using the `default` profile:
 

--- a/docs/integration/xml-curl.mdx
+++ b/docs/integration/xml-curl.mdx
@@ -372,7 +372,7 @@ Permissions are child `<permission>` elements of the `<permissions>` block insid
 | `set-vars` | `false` | Backend can set FreeSWITCH channel variables via a `<variables>` section in the response. Supports an optional `<variable-list>` child to allowlist or denylist specific variable names. |
 | `get-vars` | `false` | Backend can request channel variable values using the `<getVariable>` verb. Supports an optional `<variable-list>` child. |
 | `extended-data` | `false` | Full channel event data (caller profile and all channel variables) is included in every POST, not just on the first request. |
-| `execute-apps` | `true` | Backend can execute FreeSWITCH dialplan applications using the `<execute>` verb. Requires an `<application-list>` child element to define which applications are allowed or denied; the `default` attribute on `<application-list>` sets the list's default policy (`allow` or `deny`). |
+| `execute-apps` | `false` (vanilla `httapi.conf.xml` sets it `true`) | Backend can execute FreeSWITCH dialplan applications using the `<execute>` verb. Requires an `<application-list>` child element to define which applications are allowed or denied; the `default` attribute on `<application-list>` sets the list's default policy (`allow` or `deny`). |
 | `expand-vars-in-tag-body` | `false` | FreeSWITCH expands channel variable references found in verb tag body text before executing the verb. Supports `<variable-list>` and `<api-list>` children to restrict which variables and API functions can be expanded. |
 | `dial` | `true` | Backend can use the `<dial>` verb to transfer the call or bridge to a destination. |
 | `dial-set-context` | `false` | Backend can override the dialplan context used by `<dial>`. Enabling this implicitly enables `dial`. |

--- a/docs/media/audio-files-and-streaming.mdx
+++ b/docs/media/audio-files-and-streaming.mdx
@@ -75,6 +75,8 @@ When a bare filename is given (no leading `/`), FreeSWITCH prepends `$${sound_pr
 
 Plain file paths (`.wav`, `.ogg`, `.mp3`, etc.) are dispatched to `mod_sndfile` or `mod_shout` based on extension.
 
+Additional streaming-source format modules ship with FreeSWITCH and register their own schemes or extensions when loaded: [`mod_vlc`](../module-reference/formats/mod_vlc.mdx) plays and streams media via libVLC, [`mod_shell_stream`](../module-reference/formats/mod_shell_stream.mdx) streams audio from the standard output of an external command, and [`mod_http_cache`](../module-reference/applications/mod_http_cache.mdx) fetches and caches remote audio over HTTP(S) for playback. Each is documented in the Part 9 module reference.
+
 ---
 
 ## 18.2 mod\_sndfile and Supported File Formats
@@ -609,7 +611,7 @@ uuid_record 2dcb9f46-3a73-11ef-8d62-b7e5a3d1e2f9 stop  /var/recordings/2dcb9f46.
 
 **Sofia profile auto-recording (cross-reference)**
 
-The Sofia SIP profile parameters `record-template` and `record-path` instruct `mod_sofia` to call `record_session` automatically for every call handled by that profile, without requiring dialplan actions. Refer to the Sofia SIP Profiles chapter for the full parameter reference for those settings.
+The Sofia SIP profile parameters `record-template` and `record-path` instruct `mod_sofia` to call `record_session` automatically for every call handled by that profile, without requiring dialplan actions. Refer to [Chapter 7: SIP Profiles with Sofia](../users-endpoints/sip-profiles-sofia.mdx) for the full parameter reference for those settings.
 
 ---
 

--- a/docs/media/audio-files-and-streaming.mdx
+++ b/docs/media/audio-files-and-streaming.mdx
@@ -202,12 +202,12 @@ The `path` attribute specifies the filesystem directory from which audio files a
 | `rate` | Sample rate of the stream. Files are opened at this rate. | `8000`, `12000`, `16000`, `24000`, `32000`, `48000` | `8000` |
 | `shuffle` | Randomize playback order across the directory. When `true`, the stream starts at a random position in the file list. | `true`, `false` | `false` |
 | `channels` | Number of audio channels. | `1` (mono), `2` (stereo) | `1` |
-| `interval` | Packetization interval in milliseconds. Must be a multiple of 10 and within the platform maximum interval. | Integer (multiples of 10, typically 10, 20, 30) | `20` |
+| `interval` | Packetization interval in milliseconds. Must be a multiple of 10 and no greater than 120 ms; out-of-range values fall back to the default. | Integer, multiple of 10, `10`-`120` | `20` |
 | `timer-name` | Timer used to pace audio output. `soft` is the software timer; `posix` uses the POSIX timer. | `soft`, `posix` | `soft` |
 | `chime-list` | Comma-separated list of audio files to interject periodically. Files are played in rotation. | Comma-separated file paths | _(none)_ |
 | `chime-freq` | How often (in seconds) a chime file is played. Must be greater than 1. | Integer `> 1` | `30` |
 | `chime-max` | Maximum number of seconds the chime file plays before cutting back to the main stream. Must be greater than 1. | Integer `> 1` | _(unlimited)_ |
-| `volume` | Adjusts output volume. Granular volume control; the value is normalized to the allowed range internally. | Integer | `0` (no change) |
+| `volume` | Adjusts output volume. Granular volume control; the value is clamped to the allowed range internally. | Integer `-50`-`50` | `0` (no change) |
 | `auto-volume` | Target energy average for automatic gain control. `0` disables AGC. | Integer `0`-`20000` | `0` |
 | `auto-volume-low-point` | Low-energy threshold for the AGC. Used alongside `auto-volume`. | Integer `0`-`20000` | `0` |
 | `prebuf` | Pre-buffer size in bytes. Controls how much audio is buffered before distribution to listeners. | Integer (bytes) | `65536` |
@@ -223,7 +223,7 @@ The `path` attribute specifies the filesystem directory from which audio files a
 `mod_local_stream` exposes an API command for runtime control:
 
 ```
-local_stream <show|start|reload|stop|hup> <stream-name>
+local_stream <show|start|reload|stop|hup|vol> <stream-name> [<args>]
 ```
 
 | Subcommand | Effect |
@@ -233,6 +233,7 @@ local_stream <show|start|reload|stop|hup> <stream-name>
 | `stop` | Stops the named stream. Attached listeners receive silence. |
 | `reload` | Reloads the stream's configuration and restarts playback. If the stream is in use, a partial reload applies the subset of parameters that can change without restarting the thread. |
 | `hup` | Skips the current file and begins the next one immediately. |
+| `vol` | Adjusts the stream volume at runtime. Form: `local_stream vol <name> <level\|auto:avg[:low]>`. A plain integer level (clamped to `-50`-`50`) sets a fixed gain and disables AGC. The `auto:` form enables automatic gain control: `avg` is the target energy average and the optional `:low` is the low-energy point (each `0`-`20000`). With no argument it reports the current setting. |
 
 Example:
 
@@ -397,7 +398,7 @@ The vanilla configuration ships `conf/autoload_configs/shout.conf.xml` with all 
 | `decoder` | Force a specific mpg123 decoder architecture (e.g., `i586`). When empty, mpg123 selects the optimal decoder automatically. | _(empty, auto-select)_ |
 | `volume` | mpg123 playback volume as a floating-point multiplier (e.g., `0.1`). Applied only when `decoder` or `outscale` is also set. | _(unset)_ |
 | `outscale` | mpg123 output scale factor (integer). On 64-bit builds, FreeSWITCH applies a default of `8192` when no explicit globals are configured; set this param to override. | _(unset; 8192 applied on 64-bit when no other globals are set)_ |
-| `encode-brate` | Default encoding bit rate in kbps for the LAME encoder when writing MP3 or broadcasting to Icecast. | _(LAME default, scaled to session rate and channels)_ |
+| `encode-brate` | Encoding bit rate in kbps for the LAME encoder when writing MP3 or broadcasting to Icecast. | `16 * (samplerate/8000) * channels` kbps (16 kbps at 8 kHz mono) |
 | `encode-resample` | Output sample rate for the LAME encoder in Hz. | _(unset, LAME uses session rate)_ |
 | `encode-quality` | LAME encoding quality (integer; lower is higher quality). When unset, FreeSWITCH uses quality `2` (high). | `2` |
 

--- a/docs/media/audio-files-and-streaming.mdx
+++ b/docs/media/audio-files-and-streaming.mdx
@@ -13,38 +13,38 @@ FreeSWITCH resolves audio from multiple source types: plain file paths resolved 
 
 ## Table of Contents
 
-- [18.1 Playable Sources Overview](#181-playable-sources-overview)
-- [18.2 mod\_sndfile and Supported File Formats](#182-mod_sndfile-and-supported-file-formats)
-- [18.3 mod\_native\_file](#183-mod_native_file)
-- [18.4 mod\_local\_stream and Music on Hold](#184-mod_local_stream-and-music-on-hold)
-  - [18.4.1 Configuration File](#1841-configuration-file)
-  - [18.4.2 Directory Parameter Reference](#1842-directory-parameter-reference)
-  - [18.4.3 Runtime Management](#1843-runtime-management)
-- [18.5 mod\_tone\_stream and the TGML Generator](#185-mod_tone_stream-and-the-tgml-generator)
-  - [18.5.1 TGML Syntax](#1851-tgml-syntax)
-  - [18.5.2 silence\_stream](#1852-silence_stream)
-- [18.6 mod\_shout and the shout:// Scheme](#186-mod_shout-and-the-shout-scheme)
-- [18.7 The hold\_music Variable](#187-the-hold_music-variable)
-- [18.8 Recording Calls](#188-recording-calls)
-  - [18.8.1 record\_session: Full-Call Recording from the Dialplan](#1881-record_session-full-call-recording-from-the-dialplan)
-  - [18.8.2 uuid\_record: Live Recording Control via API](#1882-uuid_record-live-recording-control-via-api)
-  - [18.8.3 Stereo Recordings](#1883-stereo-recordings)
-  - [18.8.4 RECORD\_\* Control and Metadata Variables](#1884-record_-control-and-metadata-variables)
-  - [18.8.5 Masking Sensitive Audio](#1885-masking-sensitive-audio)
-  - [18.8.6 Post-Processing Recordings](#1886-post-processing-recordings)
-  - [18.8.7 Worked Examples](#1887-worked-examples)
-- [18.9 Phrases and the Say System](#189-phrases-and-the-say-system)
-  - [18.9.1 Three-Layer Model](#1891-three-layer-model)
-  - [18.9.2 Language Loading: the languages Section](#1892-language-loading-the-languages-section)
-  - [18.9.3 Language File Structure](#1893-language-file-structure)
-  - [18.9.4 Phrase Macro Structure](#1894-phrase-macro-structure)
-  - [18.9.5 The say Application](#1895-the-say-application)
-  - [18.9.6 sound\_prefix and Language Sound Files](#1896-sound_prefix-and-language-sound-files)
-  - [18.9.7 Adding a Custom Phrase Macro](#1897-adding-a-custom-phrase-macro)
+- [Playable Sources Overview](#playable-sources-overview)
+- [mod\_sndfile and Supported File Formats](#mod_sndfile-and-supported-file-formats)
+- [mod\_native\_file](#mod_native_file)
+- [mod\_local\_stream and Music on Hold](#mod_local_stream-and-music-on-hold)
+  - [Configuration File](#configuration-file)
+  - [Directory Parameter Reference](#directory-parameter-reference)
+  - [Runtime Management](#runtime-management)
+- [mod\_tone\_stream and the TGML Generator](#mod_tone_stream-and-the-tgml-generator)
+  - [TGML Syntax](#tgml-syntax)
+  - [silence\_stream](#silence_stream)
+- [mod\_shout and the shout:// Scheme](#mod_shout-and-the-shout-scheme)
+- [The hold\_music Variable](#the-hold_music-variable)
+- [Recording Calls](#recording-calls)
+  - [record\_session: Full-Call Recording from the Dialplan](#record_session-full-call-recording-from-the-dialplan)
+  - [uuid\_record: Live Recording Control via API](#uuid_record-live-recording-control-via-api)
+  - [Stereo Recordings](#stereo-recordings)
+  - [RECORD\_\* Control and Metadata Variables](#record_-control-and-metadata-variables)
+  - [Masking Sensitive Audio](#masking-sensitive-audio)
+  - [Post-Processing Recordings](#post-processing-recordings)
+  - [Worked Examples](#worked-examples)
+- [Phrases and the Say System](#phrases-and-the-say-system)
+  - [Three-Layer Model](#three-layer-model)
+  - [Language Loading: the languages Section](#language-loading-the-languages-section)
+  - [Language File Structure](#language-file-structure)
+  - [Phrase Macro Structure](#phrase-macro-structure)
+  - [The say Application](#the-say-application)
+  - [sound\_prefix and Language Sound Files](#sound_prefix-and-language-sound-files)
+  - [Adding a Custom Phrase Macro](#adding-a-custom-phrase-macro)
 
 ---
 
-## 18.1 Playable Sources Overview
+## Playable Sources Overview {#playable-sources-overview}
 
 Wherever FreeSWITCH accepts an audio source -- dialplan applications such as `playback`, `ringback`, `hold_music`, conference prompts, IVR menus, and so on -- the value is one of:
 
@@ -79,7 +79,7 @@ Additional streaming-source format modules ship with FreeSWITCH and register the
 
 ---
 
-## 18.2 mod\_sndfile and Supported File Formats
+## mod\_sndfile and Supported File Formats {#mod_sndfile-and-supported-file-formats}
 
 `mod_sndfile` wraps libsndfile and is the default handler for recorded audio files. It registers file extensions dynamically at load time based on what libsndfile reports as available on the host system.
 
@@ -118,7 +118,7 @@ When opening a file, `mod_sndfile` first attempts to open `<dir>/<rate>/<filenam
 
 ---
 
-## 18.3 mod\_native\_file
+## mod\_native\_file {#mod_native_file}
 
 `mod_native_file` handles files whose data is already encoded in a codec-native format, bypassing any PCM transcoding. At load time it enumerates every audio codec implementation that has a non-zero `encoded_bytes_per_packet` and registers the codec's IANA name as a file extension.
 
@@ -128,7 +128,7 @@ Files handled by `mod_native_file` are transmitted directly without re-encoding 
 
 ---
 
-## 18.4 mod\_local\_stream and Music on Hold
+## mod\_local\_stream and Music on Hold {#mod_local_stream-and-music-on-hold}
 
 `mod_local_stream` provides a shared, continuously running audio stream backed by a directory of audio files. Multiple channels can attach to the same stream simultaneously; all listeners receive the same audio at the same position. This makes it suitable for music-on-hold (MOH) and background music applications.
 
@@ -142,7 +142,7 @@ where `<directory-name>` matches the `name` attribute of a `<directory>` element
 
 When FreeSWITCH opens `local_stream://moh` it first attempts to find `moh/<session_sample_rate>` (e.g., `moh/16000`). If that directory is not configured it falls back to `moh`, and if that is also absent it falls back to `default`.
 
-### 18.4.1 Configuration File
+### Configuration File {#configuration-file}
 
 `conf/autoload_configs/local_stream.conf.xml` defines one or more named directories. The vanilla configuration ships four rate-specific MOH directories and a `default` directory:
 
@@ -195,7 +195,7 @@ When FreeSWITCH opens `local_stream://moh` it first attempts to find `moh/<sessi
 
 The `path` attribute specifies the filesystem directory from which audio files are read. The module reads every supported audio file in that directory; files with a `.loc` extension are treated as plain-text lists of file paths, one per line.
 
-### 18.4.2 Directory Parameter Reference
+### Directory Parameter Reference {#directory-parameter-reference}
 
 | Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
@@ -218,7 +218,7 @@ The `path` attribute specifies the filesystem directory from which audio files a
 | `logo-opacity` | Opacity of the logo overlay (0 = transparent, 100 = opaque). | Integer `0`-`100` | `100` |
 | `text-opacity` | Opacity of banner text overlaid on video frames. | Integer `0`-`100` | `100` |
 
-### 18.4.3 Runtime Management
+### Runtime Management {#runtime-management}
 
 `mod_local_stream` exposes an API command for runtime control:
 
@@ -244,7 +244,7 @@ local_stream reload moh/8000
 
 ---
 
-## 18.5 mod\_tone\_stream and the TGML Generator
+## mod\_tone\_stream and the TGML Generator {#mod_tone_stream-and-the-tgml-generator}
 
 `mod_tone_stream` synthesizes audio from a text description using the Teletone Generation Markup Language (TGML). The URI scheme is:
 
@@ -254,7 +254,7 @@ tone_stream://<tgml-string>[;loops=<n>]
 
 The optional `loops` suffix (separated by `;`) specifies how many times the tone sequence repeats. A value of `-1` loops indefinitely.
 
-### 18.5.1 TGML Syntax
+### TGML Syntax {#tgml-syntax}
 
 TGML is a semicolon-delimited sequence of commands and tone specifications. Each tone specification has the form:
 
@@ -319,7 +319,7 @@ tone_stream://path=</path/to/tone.tgml>
 
 The file contains TGML lines, one command or tone spec per line.
 
-### 18.5.2 silence\_stream
+### silence\_stream {#silence_stream}
 
 `mod_tone_stream` also registers the `silence_stream://` scheme, which generates silence:
 
@@ -343,7 +343,7 @@ silence_stream://-1,400
 
 ---
 
-## 18.6 mod\_shout and the shout:// Scheme
+## mod\_shout and the shout:// Scheme {#mod_shout-and-the-shout-scheme}
 
 `mod_shout` provides read and write access to MP3 files and HTTP-based Icecast/SHOUTcast streams. It links against libshout, libmp3lame, and libmpg123.
 
@@ -404,7 +404,7 @@ The vanilla configuration ships `conf/autoload_configs/shout.conf.xml` with all 
 
 ---
 
-## 18.7 The hold\_music Variable
+## The hold\_music Variable {#the-hold_music-variable}
 
 The global variable `hold_music` specifies the audio source played to a caller placed on hold. It is set in `conf/vanilla/vars.xml`:
 
@@ -436,11 +436,11 @@ When `hold_music` points to `local_stream://moh`, FreeSWITCH automatically selec
 
 ---
 
-## 18.8 Recording Calls
+## Recording Calls {#recording-calls}
 
 FreeSWITCH provides two complementary mechanisms for recording calls: the `record_session` dialplan application, which attaches a recorder to the session at call setup time, and the `uuid_record` API command, which starts or stops recording on a live call from the CLI or ESL. Both mechanisms write to any file format supported by the loaded format modules (WAV, MP3 via `mod_shout`, OGG, etc.). Recording behavior is governed by a set of channel variables prefixed with `RECORD_`.
 
-### 18.8.1 record\_session: Full-Call Recording from the Dialplan
+### record\_session: Full-Call Recording from the Dialplan {#record_session-full-call-recording-from-the-dialplan}
 
 `record_session` starts a background media tap that captures both the read (inbound, caller) and write (outbound, callee) audio legs mixed together into a single file. The recorder runs independently of dialplan execution; it continues until the call ends, an explicit `stop_record_session` is executed, or the optional timeout expires.
 
@@ -473,7 +473,7 @@ Additional per-recording controls (all accept `<path>` matching the active recor
 | `record_session_mask <path>` | Replaces audio with silence (comfort noise) in the file without stopping the recording. See section 18.8.5. |
 | `record_session_unmask <path>` | Restores normal audio capture after a mask. |
 
-### 18.8.2 uuid\_record: Live Recording Control via API
+### uuid\_record: Live Recording Control via API {#uuid_record-live-recording-control-via-api}
 
 `uuid_record` is a FreeSWITCH API command (available at the `fs_cli` prompt and over ESL) that attaches or detaches a recorder on an already-established call.
 
@@ -500,7 +500,7 @@ uuid_record 2dcb9f46-3a73-11ef-8d62-b7e5a3d1e2f9 pause /var/recordings/2dcb9f46.
 uuid_record 2dcb9f46-3a73-11ef-8d62-b7e5a3d1e2f9 resume /var/recordings/2dcb9f46.wav
 ```
 
-### 18.8.3 Stereo Recordings
+### Stereo Recordings {#stereo-recordings}
 
 By default, `record_session` mixes both legs of a call into a mono file. Setting `RECORD_STEREO=true` produces a 2-channel WAV where channel 1 carries the read stream (caller audio) and channel 2 carries the write stream (callee audio). This requires a file format that supports stereo; `.wav` and `.ogg` both qualify. `.mp3` encoding via `mod_shout` also supports stereo output.
 
@@ -508,7 +508,7 @@ By default, `record_session` mixes both legs of a call into a mono file. Setting
 
 `RECORD_STEREO` and `RECORD_STEREO_SWAP` are mutually exclusive; if both are set, `RECORD_STEREO` takes precedence. Stereo recording is only available when the session leg being tapped is mono; if the codec negotiated for the leg is already stereo, neither flag has any effect.
 
-### 18.8.4 RECORD\_\* Control and Metadata Variables
+### RECORD\_\* Control and Metadata Variables {#record_-control-and-metadata-variables}
 
 The following channel variables (or inline recording variables) control recording behavior. Variables can be set as standard channel variables with `set`, or scoped to a single recording by passing them in the inline variable block `{...}` argument.
 
@@ -533,7 +533,7 @@ The following channel variables (or inline recording variables) control recordin
 | `record_post_process_exec_app` | Dialplan application to execute after the recording completes. Format: `app_name::app_args`. Channel variables are expanded at execution time. |
 | `record_post_process_exec_api` | API command to execute after the recording completes. Format: `api_name:api_args`. Channel variables are expanded at execution time. |
 
-### 18.8.5 Masking Sensitive Audio
+### Masking Sensitive Audio {#masking-sensitive-audio}
 
 When a call enters a phase where audio must not appear in the recording (for example, while a caller enters a payment card number on their keypad), the recording can be masked without being stopped and restarted. Masking replaces captured audio with silence in the output file; the timestamp of the recording continues advancing normally so the surrounding context is preserved.
 
@@ -558,7 +558,7 @@ uuid_record <uuid> unmask /var/recordings/<uuid>.wav
 
 The path supplied to `record_session_mask`/`record_session_unmask` must match the path of an active recording on that session.
 
-### 18.8.6 Post-Processing Recordings
+### Post-Processing Recordings {#post-processing-recordings}
 
 Two channel variables trigger automatic post-processing after a recording stops.
 
@@ -575,7 +575,7 @@ Both variables are checked after every recording stops on the session, including
         data="record_post_process_exec_api=system:lame --quiet /var/recordings/${uuid}.wav /var/recordings/${uuid}.mp3"/>
 ```
 
-### 18.8.7 Worked Examples
+### Worked Examples {#worked-examples}
 
 **Dialplan: record a bridged call to a per-UUID file in stereo**
 
@@ -615,11 +615,11 @@ The Sofia SIP profile parameters `record-template` and `record-path` instruct `m
 
 ---
 
-## 18.9 Phrases and the Say System
+## Phrases and the Say System {#phrases-and-the-say-system}
 
 FreeSWITCH provides two higher-level audio primitives that sit above fixed file playback: the `say` application, which renders a value (a number, date, currency amount, and so on) by passing it to a language-specific say module; and the `phrase` application, which executes a named macro that can combine pre-recorded files, `say` actions, and dialplan application calls into a single compound prompt. Together they form the system used to build spoken IVR prompts, voicemail announcements, and any other prompt that depends on run-time data.
 
-### 18.9.1 Three-Layer Model
+### Three-Layer Model {#three-layer-model}
 
 | Layer | Application | What it does |
 |---|---|---|
@@ -629,7 +629,7 @@ FreeSWITCH provides two higher-level audio primitives that sit above fixed file 
 
 The phrase system is the highest level: a single `phrase` call can play a fixed file, invoke `say` to render a number, and insert a pause, all in the correct order for the target language.
 
-### 18.9.2 Language Loading: the languages Section
+### Language Loading: the languages Section {#language-loading-the-languages-section}
 
 `conf/vanilla/freeswitch.xml` contains a `languages` configuration section that includes every lang file at startup:
 
@@ -647,7 +647,7 @@ The phrase system is the highest level: a single `phrase` call can play a fixed 
 
 Each included XML file defines one `<language>` element. FreeSWITCH parses all included `<language>` elements at startup and makes them available to the `phrase` and `say` applications by language name. Changes to lang files take effect on a full `reloadxml`.
 
-### 18.9.3 Language File Structure
+### Language File Structure {#language-file-structure}
 
 `conf/vanilla/lang/en/en.xml` is the English language root file. It defines the `en` language entry and uses `<X-PRE-PROCESS cmd="include">` to pull in macro files from subdirectories:
 
@@ -675,7 +675,7 @@ Each included XML file defines one `<language>` element. FreeSWITCH parses all i
 
 The `<phrases>` element contains one or more `<macros>` blocks. Each `<macros>` block holds `<macro>` elements, which are the named phrase macros the `phrase` application looks up by name.
 
-### 18.9.4 Phrase Macro Structure
+### Phrase Macro Structure {#phrase-macro-structure}
 
 A phrase macro is a `<macro>` element containing one or more `<input>` blocks. Each `<input>` tests the data string passed to `phrase` against a regular expression pattern. If the pattern matches, the actions inside `<match>` execute; if it does not match, actions inside `<nomatch>` execute (if present).
 
@@ -752,13 +752,13 @@ The `phrase` application is invoked from the dialplan as:
 
 The `phrase` application reads the channel variable `language` (or falls back to `default_language`, then to `en`) to select which loaded `<language>` block to search for the named macro.
 
-### 18.9.5 The say Application
+### The say Application {#the-say-application}
 
 The `say` dialplan application passes a value directly to a language say module without going through a phrase macro. It renders numbers, dates, money, time, IP addresses, phone numbers, and spelled names via a language-specific `mod_say_*` module, which assembles pre-recorded sound files into spoken output.
 
 For the full `say` syntax, the per-type table (`number`, `currency`, `current_date_time`, `ip_address`, `telephone_number`, and so on), the say-method reference (`pronounced`, `iterated`, `counted`, `pronounced_year`), the list of supported language modules, and dialplan examples, see [the Say Modules reference](/module-reference/say).
 
-### 18.9.6 sound\_prefix and Language Sound Files
+### sound\_prefix and Language Sound Files {#sound_prefix-and-language-sound-files}
 
 When a phrase macro action uses `play-file` with a relative path, FreeSWITCH prepends the language `sound-prefix` attribute to build the full path. For the `en` language, `sound-prefix` is set to `$${sound_prefix}` in `en.xml`, which evaluates to the value of the preprocessor variable from `conf/vanilla/vars.xml`:
 
@@ -782,7 +782,7 @@ The channel variable `sound_prefix` can be overridden per call:
 
 The language XML can also lock the prefix so the channel variable cannot override it by setting `sound-prefix-enforced="true"` on a `<macros>` block.
 
-### 18.9.7 Adding a Custom Phrase Macro
+### Adding a Custom Phrase Macro {#adding-a-custom-phrase-macro}
 
 Place a new XML file in `conf/vanilla/lang/en/ivr/` (the `ivr/*.xml` glob is already included by `en.xml`) or create a new file and add an explicit `<X-PRE-PROCESS cmd="include">` for it inside the `<macros>` block in `en.xml`.
 

--- a/docs/media/audio-files-and-streaming.mdx
+++ b/docs/media/audio-files-and-streaming.mdx
@@ -39,10 +39,8 @@ FreeSWITCH resolves audio from multiple source types: plain file paths resolved 
   - [18.9.3 Language File Structure](#1893-language-file-structure)
   - [18.9.4 Phrase Macro Structure](#1894-phrase-macro-structure)
   - [18.9.5 The say Application](#1895-the-say-application)
-  - [18.9.6 Say Types Implemented in mod\_say\_en](#1896-say-types-implemented-in-mod_say_en)
-  - [18.9.7 Say Methods](#1897-say-methods)
-  - [18.9.8 sound\_prefix and Language Sound Files](#1898-sound_prefix-and-language-sound-files)
-  - [18.9.9 Adding a Custom Phrase Macro](#1899-adding-a-custom-phrase-macro)
+  - [18.9.6 sound\_prefix and Language Sound Files](#1896-sound_prefix-and-language-sound-files)
+  - [18.9.7 Adding a Custom Phrase Macro](#1897-adding-a-custom-phrase-macro)
 
 ---
 
@@ -754,76 +752,11 @@ The `phrase` application reads the channel variable `language` (or falls back to
 
 ### 18.9.5 The say Application
 
-The `say` dialplan application passes a value directly to a language say module without going through a phrase macro.
+The `say` dialplan application passes a value directly to a language say module without going through a phrase macro. It renders numbers, dates, money, time, IP addresses, phone numbers, and spelled names via a language-specific `mod_say_*` module, which assembles pre-recorded sound files into spoken output.
 
-**Syntax (from `mod_dptools`):**
+For the full `say` syntax, the per-type table (`number`, `currency`, `current_date_time`, `ip_address`, `telephone_number`, and so on), the say-method reference (`pronounced`, `iterated`, `counted`, `pronounced_year`), the list of supported language modules, and dialplan examples, see [the Say Modules reference](/module-reference/say).
 
-```
-say <module_name>[:<lang>] <say_type> <say_method> [<say_gender>] <text>
-```
-
-| Field | Description |
-|---|---|
-| `<module_name>[:<lang>]` | The say module to use, optionally followed by a colon and a language code. Example: `en` or `en:en`. When the colon form is absent, the language is resolved from the channel variable `language`, then `default_language`, then the module name itself. |
-| `<say_type>` | What kind of value `<text>` represents. See section 18.9.6 for the full table. Case-insensitive. |
-| `<say_method>` | How the value is spoken. See section 18.9.7. Case-insensitive. |
-| `<say_gender>` | Optional. `masculine`, `feminine`, or `neuter`. Used by languages whose grammar requires gender agreement. Ignored by `mod_say_en`. |
-| `<text>` | The value to speak. Its interpretation depends on `<say_type>`. |
-
-**Dialplan examples:**
-
-```xml
-<!-- Speak a cardinal number -->
-<action application="say" data="en number pronounced 1234"/>
-
-<!-- Speak a dollar amount -->
-<action application="say" data="en currency pronounced 9.95"/>
-
-<!-- Speak an IP address, digit by digit -->
-<action application="say" data="en ip_address iterated 192.168.1.1"/>
-
-<!-- Speak the current date and time -->
-<action application="say" data="en current_date_time pronounced 0"/>
-
-<!-- Speak a phone number -->
-<action application="say" data="en telephone_number pronounced 18005551212"/>
-```
-
-For `current_date`, `current_time`, and `current_date_time` types, the text value is ignored; the module reads the system clock directly.
-
-### 18.9.6 Say Types Implemented in mod\_say\_en
-
-The table below lists only the types that `mod_say_en` actually handles. Types defined in the core enum but not listed here (`telephone_extension`, `url`, `email_address`, `postal_address`, `account_number`) are not implemented in `mod_say_en` and will log an error if used with that module.
-
-| Type | What `text` should contain | What is spoken |
-|---|---|---|
-| `number` | An integer or decimal string | Cardinal number ("one thousand two hundred thirty four") |
-| `items` | An integer | Ordinal count, same audio set as `number` but used in list contexts |
-| `persons` | An integer | Person count, same audio set as `number` |
-| `messages` | An integer | Message count, same audio set as `number` |
-| `currency` | A decimal value such as `9.95` | Dollar and cent amounts ("nine dollars and ninety-five cents") |
-| `time_measurement` | An integer number of seconds | Duration in hours, minutes, and seconds |
-| `current_date` | Any (ignored) | Today's date from the system clock (month, day, year) |
-| `current_time` | Any (ignored) | Current time from the system clock (hour and minute) |
-| `current_date_time` | Any (ignored) | Current date and time from the system clock |
-| `short_date_time` | A Unix epoch timestamp as a string | A compact date and time rendering |
-| `ip_address` | A dotted-quad IPv4 address | Each octet spoken as a number with "dot" separators |
-| `name_spelled` | Any alphanumeric string | Each character spoken individually using `ascii/` sound files |
-| `name_phonetic` | Any alphanumeric string | Each character spoken using `phonetic-ascii/` sound files |
-| `telephone_number` | A digit string (may include `+` and letters) | Each digit spoken individually with pauses at non-digit separators |
-
-### 18.9.7 Say Methods
-
-Methods control how a numeric value is rendered. Not every method has a distinct effect for every type; the say module implementation determines what changes.
-
-| Method | String used in dialplan or macro | Effect for `mod_say_en` |
-|---|---|---|
-| `pronounced` | `pronounced` | Reads the value as a natural spoken number or phrase ("one thousand two hundred"). |
-| `iterated` | `iterated` | Reads each digit or character individually ("one two zero zero"). |
-| `counted` | `counted` | Reads the value as an ordinal ("first", "second", "third"). |
-| `pronounced_year` | `pronounced_year` | Reads a 4-digit year in the conventional spoken form ("nineteen ninety-nine"). Used internally by date handling; available explicitly. |
-
-### 18.9.8 sound\_prefix and Language Sound Files
+### 18.9.6 sound\_prefix and Language Sound Files
 
 When a phrase macro action uses `play-file` with a relative path, FreeSWITCH prepends the language `sound-prefix` attribute to build the full path. For the `en` language, `sound-prefix` is set to `$${sound_prefix}` in `en.xml`, which evaluates to the value of the preprocessor variable from `conf/vanilla/vars.xml`:
 
@@ -847,7 +780,7 @@ The channel variable `sound_prefix` can be overridden per call:
 
 The language XML can also lock the prefix so the channel variable cannot override it by setting `sound-prefix-enforced="true"` on a `<macros>` block.
 
-### 18.9.9 Adding a Custom Phrase Macro
+### 18.9.7 Adding a Custom Phrase Macro
 
 Place a new XML file in `conf/vanilla/lang/en/ivr/` (the `ivr/*.xml` glob is already included by `en.xml`) or create a new file and add an explicit `<X-PRE-PROCESS cmd="include">` for it inside the `<macros>` block in `en.xml`.
 

--- a/docs/media/codecs-and-negotiation.mdx
+++ b/docs/media/codecs-and-negotiation.mdx
@@ -13,25 +13,25 @@ FreeSWITCH selects codecs through a standard SDP offer/answer exchange and appli
 
 ## Table of Contents
 
-- [16.1 How Codec Negotiation Works](#161-how-codec-negotiation-works)
-- [16.2 Codec Preference Strings](#162-codec-preference-strings)
-  - [16.2.1 Global Variables](#1621-global-variables)
-  - [16.2.2 SIP Profile Parameters](#1622-sip-profile-parameters)
-  - [16.2.3 Channel Variables](#1623-channel-variables)
-- [16.3 Inbound Codec Negotiation Policy](#163-inbound-codec-negotiation-policy)
-- [16.4 Ptime and the Codec String Format](#164-ptime-and-the-codec-string-format)
-- [16.5 Transcoding](#165-transcoding)
-- [16.6 SRTP Crypto Suites](#166-srtp-crypto-suites)
-- [16.7 Bundled Codec Reference](#167-bundled-codec-reference)
-- [16.8 Opus Configuration](#168-opus-configuration)
-- [16.9 AMR Configuration](#169-amr-configuration)
-- [16.10 AMR-WB Configuration](#1610-amr-wb-configuration)
-- [16.11 H.264/H.263 (mod_av) Configuration](#1611-h264h263-mod_av-configuration)
-- [16.12 VP8/VP9 (mod_vpx) Configuration](#1612-vp8vp9-mod_vpx-configuration)
+- [How Codec Negotiation Works](#how-codec-negotiation-works)
+- [Codec Preference Strings](#codec-preference-strings)
+  - [Global Variables](#global-variables)
+  - [SIP Profile Parameters](#sip-profile-parameters)
+  - [Channel Variables](#channel-variables)
+- [Inbound Codec Negotiation Policy](#inbound-codec-negotiation-policy)
+- [Ptime and the Codec String Format](#ptime-and-the-codec-string-format)
+- [Transcoding](#transcoding)
+- [SRTP Crypto Suites](#srtp-crypto-suites)
+- [Bundled Codec Reference](#bundled-codec-reference)
+- [Opus Configuration](#opus-configuration)
+- [AMR Configuration](#amr-configuration)
+- [AMR-WB Configuration](#amr-wb-configuration)
+- [H.264/H.263 (mod_av) Configuration](#h264h263-mod_av-configuration)
+- [VP8/VP9 (mod_vpx) Configuration](#vp8vp9-mod_vpx-configuration)
 
 ---
 
-## 16.1 How Codec Negotiation Works
+## How Codec Negotiation Works {#how-codec-negotiation-works}
 
 FreeSWITCH follows RFC 3264 offer/answer semantics. When an inbound INVITE arrives, `mod_sofia` compares the codec list in the remote SDP offer against the locally configured preference list. The intersection, ordered by the local preference list (or the remote list, depending on the negotiation policy described in section 16.3), becomes the negotiated codec set for the session.
 
@@ -41,7 +41,7 @@ When a call is bridged between two legs that share a common codec and transcodin
 
 ---
 
-## 16.2 Codec Preference Strings
+## Codec Preference Strings {#codec-preference-strings}
 
 A codec preference string is a comma-separated list of codec tokens. Each token identifies a codec and, optionally, a sample rate and packetization time. The resolution order from highest to lowest precedence is:
 
@@ -50,7 +50,7 @@ A codec preference string is a comma-separated list of codec tokens. Each token 
 3. The SIP profile `inbound-codec-prefs` or `outbound-codec-prefs` parameter
 4. The `global_codec_prefs` or `outbound_codec_prefs` global variable
 
-### 16.2.1 Global Variables
+### Global Variables {#global-variables}
 
 Defined in `conf/vanilla/vars.xml`:
 
@@ -61,7 +61,7 @@ Defined in `conf/vanilla/vars.xml`:
 
 `global_codec_prefs` is the default inbound codec preference list. `outbound_codec_prefs` is the default outbound codec preference list. Both are preprocessor variables, meaning they are expanded at configuration load time and are available to other config files as `$${global_codec_prefs}` and `$${outbound_codec_prefs}`.
 
-### 16.2.2 SIP Profile Parameters
+### SIP Profile Parameters {#sip-profile-parameters}
 
 Within a SIP profile (`conf/vanilla/sip_profiles/*.xml`), two parameters control per-profile codec preferences:
 
@@ -79,7 +79,7 @@ The vanilla internal profile sets both to `$${global_codec_prefs}`:
 
 A profile-level codec preference overrides the global variable for calls handled by that profile.
 
-### 16.2.3 Channel Variables
+### Channel Variables {#channel-variables}
 
 Two channel variables allow per-call codec control from the dialplan or an ESL application:
 
@@ -98,7 +98,7 @@ Using `absolute_codec_string` prevents FreeSWITCH from adapting to what the othe
 
 ---
 
-## 16.3 Inbound Codec Negotiation Policy
+## Inbound Codec Negotiation Policy {#inbound-codec-negotiation-policy}
 
 The `inbound-codec-negotiation` SIP profile parameter controls which side's preference order wins during inbound codec selection.
 
@@ -116,7 +116,7 @@ The default for profiles that do not set this parameter explicitly is `generous`
 
 ---
 
-## 16.4 Ptime and the Codec String Format
+## Ptime and the Codec String Format {#ptime-and-the-codec-string-format}
 
 The general format for a codec token in a preference string is:
 
@@ -149,7 +149,7 @@ FreeSWITCH supports ptimes from 10 ms to 120 ms on many codecs, subject to the c
 
 ---
 
-## 16.5 Transcoding
+## Transcoding {#transcoding}
 
 FreeSWITCH transcodes automatically when the two legs of a bridged call do not share a codec. No explicit configuration is required to enable transcoding; it occurs whenever the negotiated codecs on the A-leg and B-leg differ and the relevant codec modules are loaded.
 
@@ -167,15 +167,15 @@ For features that require FreeSWITCH to access the media stream (conference, rec
 
 ---
 
-## 16.6 SRTP Crypto Suites
+## SRTP Crypto Suites {#srtp-crypto-suites}
 
-SRTP secures the media transport rather than the codec/SDP negotiation that is the subject of this chapter, so the full crypto-suite catalog, the `rtp_secure_media` negotiation modes, and the `rtp_sdes_suites` global list are documented in [Chapter 17, section 17.8: Secure Media with SRTP](../media/media-handling.mdx#178-secure-media-with-srtp). In summary, when SRTP is enabled via the `rtp_secure_media` variable FreeSWITCH offers crypto suites in the order defined by `rtp_sdes_suites` (pipe-delimited, strongest first), and the negotiated suite is the first entry the remote endpoint also supports. FreeSWITCH supports the AES-CM (HMAC-SHA1) suites and the AES-GCM authenticated-encryption suites (RFC 7714 for the SRTP-AES-GCM suites).
+SRTP secures the media transport rather than the codec/SDP negotiation that is the subject of this chapter, so the full crypto-suite catalog, the `rtp_secure_media` negotiation modes, and the `rtp_sdes_suites` global list are documented in [Chapter 17, section 17.8: Secure Media with SRTP](../media/media-handling.mdx#secure-media-with-srtp). In summary, when SRTP is enabled via the `rtp_secure_media` variable FreeSWITCH offers crypto suites in the order defined by `rtp_sdes_suites` (pipe-delimited, strongest first), and the negotiated suite is the first entry the remote endpoint also supports. FreeSWITCH supports the AES-CM (HMAC-SHA1) suites and the AES-GCM authenticated-encryption suites (RFC 7714 for the SRTP-AES-GCM suites).
 
 The one point that bears directly on codec negotiation: when using SRTP, variable-bitrate codecs should not be offered or accepted, as VBR payloads can leak information through packet size variation and compromise the SRTP stream (note from `vars.xml`). Prefer fixed-rate codecs, or Opus at a fixed bitrate (`use-vbr=0`), on secure calls.
 
 ---
 
-## 16.7 Bundled Codec Reference
+## Bundled Codec Reference {#bundled-codec-reference}
 
 The exhaustive catalog of bundled codec modules — every codec's IANA name, confirmed sample rates, configuration file, module location, external-library requirements, and whether the module loads by default in the vanilla `modules.conf.xml` — lives in [Appendix B: Codec Reference Table](../reference/appendix-codec-table.mdx). Consult it when you need the full inventory; the rest of this section covers only the points that affect how codecs appear in a preference string.
 
@@ -191,7 +191,7 @@ Per-module audio and video configuration files referenced from a preference stri
 
 ---
 
-## 16.8 Opus Configuration
+## Opus Configuration {#opus-configuration}
 
 `mod_opus` is configured in `conf/vanilla/autoload_configs/opus.conf.xml`. All parameters apply globally to the Opus encoder and decoder for every call using the Opus codec.
 
@@ -241,7 +241,7 @@ The `use-vbr` parameter controls the SDP `cbr` fmtp attribute: when `use-vbr=0`,
 
 ---
 
-## 16.9 AMR Configuration
+## AMR Configuration {#amr-configuration}
 
 `mod_amr` is configured in `conf/vanilla/autoload_configs/amr.conf.xml`. When compiled without `opencore-amrnb`, the module operates in pass-through mode only and the encoder/decoder parameters below have no effect.
 
@@ -282,7 +282,7 @@ The `mode-set`, `octet-align`, `mode-change-period`, `mode-change-neighbor`, `cr
 
 ---
 
-## 16.10 AMR-WB Configuration
+## AMR-WB Configuration {#amr-wb-configuration}
 
 `mod_amrwb` is configured in `conf/vanilla/autoload_configs/amrwb.conf.xml`. When compiled without `opencore-amrwb`/`vo-amrwbenc`, the module operates in pass-through mode only.
 
@@ -324,11 +324,11 @@ AMR-WB mode index to bitrate mapping:
 
 ---
 
-## 16.11 H.264/H.263 (mod_av) Configuration
+## H.264/H.263 (mod_av) Configuration {#h264h263-mod_av-configuration}
 
 `mod_av` provides the H.264, H.263, and H.263+ video codecs through libavcodec (FFmpeg). The codec side of the module is configured in `conf/vanilla/autoload_configs/av.conf.xml`, which contains two configuration blocks: `avcodec.conf` (the encoder/decoder settings and per-profile parameters documented here) and `avformat.conf` (used by the recording/playback side of `mod_av`, with a single `colorspace` setting). The vanilla file ships `avformat.conf` with `colorspace=1` (BT.709).
 
-### 16.11.1 avcodec.conf settings
+### avcodec.conf settings {#avcodecconf-settings}
 
 The `<settings>` block applies module-wide. The shipped vanilla `av.conf.xml` sets only `dec-threads` and `enc-threads`; the others are present as commented examples. Defaults shown are the effective values applied after the config is loaded (out-of-range or unset values are clamped to these).
 
@@ -340,7 +340,7 @@ The `<settings>` block applies module-wide. The shipped vanilla `av.conf.xml` se
 | `dec-threads` | Decoder thread count. Accepts an integer, `auto`, or a `cpu` expression. | integer, `auto`, or `cpu/<divisor>/<max>` | `1` |
 | `enc-threads` | Encoder thread count. Accepts an integer, `auto`, or a `cpu` expression. | integer, `auto`, or `cpu/<divisor>/<max>` | `cpu/2/4` |
 
-### 16.11.2 Per-profile H.264/H.263 parameters
+### Per-profile H.264/H.263 parameters {#per-profile-h264h263-parameters}
 
 Profiles are defined under `<profiles>` as `<profile name="...">` elements. The vanilla file ships profiles named `H263`, `H263+`, `H264`, `H265`, `conference`, and `conference-H264`. The `conference` profile maps codec names to profiles for conference video via a `<codecs>` block. Each profile accepts the following `<param>` entries, which map to libavcodec `AVCodecContext` fields:
 
@@ -369,13 +369,13 @@ Profiles are defined under `<profiles>` as `<profile name="...">` elements. The 
 
 The vanilla `H264` profile additionally ships `flags="LOOP_FILTER|PSNR"`.
 
-### 16.11.3 Encoder flags vocabulary
+### Encoder flags vocabulary {#encoder-flags-vocabulary}
 
 The `flags` parameter takes a pipe-delimited (`|`) list. Each token is matched case-insensitively and OR-ed into the libavcodec flag set (only applied if the corresponding `AV_CODEC_FLAG_*` is defined in the linked FFmpeg):
 
 `UNALIGNED`, `QSCALE`, `4MV`, `CORRUPT`, `QPEL`, `PASS1`, `PASS2`, `LOOP_FILTER`, `GRAY`, `PSNR`, `TRUNCATED`, `INTERLACED_DCT`, `LOW_DELAY`, `HEADER` (global header), `BITEXACT`, `AC_PRED`, `INTERLACED_ME`, `CLOSED_GOP`.
 
-### 16.11.4 x264 private options passthrough
+### x264 private options passthrough {#x264-private-options-passthrough}
 
 A profile may include an `<options>` block whose `<option>` entries are passed verbatim to the underlying encoder's private option dictionary (for H.264 this is x264). These are not validated by FreeSWITCH; any libx264 option name and value may be supplied.
 
@@ -397,11 +397,11 @@ The vanilla `H264` profile ships the options above (`crf=18`); the `conference-H
 
 ---
 
-## 16.12 VP8/VP9 (mod_vpx) Configuration
+## VP8/VP9 (mod_vpx) Configuration {#vp8vp9-mod_vpx-configuration}
 
 The VP8 and VP9 video codecs are provided by the built-in VPX implementation (`src/switch_vpx.c`) using libvpx, not a separately loaded module. They are configured in `conf/vanilla/autoload_configs/vpx.conf.xml`.
 
-### 16.12.1 vpx.conf settings
+### vpx.conf settings {#vpxconf-settings}
 
 The `<settings>` block applies to both VP8 and VP9. In the vanilla file every setting is shipped commented out, so the effective defaults below apply. Out-of-range or unset values are clamped to these defaults after the config is loaded.
 
@@ -414,7 +414,7 @@ The `<settings>` block applies to both VP8 and VP9. In the vanilla file every se
 | `dec-threads` | Default decoder thread count (per-profile fallback) | integer, `auto`, or `cpu/<divisor>/<max>` | `cpu/2/4` (per-profile effective default) |
 | `enc-threads` | Default encoder thread count (per-profile fallback) | integer, `auto`, or `cpu/<divisor>/<max>` | `1` (per-profile effective default) |
 
-### 16.12.2 Per-profile VP8/VP9 parameters
+### Per-profile VP8/VP9 parameters {#per-profile-vp8vp9-parameters}
 
 Profiles are defined under `<profiles>` as `<profile name="...">` elements. The vanilla file ships profiles named `vp8`, `vp9`, `conference`, and `conference-vp8`. Most parameters map directly to libvpx `vpx_codec_enc_cfg_t` (`enc_cfg`) or `vpx_codec_dec_cfg_t` (`dec_cfg`) fields and are range-checked; an out-of-range value is rejected and the libvpx default is kept. Some parameters apply only to one codec, as noted.
 

--- a/docs/media/codecs-and-negotiation.mdx
+++ b/docs/media/codecs-and-negotiation.mdx
@@ -26,6 +26,8 @@ FreeSWITCH selects codecs through a standard SDP offer/answer exchange and appli
 - [16.8 Opus Configuration](#168-opus-configuration)
 - [16.9 AMR Configuration](#169-amr-configuration)
 - [16.10 AMR-WB Configuration](#1610-amr-wb-configuration)
+- [16.11 H.264/H.263 (mod_av) Configuration](#1611-h264h263-mod_av-configuration)
+- [16.12 VP8/VP9 (mod_vpx) Configuration](#1612-vp8vp9-mod_vpx-configuration)
 
 ---
 
@@ -177,7 +179,9 @@ Suites are separated by `|` and offered in left-to-right order (strongest first)
 
 | Suite | Key length | Auth tag | Notes |
 |---|---|---|---|
+| `AEAD_AES_256_GCM` | 256-bit | 128-bit | GCM authenticated encryption; full 16-octet tag (RFC 7714) |
 | `AEAD_AES_256_GCM_8` | 256-bit | 64-bit | GCM authenticated encryption; 8-octet tag (RFC 7714) |
+| `AEAD_AES_128_GCM` | 128-bit | 128-bit | GCM authenticated encryption; full 16-octet tag (RFC 7714) |
 | `AEAD_AES_128_GCM_8` | 128-bit | 64-bit | GCM authenticated encryption; 8-octet tag (RFC 7714) |
 | `AES_CM_256_HMAC_SHA1_80` | 256-bit | 80-bit | AES counter mode, HMAC-SHA1 |
 | `AES_CM_192_HMAC_SHA1_80` | 192-bit | 80-bit | AES counter mode, HMAC-SHA1 |
@@ -186,6 +190,8 @@ Suites are separated by `|` and offered in left-to-right order (strongest first)
 | `AES_CM_192_HMAC_SHA1_32` | 192-bit | 32-bit | Short tag |
 | `AES_CM_128_HMAC_SHA1_32` | 128-bit | 32-bit | Short tag |
 | `AES_CM_128_NULL_AUTH` | 128-bit | None | No authentication; not recommended (RFC 3711 section 7.5) |
+
+The full-tag GCM suites `AEAD_AES_256_GCM` and `AEAD_AES_128_GCM` (16-octet authentication tag) are recognized by FreeSWITCH but are not part of the default `rtp_sdes_suites` list shown above, which uses only the 8-octet (`_8`) GCM variants. To offer the full-tag suites, add them explicitly to `rtp_sdes_suites`.
 
 The `rtp_secure_media` variable controls SRTP negotiation mode. Its accepted values are:
 
@@ -249,11 +255,11 @@ Audio codecs whose module column shows "Built-in" are registered by the FreeSWIT
 | `BV32` | `mod_bv` | 16000 Hz | BroadVoice 32 wideband (32 kbit/s). |
 | `CODEC2` | `mod_codec2` | 8000 Hz | Low-bitrate open codec (3200/2400/1400/1200 bps). Requires libcodec2. |
 | `b64` | `mod_b64` | 8000, 16000, 32000 Hz | Base64-encoded audio; primarily for testing. |
-| `H264` | `mod_av` | Video | H.264 via libavcodec. See `av.conf.xml`. Also available via `mod_openh264` (Cisco OpenH264). |
-| `H263` | `mod_av` | Video | H.263 via libavcodec. |
-| `H263-1998` | `mod_av` | Video | H.263+ (RFC 2429) via libavcodec. |
-| `VP8` | Built-in (`switch_vpx.c`) | Video | VP8 via libvpx. See `vpx.conf.xml`. |
-| `VP9` | Built-in (`switch_vpx.c`) | Video | VP9 via libvpx. See `vpx.conf.xml`. |
+| `H264` | `mod_av` | Video | H.264 via libavcodec. See `av.conf.xml` (section 16.11). Also available via `mod_openh264` (Cisco OpenH264). |
+| `H263` | `mod_av` | Video | H.263 via libavcodec. See `av.conf.xml` (section 16.11). |
+| `H263-1998` | `mod_av` | Video | H.263+ (RFC 2429) via libavcodec. See `av.conf.xml` (section 16.11). |
+| `VP8` | Built-in (`switch_vpx.c`) | Video | VP8 via libvpx. See `vpx.conf.xml` (section 16.12). |
+| `VP9` | Built-in (`switch_vpx.c`) | Video | VP9 via libvpx. See `vpx.conf.xml` (section 16.12). |
 
 Note: `mod_com_g729` (in `src/mod/codecs/mod_com_g729/`) is a separate commercial G.729 module with full encode/decode support, distinct from the pass-through `mod_g729`.
 
@@ -389,3 +395,142 @@ AMR-WB mode index to bitrate mapping:
 | `6` | 19.85 kbit/s |
 | `7` | 23.05 kbit/s |
 | `8` | 23.85 kbit/s |
+
+---
+
+## 16.11 H.264/H.263 (mod_av) Configuration
+
+`mod_av` provides the H.264, H.263, and H.263+ video codecs through libavcodec (FFmpeg). The codec side of the module is configured in `conf/vanilla/autoload_configs/av.conf.xml`, which contains two configuration blocks: `avcodec.conf` (the encoder/decoder settings and per-profile parameters documented here) and `avformat.conf` (used by the recording/playback side of `mod_av`, with a single `colorspace` setting). The vanilla file ships `avformat.conf` with `colorspace=1` (BT.709).
+
+### 16.11.1 avcodec.conf settings
+
+The `<settings>` block applies module-wide. The shipped vanilla `av.conf.xml` sets only `dec-threads` and `enc-threads`; the others are present as commented examples. Defaults shown are the effective values applied after the config is loaded (out-of-range or unset values are clamped to these).
+
+| Parameter | Purpose | Accepted Values | Default |
+|---|---|---|---|
+| `max-bitrate` | Maximum bitrate the system will encode at; the encoder bandwidth is truncated to this value. A bandwidth string such as `5mb` is parsed. | Bandwidth string (e.g. `5mb`, `2000k`) | calculated for 1920x1080 @ 5 fps (used when unset or `<= 0`) |
+| `rtp-slice-size` | Maximum RTP payload size (before encryption) for packetized video. Values outside the valid range are reset to the default. | `500` to `1500` | `1200` |
+| `key-frame-min-freq` | Minimum interval between generated key frames, in milliseconds. Values outside the valid range are reset to the default. | `10` to `3000` (ms) | `250` |
+| `dec-threads` | Decoder thread count. Accepts an integer, `auto`, or a `cpu` expression. | integer, `auto`, or `cpu/<divisor>/<max>` | `1` |
+| `enc-threads` | Encoder thread count. Accepts an integer, `auto`, or a `cpu` expression. | integer, `auto`, or `cpu/<divisor>/<max>` | `cpu/2/4` |
+
+### 16.11.2 Per-profile H.264/H.263 parameters
+
+Profiles are defined under `<profiles>` as `<profile name="...">` elements. The vanilla file ships profiles named `H263`, `H263+`, `H264`, `H265`, `conference`, and `conference-H264`. The `conference` profile maps codec names to profiles for conference video via a `<codecs>` block. Each profile accepts the following `<param>` entries, which map to libavcodec `AVCodecContext` fields:
+
+| Parameter | Purpose | Accepted Values | Default |
+|---|---|---|---|
+| `dec-threads` | Decoder thread count for this profile | integer, `auto`, or `cpu/<divisor>/<max>` | inherits settings `dec-threads` |
+| `enc-threads` | Encoder thread count for this profile | integer, `auto`, or `cpu/<divisor>/<max>` | inherits settings `enc-threads` |
+| `profile` | Codec profile. For H.264, the names `baseline`, `main`, `high` are accepted, or a numeric libavcodec profile id. | `baseline` \| `main` \| `high` \| integer | `baseline` (FF_PROFILE_H264_BASELINE) |
+| `level` | Codec level (e.g. H.264 level 3.1 = `31`, 4.1 = `41`) | integer | `31` |
+| `timebase` | Encoder time base as `num/den` | `<num>/<den>` (e.g. `1/90`) | unset (libavcodec default) |
+| `flags` | libavcodec encoder flags; pipe-delimited list of flag tokens (see vocabulary below) | pipe-delimited tokens, e.g. `LOOP_FILTER\|PSNR` | unset |
+| `me-cmp` | Motion-estimation comparison function | integer | libavcodec default |
+| `me-range` | Motion-estimation search range | integer | libavcodec default |
+| `max-b-frames` | Maximum number of B-frames between non-B-frames | integer | libavcodec default |
+| `refs` | Number of reference frames | integer | libavcodec default |
+| `gop-size` | Group-of-pictures size (key-frame interval in frames) | integer | libavcodec default |
+| `keyint-min` | Minimum GOP size | integer | libavcodec default |
+| `i-quant-factor` | I-frame quantizer factor relative to P-frames | float | libavcodec default |
+| `b-quant-factor` | B-frame quantizer factor relative to P-frames | float | libavcodec default |
+| `qcompress` | Quantizer curve compression factor | float (`0.0` to `1.0`) | libavcodec default |
+| `qmin` | Minimum quantizer | integer | libavcodec default |
+| `qmax` | Maximum quantizer | integer | libavcodec default |
+| `max-qdiff` | Maximum quantizer difference between frames | integer | libavcodec default |
+| `colorspace` | YUV colorspace (`AVColorSpace` enum value); values above the supported maximum fall back to RGB | integer (e.g. `0` = RGB/GBR, `1` = BT.709, `5` = BT.470BG, `6` = SMPTE170M) | `0` in vanilla H264 profile |
+| `color-range` | Color range (`AVColorRange` enum value); out-of-range values reset to `0` | `0` (unspecified) \| `1` (MPEG/limited) \| `2` (JPEG/full) | `2` in vanilla H264 profile |
+
+The vanilla `H264` profile additionally ships `flags="LOOP_FILTER|PSNR"`.
+
+### 16.11.3 Encoder flags vocabulary
+
+The `flags` parameter takes a pipe-delimited (`|`) list. Each token is matched case-insensitively and OR-ed into the libavcodec flag set (only applied if the corresponding `AV_CODEC_FLAG_*` is defined in the linked FFmpeg):
+
+`UNALIGNED`, `QSCALE`, `4MV`, `CORRUPT`, `QPEL`, `PASS1`, `PASS2`, `LOOP_FILTER`, `GRAY`, `PSNR`, `TRUNCATED`, `INTERLACED_DCT`, `LOW_DELAY`, `HEADER` (global header), `BITEXACT`, `AC_PRED`, `INTERLACED_ME`, `CLOSED_GOP`.
+
+### 16.11.4 x264 private options passthrough
+
+A profile may include an `<options>` block whose `<option>` entries are passed verbatim to the underlying encoder's private option dictionary (for H.264 this is x264). These are not validated by FreeSWITCH; any libx264 option name and value may be supplied.
+
+```xml
+<profile name="H264">
+  <param name="flags" value="LOOP_FILTER|PSNR"/>
+  <options>
+    <option name="preset" value="veryfast"/>
+    <option name="intra_refresh" value="1"/>
+    <option name="tune" value="animation+zerolatency"/>
+    <option name="sc_threshold" value="40"/>
+    <option name="b_strategy" value="1"/>
+    <option name="crf" value="18"/>
+  </options>
+</profile>
+```
+
+The vanilla `H264` profile ships the options above (`crf=18`); the `conference-H264` profile ships the same set with `crf=10` for higher conference quality.
+
+---
+
+## 16.12 VP8/VP9 (mod_vpx) Configuration
+
+The VP8 and VP9 video codecs are provided by the built-in VPX implementation (`src/switch_vpx.c`) using libvpx, not a separately loaded module. They are configured in `conf/vanilla/autoload_configs/vpx.conf.xml`.
+
+### 16.12.1 vpx.conf settings
+
+The `<settings>` block applies to both VP8 and VP9. In the vanilla file every setting is shipped commented out, so the effective defaults below apply. Out-of-range or unset values are clamped to these defaults after the config is loaded.
+
+| Parameter | Purpose | Accepted Values | Default |
+|---|---|---|---|
+| `debug` | Enable VPX debug logging | integer (`0` = off, non-zero = on) | `0` |
+| `max-bitrate` | Maximum bitrate the system will encode at; the encoder bandwidth is truncated to this value. A bandwidth string is parsed. | Bandwidth string (e.g. `5mb`) | calculated for 1920x1080 @ 5 fps (used when unset or `<= 0`) |
+| `rtp-slice-size` | Maximum RTP payload size before encryption | `500` to `1500` | `1200` |
+| `key-frame-min-freq` | Minimum interval between generated key frames, in milliseconds | `10` to `3000` (ms) | `250` |
+| `dec-threads` | Default decoder thread count (per-profile fallback) | integer, `auto`, or `cpu/<divisor>/<max>` | `cpu/2/4` (per-profile effective default) |
+| `enc-threads` | Default encoder thread count (per-profile fallback) | integer, `auto`, or `cpu/<divisor>/<max>` | `1` (per-profile effective default) |
+
+### 16.12.2 Per-profile VP8/VP9 parameters
+
+Profiles are defined under `<profiles>` as `<profile name="...">` elements. The vanilla file ships profiles named `vp8`, `vp9`, `conference`, and `conference-vp8`. Most parameters map directly to libvpx `vpx_codec_enc_cfg_t` (`enc_cfg`) or `vpx_codec_dec_cfg_t` (`dec_cfg`) fields and are range-checked; an out-of-range value is rejected and the libvpx default is kept. Some parameters apply only to one codec, as noted.
+
+| Parameter | Purpose | Accepted Values | Default |
+|---|---|---|---|
+| `dec-threads` | Decoder thread count | integer, `auto`, or `cpu/<divisor>/<max>` (min `1`) | `cpu/2/4` |
+| `enc-threads` | Encoder thread count (`g_threads`) | integer, `auto`, or `cpu/<divisor>/<max>` (min `1`) | `1` |
+| `g-profile` | libvpx bitstream profile (`g_profile`) | `0` to `3` | libvpx default (vanilla `vp9` profile sets `0`) |
+| `g-error-resilient` | Error-resilience flags (`g_error_resilient`); pipe-delimited | `DEFAULT` \| `PARTITIONS` (pipe-delimited) | libvpx default |
+| `g-pass` | Encoding pass (`g_pass`) | `ONE_PASS` \| `FIRST_PASS` \| `LAST_PASS` | libvpx default |
+| `g-lag-in-frames` | Frames the encoder may consume before producing output (`g_lag_in_frames`) | `0` to `25` | libvpx default |
+| `rc_dropframe_thresh` | Frame-drop threshold for rate control (`rc_dropframe_thresh`). Note: the code matches this name with underscores. | `0` to `100` | libvpx default |
+| `rc-resize-allowed` | Allow spatial resampling (`rc_resize_allowed`) | `0` or `1` | libvpx default |
+| `rc-scaled-width` | Internal scaled width (`rc_scaled_width`) | `0` or greater | libvpx default |
+| `rc-scaled-height` | Internal scaled height (`rc_scaled_height`) | `0` or greater | libvpx default |
+| `rc-resize-up-thresh` | Upscale trigger threshold (`rc_resize_up_thresh`) | `0` to `100` | libvpx default |
+| `rc-resize-down-thresh` | Downscale trigger threshold (`rc_resize_down_thresh`) | `0` to `100` | libvpx default |
+| `rc-end-usage` | Rate-control mode (`rc_end_usage`) | `VBR` \| `CBR` \| `CQ` \| `Q` | libvpx default |
+| `rc-target-bitrate` | Target bitrate (`rc_target_bitrate`); bandwidth string parsed | Bandwidth string (e.g. `1mb`), min `1` | libvpx default |
+| `rc-min-quantizer` | Minimum quantizer (`rc_min_quantizer`) | `0` to `63` | libvpx default |
+| `rc-max-quantizer` | Maximum quantizer (`rc_max_quantizer`) | `0` to `63` | libvpx default |
+| `rc-undershoot-pct` | Undershoot percentage (`rc_undershoot_pct`) | `0` to `100` (VP9) / `0` to `1000` (VP8) | libvpx default |
+| `rc-overshoot-pct` | Overshoot percentage (`rc_overshoot_pct`) | `0` to `100` (VP9) / `0` to `1000` (VP8) | libvpx default |
+| `rc-buf-sz` | Decoder buffer size in ms (`rc_buf_sz`) | `1` or greater | libvpx default |
+| `rc-buf-initial-sz` | Initial decoder buffer size in ms (`rc_buf_initial_sz`) | `1` or greater | libvpx default |
+| `rc-buf-optimal-sz` | Optimal decoder buffer size in ms (`rc_buf_optimal_sz`) | `1` or greater | libvpx default |
+| `rc-2pass-vbr-bias-pct` | Two-pass VBR bias (`rc_2pass_vbr_bias_pct`) | `0` to `100` | libvpx default |
+| `rc-2pass-vbr-minsection-pct` | Two-pass VBR min section (`rc_2pass_vbr_minsection_pct`) | `1` or greater | libvpx default |
+| `rc-2pass-vbr-maxsection-pct` | Two-pass VBR max section (`rc_2pass_vbr_maxsection_pct`) | `1` or greater | libvpx default |
+| `kf-mode` | Key-frame placement mode (`kf_mode`) | `AUTO` \| `DISABLED` | libvpx default |
+| `kf-min-dist` | Minimum key-frame interval (`kf_min_dist`) | `0` or greater | libvpx default |
+| `kf-max-dist` | Maximum key-frame interval (`kf_max_dist`) | `0` or greater | libvpx default |
+| `ss-number-layers` | Number of spatial layers (`ss_number_layers`) | `0` to `VPX_SS_MAX_LAYERS` | libvpx default |
+| `ts-number-layers` | Number of temporal layers (`ts_number_layers`); locked for VP9 | `0` to `VPX_SS_MAX_LAYERS` (VP8); locked (VP9) | libvpx default |
+| `ts-periodicity` | Temporal layering periodicity (`ts_periodicity`); locked for VP9 | `0` to `16` (VP8); locked (VP9) | libvpx default |
+| `temporal-layering-mode` | Temporal layering mode (`temporal_layering_mode`); locked for VP9 | `0` to `3` (VP8); locked (VP9) | libvpx default |
+| `lossless` | VP9 lossless mode (set via codec_control). VP9 only. | `0` or `1` | `0` |
+| `cpuused` | Encoder speed/quality trade-off (set via codec_control) | `-16` to `16` (VP8) / `-8` to `8` (VP9) | libvpx default |
+| `token-parts` | Token partition count (set via codec_control) | `cpu` expression or integer, `1` to `8` partitions | libvpx default |
+| `static-thresh` | Static-content threshold (set via codec_control) | `0` or greater | libvpx default |
+| `noise-sensitivity` | Temporal denoising level (set via codec_control). VP8 only. | `0` to `6` | libvpx default |
+| `max-intra-bitrate-pct` | Maximum intra-frame bitrate as a percentage (set via codec_control). VP8 only. | `0` or greater | libvpx default |
+| `vp9e-tune-content` | VP9 content tuning (set via codec_control). VP9 only. | `DEFAULT` \| `SCREEN` | libvpx default |
+
+Parameters marked "set via codec_control" are applied to the live encoder through libvpx control calls rather than the initial `enc_cfg`. The `conference` profile uses a `<codecs>` block to bind codec names (`vp8`, `vp9`) to the profiles applied for conference video; the vanilla `conference-vp8` profile demonstrates an explicit CBR configuration tuned for conferencing.

--- a/docs/media/codecs-and-negotiation.mdx
+++ b/docs/media/codecs-and-negotiation.mdx
@@ -37,7 +37,7 @@ FreeSWITCH follows RFC 3264 offer/answer semantics. When an inbound INVITE arriv
 
 For outbound calls, FreeSWITCH generates an SDP offer from the outbound codec preference list and accepts the first mutually supported codec in the answer.
 
-When a call is bridged between two legs that share a common codec and transcoding is not required, FreeSWITCH can pass RTP directly between legs without decoding or re-encoding the audio. When the two legs do not share a codec, or when features that require media access (such as recording or conferencing) are in use, FreeSWITCH decodes and re-encodes the audio, performing transcoding between the two legs.
+When a call is bridged between two legs that share a common codec and transcoding is not required, FreeSWITCH can pass RTP directly between legs without decoding or re-encoding the audio (see [Chapter 17: Media Handling](../media/media-handling.mdx) for the media modes that govern whether RTP flows through the server). When the two legs do not share a codec, or when features that require media access (such as recording or conferencing) are in use, FreeSWITCH decodes and re-encodes the audio, performing transcoding between the two legs.
 
 ---
 
@@ -163,7 +163,7 @@ Transcoding is suppressed in two cases:
 
 2. **`absolute_codec_string` channel variable.** When this variable is set, FreeSWITCH skips the merge of inbound and outbound codec sets and presents only the specified list to the outbound leg. If the outbound endpoint cannot match any of those codecs, the call fails.
 
-For features that require FreeSWITCH to access the media stream (conference, recording, playback, speech detection), transcoding always occurs regardless of these settings, because the media must be decoded to PCM for processing.
+For features that require FreeSWITCH to access the media stream (conference, recording, [playback of audio files and streams](../media/audio-files-and-streaming.mdx), speech detection), transcoding always occurs regardless of these settings, because the media must be decoded to PCM for processing.
 
 ---
 

--- a/docs/media/codecs-and-negotiation.mdx
+++ b/docs/media/codecs-and-negotiation.mdx
@@ -124,7 +124,7 @@ The general format for a codec token in a preference string is:
 codecname[@<samplerate>h[@<ptime>i]]
 ```
 
-- `codecname` is the IANA codec name as used by FreeSWITCH (case-insensitive in configuration, but the canonical forms are shown in the table in section 16.7).
+- `codecname` is the IANA codec name as used by FreeSWITCH (case-insensitive in configuration; the canonical forms are listed in [Appendix B: Codec Reference Table](../reference/appendix-codec-table.mdx) and summarized in section 16.7).
 - `@<samplerate>h` specifies the sample rate in Hz. Required for codecs that operate at multiple rates (for example, `speex@8000h` vs `speex@16000h`). Omit for codecs with a single defined rate.
 - `@<ptime>i` specifies the packetization time in milliseconds. The value must be a multiple of the codec's frame size. Omit to use the codec's default ptime.
 
@@ -169,99 +169,25 @@ For features that require FreeSWITCH to access the media stream (conference, rec
 
 ## 16.6 SRTP Crypto Suites
 
-When SRTP is enabled via the `rtp_secure_media` variable, FreeSWITCH offers crypto suites in the order defined by `rtp_sdes_suites`. The default suite list from `conf/vanilla/vars.xml` is:
+SRTP secures the media transport rather than the codec/SDP negotiation that is the subject of this chapter, so the full crypto-suite catalog, the `rtp_secure_media` negotiation modes, and the `rtp_sdes_suites` global list are documented in [Chapter 17, section 17.8: Secure Media with SRTP](../media/media-handling.mdx#178-secure-media-with-srtp). In summary, when SRTP is enabled via the `rtp_secure_media` variable FreeSWITCH offers crypto suites in the order defined by `rtp_sdes_suites` (pipe-delimited, strongest first), and the negotiated suite is the first entry the remote endpoint also supports. FreeSWITCH supports the AES-CM (HMAC-SHA1) suites and the AES-GCM authenticated-encryption suites (RFC 7714 for the SRTP-AES-GCM suites).
 
-```xml
-<X-PRE-PROCESS cmd="set" data="rtp_sdes_suites=AEAD_AES_256_GCM_8|AEAD_AES_128_GCM_8|AES_CM_256_HMAC_SHA1_80|AES_CM_192_HMAC_SHA1_80|AES_CM_128_HMAC_SHA1_80|AES_CM_256_HMAC_SHA1_32|AES_CM_192_HMAC_SHA1_32|AES_CM_128_HMAC_SHA1_32|AES_CM_128_NULL_AUTH"/>
-```
-
-Suites are separated by `|` and offered in left-to-right order (strongest first). The negotiated suite is the first entry in this list that the remote endpoint also supports.
-
-| Suite | Key length | Auth tag | Notes |
-|---|---|---|---|
-| `AEAD_AES_256_GCM` | 256-bit | 128-bit | GCM authenticated encryption; full 16-octet tag (RFC 7714) |
-| `AEAD_AES_256_GCM_8` | 256-bit | 64-bit | GCM authenticated encryption; 8-octet tag (RFC 7714) |
-| `AEAD_AES_128_GCM` | 128-bit | 128-bit | GCM authenticated encryption; full 16-octet tag (RFC 7714) |
-| `AEAD_AES_128_GCM_8` | 128-bit | 64-bit | GCM authenticated encryption; 8-octet tag (RFC 7714) |
-| `AES_CM_256_HMAC_SHA1_80` | 256-bit | 80-bit | AES counter mode, HMAC-SHA1 |
-| `AES_CM_192_HMAC_SHA1_80` | 192-bit | 80-bit | AES counter mode, HMAC-SHA1 |
-| `AES_CM_128_HMAC_SHA1_80` | 128-bit | 80-bit | SRTP default cipher (RFC 3711) |
-| `AES_CM_256_HMAC_SHA1_32` | 256-bit | 32-bit | Short tag; 30-octet key+salt required |
-| `AES_CM_192_HMAC_SHA1_32` | 192-bit | 32-bit | Short tag |
-| `AES_CM_128_HMAC_SHA1_32` | 128-bit | 32-bit | Short tag |
-| `AES_CM_128_NULL_AUTH` | 128-bit | None | No authentication; not recommended (RFC 3711 section 7.5) |
-
-The full-tag GCM suites `AEAD_AES_256_GCM` and `AEAD_AES_128_GCM` (16-octet authentication tag) are recognized by FreeSWITCH but are not part of the default `rtp_sdes_suites` list shown above, which uses only the 8-octet (`_8`) GCM variants. To offer the full-tag suites, add them explicitly to `rtp_sdes_suites`.
-
-The `rtp_secure_media` variable controls SRTP negotiation mode. Its accepted values are:
-
-| Value | Behavior |
-|---|---|
-| `mandatory` or `true` | Accept and offer SAVP only. Calls that do not negotiate SRTP are rejected. |
-| `optional` | Offer and accept both SAVP and AVP; prefer SAVP. |
-| `forbidden` or `false` | Deny SAVP negotiation on inbound; do not offer SAVP on outbound. |
-
-Direction-specific overrides are available as `rtp_secure_media_inbound` and `rtp_secure_media_outbound`, using the same value set.
-
-To restrict which suites are offered without embedding them in `rtp_secure_media`, set `rtp_sdes_suites` to the desired pipe-delimited list, then set `rtp_secure_media` independently:
-
-```xml
-<X-PRE-PROCESS cmd="set" data="rtp_sdes_suites=AEAD_AES_256_GCM_8|AES_CM_128_HMAC_SHA1_80"/>
-```
-
-You can also specify suites inline with `rtp_secure_media` using a colon-separated suffix:
-
-```xml
-<action application="set" data="rtp_secure_media=mandatory:AES_CM_256_HMAC_SHA1_80:AES_CM_128_HMAC_SHA1_80"/>
-```
-
-Note from `vars.xml`: when using SRTP, variable-bitrate codecs should not be offered or accepted, as VBR payloads can leak information through packet size variation and compromise the SRTP stream.
+The one point that bears directly on codec negotiation: when using SRTP, variable-bitrate codecs should not be offered or accepted, as VBR payloads can leak information through packet size variation and compromise the SRTP stream (note from `vars.xml`). Prefer fixed-rate codecs, or Opus at a fixed bitrate (`use-vbr=0`), on secure calls.
 
 ---
 
 ## 16.7 Bundled Codec Reference
 
-The following codec modules are present in `src/mod/codecs/` (audio) or provided by `mod_av` / the built-in VPX implementation (video). All modules listed below ship with the FreeSWITCH source tree; some require external libraries and must be explicitly compiled and loaded.
+The exhaustive catalog of bundled codec modules — every codec's IANA name, confirmed sample rates, configuration file, module location, external-library requirements, and whether the module loads by default in the vanilla `modules.conf.xml` — lives in [Appendix B: Codec Reference Table](../reference/appendix-codec-table.mdx). Consult it when you need the full inventory; the rest of this section covers only the points that affect how codecs appear in a preference string.
 
-Audio codecs whose module column shows "Built-in" are registered by the FreeSWITCH core at startup without loading a separate `.so` file. `mod_spandsp` provides G.722, G.726, DVI4, GSM, and LPC. `mod_speex` (the internal Speex wrapper, `CORE_SPEEX_MODULE`) provides Speex.
+When writing a preference string (section 16.2) or an `absolute_codec_string`, use the codec's IANA token as listed in Appendix B — for example `OPUS`, `PCMU`, `PCMA`, `G722`, `G729`, `AMR`, `H264`, or `VP8`. A few tokens carry negotiation- or ptime-specific nuances worth keeping in mind:
 
-| Codec | Module | Sample rates | Notes / config file |
-|---|---|---|---|
-| `OPUS` | `mod_opus` | 8000, 12000, 16000, 24000, 48000 Hz (always negotiated at 48000 Hz on the wire) | Full encoder/decoder. Requires libopus. See `opus.conf.xml` (section 16.8). |
-| `PCMU` | Built-in (`switch_pcm.c`) | 8000 Hz | G.711 mu-law. No external library required. |
-| `PCMA` | Built-in (`switch_pcm.c`) | 8000 Hz | G.711 A-law. No external library required. |
-| `L16` | Built-in (`switch_pcm.c`) | 8000-48000 Hz | Linear 16-bit PCM. Can exceed the RTP MTU at higher rates; use with caution. |
-| `G722` | `mod_spandsp` | 16000 Hz | G.722 wideband. Requires libspandsp. |
-| `G726-16` | `mod_spandsp` | 8000 Hz | G.726 ADPCM 16 kbit/s. |
-| `G726-24` | `mod_spandsp` | 8000 Hz | G.726 ADPCM 24 kbit/s. |
-| `G726-32` | `mod_spandsp` | 8000 Hz | G.726 ADPCM 32 kbit/s. |
-| `G726-40` | `mod_spandsp` | 8000 Hz | G.726 ADPCM 40 kbit/s. |
-| `AAL2-G726-16` | `mod_spandsp` | 8000 Hz | G.726 16 kbit/s with AAL2 packing. |
-| `AAL2-G726-24` | `mod_spandsp` | 8000 Hz | G.726 24 kbit/s with AAL2 packing. |
-| `AAL2-G726-32` | `mod_spandsp` | 8000 Hz | G.726 32 kbit/s with AAL2 packing. |
-| `AAL2-G726-40` | `mod_spandsp` | 8000 Hz | G.726 40 kbit/s with AAL2 packing. |
-| `DVI4` | `mod_spandsp` | 8000, 16000 Hz | IMA ADPCM. Multiples of 10 ms. |
-| `GSM` | `mod_spandsp` | 8000 Hz | GSM 06.10. Default 20 ms; multiples of 20 ms only. |
-| `LPC` | `mod_spandsp` | 8000 Hz | LPC-10. Only 90 ms ptime supported. |
-| `speex` | Built-in (`switch_speex.c`) | 8000, 16000, 32000 Hz | Speex narrowband, wideband, and ultra-wideband. |
-| `G729` | `mod_g729` | 8000 Hz | Pass-through only (no transcoding without a licensed DSP library). |
-| `G723` | `mod_g723_1` | 8000 Hz | G.723.1 pass-through only. |
-| `AMR` | `mod_amr` | 8000 Hz | AMR narrowband. Octet-aligned and bandwidth-efficient modes. Requires opencore-amrnb for full encode/decode; pass-through otherwise. See `amr.conf.xml` (section 16.9). |
-| `AMR-WB` | `mod_amrwb` | 16000 Hz | AMR wideband. Octet-aligned and bandwidth-efficient modes. Requires opencore-amrwb/vo-amrwbenc for full encode/decode; pass-through otherwise. See `amrwb.conf.xml` (section 16.10). |
-| `iLBC` | `mod_ilbc` | 8000 Hz | Supports 20 ms (mode 20) and 30 ms (mode 30) frame sizes. Use `iLBC@30i` to force mode 30. |
-| `SILK` | `mod_silk` | 8000, 12000, 16000, 24000 Hz | Skype narrowband/wideband codec. Requires libSKP_SILK_SDK. |
-| `G7221` | `mod_siren` | 16000, 32000 Hz | G.722.1 (Siren 7 at 16 kHz) and G.722.1C (Siren 14 at 32 kHz). |
-| `BV16` | `mod_bv` | 8000 Hz | BroadVoice 16 narrowband (16 kbit/s). |
-| `BV32` | `mod_bv` | 16000 Hz | BroadVoice 32 wideband (32 kbit/s). |
-| `CODEC2` | `mod_codec2` | 8000 Hz | Low-bitrate open codec (3200/2400/1400/1200 bps). Requires libcodec2. |
-| `b64` | `mod_b64` | 8000, 16000, 32000 Hz | Base64-encoded audio; primarily for testing. |
-| `H264` | `mod_av` | Video | H.264 via libavcodec. See `av.conf.xml` (section 16.11). Also available via `mod_openh264` (Cisco OpenH264). |
-| `H263` | `mod_av` | Video | H.263 via libavcodec. See `av.conf.xml` (section 16.11). |
-| `H263-1998` | `mod_av` | Video | H.263+ (RFC 2429) via libavcodec. See `av.conf.xml` (section 16.11). |
-| `VP8` | Built-in (`switch_vpx.c`) | Video | VP8 via libvpx. See `vpx.conf.xml` (section 16.12). |
-| `VP9` | Built-in (`switch_vpx.c`) | Video | VP9 via libvpx. See `vpx.conf.xml` (section 16.12). |
+- `OPUS` is negotiated at 48000 Hz on the wire regardless of the internal sample rate, so a preference string lists it as plain `OPUS` (no `@<samplerate>h`).
+- `speex` operates at three rates and therefore requires an explicit rate token: `speex@8000h`, `speex@16000h`, or `speex@32000h`.
+- `iLBC` supports a 20 ms (mode 20) and a 30 ms (mode 30) frame size; use `iLBC@30i` in the preference string to force mode 30.
+- `GSM` packetizes in multiples of 20 ms and `LPC` only at 90 ms, so a ptime token such as `GSM@40i` must respect the codec's frame-size constraint (section 16.4).
+- The video tokens `H264`, `H263`, `H263-1998`, `VP8`, and `VP9` are listed in a preference string by name; their per-codec tuning is in sections 16.11 and 16.12, not the preference string.
 
-Note: `mod_com_g729` (in `src/mod/codecs/mod_com_g729/`) is a separate commercial G.729 module with full encode/decode support, distinct from the pass-through `mod_g729`.
+Per-module audio and video configuration files referenced from a preference string are documented later in this chapter: Opus (`opus.conf.xml`, section 16.8), AMR (`amr.conf.xml`, section 16.9), AMR-WB (`amrwb.conf.xml`, section 16.10), H.264/H.263 (`av.conf.xml`, section 16.11), and VP8/VP9 (`vpx.conf.xml`, section 16.12).
 
 ---
 

--- a/docs/media/index.mdx
+++ b/docs/media/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Part 5: Media and Codecs"
 slug: /media-and-codecs
-description: Codec negotiation, media handling, and audio playback.
+description: "Codec negotiation, media handling, and audio playback."
 ---
 
 import DocCardList from '@theme/DocCardList';

--- a/docs/media/media-handling.mdx
+++ b/docs/media/media-handling.mdx
@@ -13,58 +13,58 @@ FreeSWITCH gives the operator explicit control over whether RTP audio and video 
 
 ## Table of Contents
 
-- [17.1 Media Modes](#171-media-modes)
-  - [17.1.1 FreeSWITCH in the Media Path](#1711-freeswitch-in-the-media-path)
-  - [17.1.2 Proxy Media Mode](#1712-proxy-media-mode)
-  - [17.1.3 Bypass Media Mode](#1713-bypass-media-mode)
-  - [17.1.4 Mode Comparison Table](#1714-mode-comparison-table)
-- [17.2 Setting Media Mode](#172-setting-media-mode)
-  - [17.2.1 Profile-Level Defaults](#1721-profile-level-defaults)
-  - [17.2.2 Per-Call Channel Variables](#1722-per-call-channel-variables)
-  - [17.2.3 media-option Behaviors](#1723-media-option-behaviors)
-- [17.3 Early Media](#173-early-media)
-- [17.4 Late Negotiation](#174-late-negotiation)
-  - [17.4.1 inbound-late-negotiation](#1741-inbound-late-negotiation)
-  - [17.4.2 inbound-proxy-media](#1742-inbound-proxy-media)
-- [17.5 RTP Timeouts](#175-rtp-timeouts)
-  - [17.5.1 Current Mechanism: Channel Variables](#1751-current-mechanism-channel-variables)
-  - [17.5.2 Deprecated Profile Parameters](#1752-deprecated-profile-parameters)
-  - [17.5.3 execute_on_media_timeout](#1753-execute_on_media_timeout)
-- [17.6 Jitter Buffer](#176-jitter-buffer)
-- [17.7 Additional RTP Parameters](#177-additional-rtp-parameters)
-- [17.8 Secure Media with SRTP](#178-secure-media-with-srtp)
-  - [17.8.1 rtp_secure_media Channel Variable](#1781-rtp_secure_media-channel-variable)
-  - [17.8.2 Crypto Suite Selection](#1782-crypto-suite-selection)
-  - [17.8.3 Global Suite List with rtp_sdes_suites](#1783-global-suite-list-with-rtp_sdes_suites)
-  - [17.8.4 DTLS-SRTP and WebRTC](#1784-dtls-srtp-and-webrtc)
-- [17.9 NAT Traversal](#179-nat-traversal)
-  - [17.9.1 The NAT Problem](#1791-the-nat-problem)
-  - [17.9.2 Advertising the Public Address: ext-sip-ip and ext-rtp-ip](#1792-advertising-the-public-address-ext-sip-ip-and-ext-rtp-ip)
-  - [17.9.3 ext-ip Value Forms](#1793-ext-ip-value-forms)
-  - [17.9.4 vars.xml Global Variables and the external Profile](#1794-varsxml-global-variables-and-the-external-profile)
-  - [17.9.5 auto-nat: NAT-PMP and UPnP Discovery](#1795-auto-nat-nat-pmp-and-upnp-discovery)
-  - [17.9.6 Far-End NAT Handling](#1796-far-end-nat-handling)
-  - [17.9.7 NAT Traversal Parameter Reference](#1797-nat-traversal-parameter-reference)
+- [Media Modes](#media-modes)
+  - [FreeSWITCH in the Media Path](#freeswitch-in-the-media-path)
+  - [Proxy Media Mode](#proxy-media-mode)
+  - [Bypass Media Mode](#bypass-media-mode)
+  - [Mode Comparison Table](#mode-comparison-table)
+- [Setting Media Mode](#setting-media-mode)
+  - [Profile-Level Defaults](#profile-level-defaults)
+  - [Per-Call Channel Variables](#per-call-channel-variables)
+  - [media-option Behaviors](#media-option-behaviors)
+- [Early Media](#early-media)
+- [Late Negotiation](#late-negotiation)
+  - [inbound-late-negotiation](#inbound-late-negotiation)
+  - [inbound-proxy-media](#inbound-proxy-media)
+- [RTP Timeouts](#rtp-timeouts)
+  - [Current Mechanism: Channel Variables](#current-mechanism-channel-variables)
+  - [Deprecated Profile Parameters](#deprecated-profile-parameters)
+  - [execute_on_media_timeout](#execute_on_media_timeout)
+- [Jitter Buffer](#jitter-buffer)
+- [Additional RTP Parameters](#additional-rtp-parameters)
+- [Secure Media with SRTP](#secure-media-with-srtp)
+  - [rtp_secure_media Channel Variable](#rtp_secure_media-channel-variable)
+  - [Crypto Suite Selection](#crypto-suite-selection)
+  - [Global Suite List with rtp_sdes_suites](#global-suite-list-with-rtp_sdes_suites)
+  - [DTLS-SRTP and WebRTC](#dtls-srtp-and-webrtc)
+- [NAT Traversal](#nat-traversal)
+  - [The NAT Problem](#the-nat-problem)
+  - [Advertising the Public Address: ext-sip-ip and ext-rtp-ip](#advertising-the-public-address-ext-sip-ip-and-ext-rtp-ip)
+  - [ext-ip Value Forms](#ext-ip-value-forms)
+  - [vars.xml Global Variables and the external Profile](#varsxml-global-variables-and-the-external-profile)
+  - [auto-nat: NAT-PMP and UPnP Discovery](#auto-nat-nat-pmp-and-upnp-discovery)
+  - [Far-End NAT Handling](#far-end-nat-handling)
+  - [NAT Traversal Parameter Reference](#nat-traversal-parameter-reference)
 
 ---
 
-## 17.1 Media Modes
+## Media Modes {#media-modes}
 
 FreeSWITCH supports three distinct modes that determine how RTP flows between call legs.
 
-### 17.1.1 FreeSWITCH in the Media Path
+### FreeSWITCH in the Media Path {#freeswitch-in-the-media-path}
 
 This is the default mode. FreeSWITCH terminates RTP on both legs independently. It decodes, processes, and re-encodes media internally. Transcoding between codecs, recording, DTMF detection, jitter buffering, and hold music all require this mode. The server allocates two RTP ports per call (one per leg) and is fully visible in the media path.
 
-### 17.1.2 Proxy Media Mode
+### Proxy Media Mode {#proxy-media-mode}
 
 In proxy media mode, FreeSWITCH passes RTP packets between endpoints transparently without decoding the payload. The server still allocates RTP ports for both legs and remains in the media path at the IP/UDP layer, but it does not inspect or modify the RTP payload. SDP is rewritten so each endpoint sends RTP to FreeSWITCH's ports, but packets are forwarded with minimal processing. Transcoding is not possible in this mode.
 
-### 17.1.3 Bypass Media Mode
+### Bypass Media Mode {#bypass-media-mode}
 
 In bypass media mode (also referred to as no-media mode), FreeSWITCH rewrites the SDP to direct the two endpoints to exchange RTP directly with each other. Once the call is established, RTP does not touch the FreeSWITCH host at all. Transcoding, recording, DTMF detection on the RTP stream, hold music injection, and other media processing are unavailable. The server handles signaling only.
 
-### 17.1.4 Mode Comparison Table
+### Mode Comparison Table {#mode-comparison-table}
 
 | Mode | RTP Path | How to Enable |
 |------|----------|---------------|
@@ -74,13 +74,13 @@ In bypass media mode (also referred to as no-media mode), FreeSWITCH rewrites th
 
 ---
 
-## 17.2 Setting Media Mode
+## Setting Media Mode {#setting-media-mode}
 
-### 17.2.1 Profile-Level Defaults
+### Profile-Level Defaults {#profile-level-defaults}
 
 The following parameters in a [Sofia SIP profile](../users-endpoints/sip-profiles-sofia.mdx) set the media mode for all inbound calls handled by that profile. They are configured inside the `<settings>` block of the profile XML file (for example, `conf/sip_profiles/internal.xml`).
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |-----------|---------|--------|---------|
 | `inbound-bypass-media` | Force all inbound calls to bypass media mode. Alias: `inbound-no-media`. Implicitly enables `inbound-late-negotiation`. | `true`, `false` | `false` |
 | `inbound-proxy-media` | Force all inbound calls to proxy media mode | `true`, `false` | `false` |
@@ -102,7 +102,7 @@ The following parameters in a [Sofia SIP profile](../users-endpoints/sip-profile
 <!--<param name="disable-transcoding" value="true"/>-->
 ```
 
-### 17.2.2 Per-Call Channel Variables
+### Per-Call Channel Variables {#per-call-channel-variables}
 
 Media mode can be controlled per call in the dialplan using channel variables. Set these variables before bridging.
 
@@ -137,7 +137,7 @@ If both variables are set, `proxy_media` takes precedence over `bypass_media`.
 </extension>
 ```
 
-### 17.2.3 media-option Behaviors
+### media-option Behaviors {#media-option-behaviors}
 
 The `media-option` profile parameter adjusts media mode behavior for specific events. Multiple values can be set by repeating the parameter. `proxy-hold=true` is incompatible with `resume-media-on-hold` and `bypass-media-after-hold`; FreeSWITCH logs a warning and clears the conflicting option at profile load time.
 
@@ -156,7 +156,7 @@ The `media-option` profile parameter adjusts media mode behavior for specific ev
 
 ---
 
-## 17.3 Early Media
+## Early Media {#early-media}
 
 Early media allows FreeSWITCH to establish an RTP stream before a call is answered. It is used to pass ringback tone, IVR prompts, or other audio to the caller during the alerting phase.
 
@@ -176,9 +176,9 @@ Early media and bypass media mode interact: if `bypass_media` is set and the cal
 
 ---
 
-## 17.4 Late Negotiation
+## Late Negotiation {#late-negotiation}
 
-### 17.4.1 inbound-late-negotiation
+### inbound-late-negotiation {#inbound-late-negotiation}
 
 By default, FreeSWITCH selects a codec for the inbound leg as soon as the INVITE arrives, before the dialplan executes. With `inbound-late-negotiation` enabled, codec selection for the A-leg is deferred until after the dialplan has run. This allows dialplan logic to influence codec selection and is required for some advanced routing scenarios.
 
@@ -189,21 +189,21 @@ By default, FreeSWITCH selects a codec for the inbound leg as soon as the INVITE
 
 The vanilla `internal` profile ships with this parameter enabled (`true`).
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |-----------|---------|--------|---------|
 | `inbound-late-negotiation` | Defer A-leg codec selection until after the dialplan runs | `true`, `false` | `false` |
 
-### 17.4.2 inbound-proxy-media
+### inbound-proxy-media {#inbound-proxy-media}
 
 `inbound-proxy-media` is a profile-level shorthand for enabling proxy media mode on all inbound calls. See the table in section 17.2.1. When set, it is equivalent to setting `proxy_media=true` on every inbound call channel.
 
 ---
 
-## 17.5 RTP Timeouts
+## RTP Timeouts {#rtp-timeouts}
 
 FreeSWITCH can terminate a call when no RTP activity is detected for a configurable period.
 
-### 17.5.1 Current Mechanism: Channel Variables
+### Current Mechanism: Channel Variables {#current-mechanism-channel-variables}
 
 The preferred mechanism is per-channel variables. These values are in **milliseconds**.
 
@@ -228,18 +228,18 @@ The preferred mechanism is per-channel variables. These values are in **millisec
 </extension>
 ```
 
-### 17.5.2 Deprecated Profile Parameters
+### Deprecated Profile Parameters {#deprecated-profile-parameters}
 
 The profile parameters `rtp-timeout-sec` and `rtp-hold-timeout-sec` are deprecated. FreeSWITCH logs a `WARNING` to the console whenever they are parsed at profile load. Their values are in **seconds**. They remain functional in the current codebase and continue to appear in the vanilla `internal.xml` for backward compatibility, but new deployments should use the channel variables in section 17.5.1 instead.
 
-| Parameter | Purpose | Values | Default (vanilla) |
+| Parameter | Purpose | Accepted Values | Default (vanilla) |
 |-----------|---------|--------|---------|
 | `rtp-timeout-sec` | Seconds of RTP inactivity on an active call before hangup. **Deprecated.** | Integer (seconds), `0` to disable | `300` |
 | `rtp-hold-timeout-sec` | Seconds of RTP inactivity while on hold before hangup. **Deprecated.** | Integer (seconds), `0` to disable | `1800` |
 
 Deprecated channel variables `rtp_timeout_sec` and `rtp_hold_timeout_sec` also exist and are logged as deprecated with the same warning. Use `media_timeout` and `media_hold_timeout` instead.
 
-### 17.5.3 execute_on_media_timeout
+### execute_on_media_timeout {#execute_on_media_timeout}
 
 A media timeout causes FreeSWITCH to hang up the call with `SWITCH_CAUSE_MEDIA_TIMEOUT`. Setting the `execute_on_media_timeout` channel variable to a dialplan application name causes FreeSWITCH to execute that application when the timeout fires, allowing custom handling such as logging or notification.
 
@@ -256,7 +256,7 @@ So `execute_on_media_timeout` is best treated as a hook that runs alongside the 
 
 ---
 
-## 17.6 Jitter Buffer
+## Jitter Buffer {#jitter-buffer}
 
 The software jitter buffer is activated per channel via the `jitterbuffer_msec` channel variable. It is only available in normal (non-proxy, non-bypass) media mode.
 
@@ -283,11 +283,11 @@ The `rtp_jitter_buffer_plc` channel variable controls packet loss concealment wi
 
 ---
 
-## 17.7 Additional RTP Parameters
+## Additional RTP Parameters {#additional-rtp-parameters}
 
 The following profile parameters control RTP behavior beyond media mode and timeouts.
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |-----------|---------|--------|---------|
 | `rtp-autofix-timing` | Attempt to correct RTP timing anomalies from endpoints that send at irregular packet rates | `true`, `false` | `true` |
 | `disable-rtp-auto-adjust` | Disable automatic RTP source IP/port learning (re-INVITE NAT traversal) | `true`, `false` | `false` (auto-adjust enabled) |
@@ -306,11 +306,11 @@ The channel variable `rtp_media_autofix_timing` (`true`/`false`) overrides the `
 
 ---
 
-## 17.8 Secure Media with SRTP
+## Secure Media with SRTP {#secure-media-with-srtp}
 
 FreeSWITCH supports Secure RTP (SRTP) with key exchange via SDES (SDP security descriptions, RFC 4568). The `rtp_secure_media` channel variable and the global `rtp_sdes_suites` variable control SRTP negotiation.
 
-### 17.8.1 rtp_secure_media Channel Variable
+### rtp_secure_media Channel Variable {#rtp_secure_media-channel-variable}
 
 The `rtp_secure_media` channel variable controls whether FreeSWITCH offers, accepts, or rejects SAVP (Secure Audio/Video Profile) in SDP negotiation.
 
@@ -349,7 +349,7 @@ When a directional variable is set, it takes precedence over `rtp_secure_media` 
 
 **Note:** When using SRTP, do not offer or accept variable bit rate codecs (such as variable-rate Opus or AMR). Doing so leaks information about the payload through packet size patterns, potentially compromising the SRTP stream. Use fixed-rate codecs (for example, `PCMU`, `PCMA`, `G722`, or Opus at a fixed bitrate) with SRTP.
 
-### 17.8.2 Crypto Suite Selection
+### Crypto Suite Selection {#crypto-suite-selection}
 
 Specific SRTP crypto suites can be appended to the `rtp_secure_media` value as a colon-separated list. FreeSWITCH will offer or accept only the listed suites, in the specified order.
 
@@ -387,7 +387,7 @@ The supported crypto suites are listed in the table below.
 | `AES_CM_128_HMAC_SHA1_32` | AES-128 Counter Mode with 32-bit HMAC-SHA1 authentication tag |
 | `AES_CM_128_NULL_AUTH` | AES-128 Counter Mode with no authentication. Not recommended (see RFC 3711 Section 7.5). |
 
-### 17.8.3 Global Suite List with rtp_sdes_suites
+### Global Suite List with rtp_sdes_suites {#global-suite-list-with-rtp_sdes_suites}
 
 The `rtp_sdes_suites` preprocessor variable in `conf/vars.xml` sets the default ordered list of SRTP suites offered system-wide when no per-call suite override is in effect. Suites are separated by `\|`.
 
@@ -398,7 +398,7 @@ The `rtp_sdes_suites` preprocessor variable in `conf/vars.xml` sets the default 
 
 The vanilla default lists all supported suites from strongest to weakest. FreeSWITCH selects the strongest suite that both endpoints share. Narrow this list to restrict acceptable suites globally.
 
-### 17.8.4 DTLS-SRTP and WebRTC
+### DTLS-SRTP and WebRTC {#dtls-srtp-and-webrtc}
 
 WebRTC endpoints (browsers and WebRTC-capable SIP clients connecting over WebSocket or Secure WebSocket) use DTLS-SRTP (RFC 5764) rather than SDES for key exchange. DTLS-SRTP is negotiated automatically when FreeSWITCH detects an AVPF SDP profile from the remote endpoint, which is standard for WebRTC. The `rtp_secure_media` SDES mechanism described in this chapter does not apply to DTLS-SRTP negotiation.
 
@@ -406,9 +406,9 @@ For WebRTC configuration, including WebSocket bindings (`ws-binding`, `wss-bindi
 
 ---
 
-## 17.9 NAT Traversal
+## NAT Traversal {#nat-traversal}
 
-### 17.9.1 The NAT Problem
+### The NAT Problem {#the-nat-problem}
 
 When FreeSWITCH runs on a host behind a Network Address Translator, it binds to the host's private IP address. By default it inserts that private IP into SIP Contact and Via headers and into the SDP `c=` and `m=` connection lines. A far-end endpoint on the public Internet receives these private addresses and cannot route RTP back to FreeSWITCH, causing one-way audio or no audio at all.
 
@@ -419,7 +419,7 @@ The solution has two parts:
 
 Both parts are configured at the [SIP profile level](../users-endpoints/sip-profiles-sofia.mdx).
 
-### 17.9.2 Advertising the Public Address: ext-sip-ip and ext-rtp-ip
+### Advertising the Public Address: ext-sip-ip and ext-rtp-ip {#advertising-the-public-address-ext-sip-ip-and-ext-rtp-ip}
 
 `ext-sip-ip` and `ext-rtp-ip` are Sofia SIP profile parameters. They tell FreeSWITCH which address to advertise externally. They do not change the local bind address (`sip-ip`, `rtp-ip`); they only override the address placed in outgoing SIP headers and SDP.
 
@@ -432,7 +432,7 @@ When `ext-sip-ip` is set and `ext-rtp-ip` is not, `ext-rtp-ip` inherits the reso
 
 The local bind parameters, `sip-ip` and `rtp-ip`, accept `auto` or a literal IP and determine which local interface FreeSWITCH listens on. Setting `sip-ip` or `rtp-ip` to `auto` causes FreeSWITCH to use its best-guess local IP (`local_ip_v4`). They also accept the `interface:` prefix (`interface:eth0`, `interface:ipv4/eth0`, `interface:ipv6/eth0`) to bind to a specific network interface.
 
-### 17.9.3 ext-ip Value Forms
+### ext-ip Value Forms {#ext-ip-value-forms}
 
 Both `ext-sip-ip` and `ext-rtp-ip` accept the same set of value forms.
 
@@ -448,7 +448,7 @@ All resolution forms (`auto-nat`, `stun:`, `host:`) are performed once when the 
 
 `0.0.0.0` is explicitly rejected. FreeSWITCH logs a warning and substitutes the local best-guess IP.
 
-### 17.9.4 vars.xml Global Variables and the external Profile
+### vars.xml Global Variables and the external Profile {#varsxml-global-variables-and-the-external-profile}
 
 The vanilla configuration centralizes external IP resolution in `conf/vars.xml` using the `stun-set` preprocessor command:
 
@@ -472,7 +472,7 @@ Replace the `stun:stun.freeswitch.org` values with a literal IP, a `host:` form,
 
 If `external_rtp_ip` or `external_sip_ip` are unset (for example, STUN resolution failed), the external profile falls back to the resolved `local_ip_v4` value, which will be a private address behind NAT.
 
-### 17.9.5 auto-nat: NAT-PMP and UPnP Discovery
+### auto-nat: NAT-PMP and UPnP Discovery {#auto-nat-nat-pmp-and-upnp-discovery}
 
 Setting `ext-sip-ip` or `ext-rtp-ip` to `auto-nat` causes FreeSWITCH to query the local gateway using NAT-PMP (RFC 6886) and UPnP IGD to obtain the public IP address. FreeSWITCH tries NAT-PMP first; if no response is received, it falls back to UPnP.
 
@@ -482,7 +482,7 @@ When a gateway is found, FreeSWITCH stores the public address in the global vari
 
 If `auto-nat` is used and no gateway responds, `ext-sip-ip` and `ext-rtp-ip` are left unresolved and the profile will not advertise a public address.
 
-### 17.9.6 Far-End NAT Handling
+### Far-End NAT Handling {#far-end-nat-handling}
 
 FreeSWITCH also needs to handle SIP endpoints that are themselves behind NAT: their REGISTER Contact headers contain private addresses that FreeSWITCH cannot route to, and their RTP source port may differ from what their SDP advertises.
 
@@ -530,11 +530,11 @@ When an endpoint is behind NAT, the source IP and port of arriving RTP packets o
 
 This is enabled by default. The profile parameter `disable-rtp-auto-adjust` (section 17.7) turns it off globally; the per-call channel variable `disable_rtp_auto_adjust=true` turns it off for a single call. Auto-adjust is automatically suppressed for AVPF (WebRTC) sessions, where ICE handles address negotiation.
 
-### 17.9.7 NAT Traversal Parameter Reference
+### NAT Traversal Parameter Reference {#nat-traversal-parameter-reference}
 
 The following table consolidates all NAT-related profile parameters.
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |-----------|---------|--------|---------|
 | `ext-sip-ip` | Public IP advertised in SIP Contact, Via, and Record-Route | Literal IP, `auto`, `auto-nat`, `stun:server`, `host:name` | none |
 | `ext-rtp-ip` | Public IP advertised in SDP `c=` and `m=` lines | Literal IP, `auto`, `auto-nat`, `stun:server`, `host:name` | none |

--- a/docs/media/media-handling.mdx
+++ b/docs/media/media-handling.mdx
@@ -78,7 +78,7 @@ In bypass media mode (also referred to as no-media mode), FreeSWITCH rewrites th
 
 ### 17.2.1 Profile-Level Defaults
 
-The following parameters in a Sofia SIP profile set the media mode for all inbound calls handled by that profile. They are configured inside the `<settings>` block of the profile XML file (for example, `conf/sip_profiles/internal.xml`).
+The following parameters in a [Sofia SIP profile](../users-endpoints/sip-profiles-sofia.mdx) set the media mode for all inbound calls handled by that profile. They are configured inside the `<settings>` block of the profile XML file (for example, `conf/sip_profiles/internal.xml`).
 
 | Parameter | Purpose | Values | Default |
 |-----------|---------|--------|---------|
@@ -402,7 +402,7 @@ The vanilla default lists all supported suites from strongest to weakest. FreeSW
 
 WebRTC endpoints (browsers and WebRTC-capable SIP clients connecting over WebSocket or Secure WebSocket) use DTLS-SRTP (RFC 5764) rather than SDES for key exchange. DTLS-SRTP is negotiated automatically when FreeSWITCH detects an AVPF SDP profile from the remote endpoint, which is standard for WebRTC. The `rtp_secure_media` SDES mechanism described in this chapter does not apply to DTLS-SRTP negotiation.
 
-For WebRTC configuration, including WebSocket bindings (`ws-binding`, `wss-binding`), DTLS certificate setup, and ICE/STUN configuration, see the WebRTC chapters of this manual.
+For WebRTC configuration, including WebSocket bindings (`ws-binding`, `wss-binding`), DTLS certificate setup, and ICE/STUN configuration, see [Chapter 9: WebRTC with Verto](../users-endpoints/webrtc-verto.mdx) and [Chapter 10: WebRTC over SIP (WSS)](../users-endpoints/webrtc-sip-wss.mdx).
 
 ---
 
@@ -417,7 +417,7 @@ The solution has two parts:
 1. Configure FreeSWITCH to advertise the public IP address in SIP and SDP (`ext-sip-ip`, `ext-rtp-ip`).
 2. Handle far-end registrants and callers that are themselves behind NAT (`aggressive-nat-detection`, `apply-nat-acl`, `NDLB-force-rport`, RTP auto-adjust).
 
-Both parts are configured at the SIP profile level.
+Both parts are configured at the [SIP profile level](../users-endpoints/sip-profiles-sofia.mdx).
 
 ### 17.9.2 Advertising the Public Address: ext-sip-ip and ext-rtp-ip
 

--- a/docs/media/media-handling.mdx
+++ b/docs/media/media-handling.mdx
@@ -241,7 +241,14 @@ Deprecated channel variables `rtp_timeout_sec` and `rtp_hold_timeout_sec` also e
 
 ### 17.5.3 execute_on_media_timeout
 
-By default, a media timeout causes FreeSWITCH to hang up the call with `SWITCH_CAUSE_MEDIA_TIMEOUT`. Setting the `execute_on_media_timeout` channel variable to a dialplan application name causes FreeSWITCH to execute that application instead of immediately hanging up, allowing custom handling.
+A media timeout causes FreeSWITCH to hang up the call with `SWITCH_CAUSE_MEDIA_TIMEOUT`. Setting the `execute_on_media_timeout` channel variable to a dialplan application name causes FreeSWITCH to execute that application when the timeout fires, allowing custom handling such as logging or notification.
+
+The behavior depends on which code path detects the timeout:
+
+- **Read-frame path:** when the timeout is detected while the channel is reading frames, FreeSWITCH executes the `execute_on_media_timeout` application as the timeout handler.
+- **RTP-thread timeout path** (`switch_rtp.c`): the dedicated RTP timeout check (`check_timeout`) executes the `execute_on_media_timeout` application **and then still hangs up the call** with `SWITCH_CAUSE_MEDIA_TIMEOUT`. On this path the application runs first, but the hangup is unconditional.
+
+So `execute_on_media_timeout` is best treated as a hook that runs alongside the timeout rather than a guaranteed replacement for the hangup.
 
 ```xml
 <action application="set" data="execute_on_media_timeout=hangup"/>
@@ -255,9 +262,11 @@ The software jitter buffer is activated per channel via the `jitterbuffer_msec` 
 
 | Variable | Purpose | Format | Range |
 |----------|---------|--------|-------|
-| `jitterbuffer_msec` | Target buffer depth and optional maximum depth | `N` or `N:M` (milliseconds); suffix `p` treats `N`/`M` as packet counts | 10 to 10000 ms |
+| `jitterbuffer_msec` | Target buffer depth and optional maximum depth | `N` or `N:M` (milliseconds); suffix `p` treats `N`/`M` as packet counts | 10 to 10000 ms (see note) |
 
 When `jitterbuffer_msec` is set to a value with a `p` suffix (for example, `4p`), the number is treated as a packet count rather than milliseconds and multiplied by the codec packet duration. The optional `:M` component sets the maximum buffer depth; if omitted, the maximum defaults to 50 times the target value.
+
+The supported range is 10 to 10000 ms, but FreeSWITCH does not clamp out-of-range values to those bounds. If the resolved target falls below 10 ms or above 10000 ms, the value is discarded and reset to a single-packet default (the codec packet duration multiplied by 1), with the maximum recomputed as 100 times that one-packet target. A value such as `5` or `20000` therefore does not become `10` or `10000`; it collapses to roughly one packet of buffering.
 
 ```xml
 <!-- 60 ms target, default maximum -->
@@ -367,7 +376,9 @@ The supported crypto suites are listed in the table below.
 | Suite Name | Description |
 |------------|-------------|
 | `AEAD_AES_256_GCM_8` | AES-256 GCM with 8-octet authentication tag (RFC 5116) |
+| `AEAD_AES_256_GCM` | AES-256 GCM with full 16-octet authentication tag (RFC 7714) |
 | `AEAD_AES_128_GCM_8` | AES-128 GCM with 8-octet authentication tag (RFC 5116) |
+| `AEAD_AES_128_GCM` | AES-128 GCM with full 16-octet authentication tag (RFC 7714) |
 | `AES_CM_256_HMAC_SHA1_80` | AES-256 Counter Mode with 80-bit HMAC-SHA1 authentication tag |
 | `AES_CM_192_HMAC_SHA1_80` | AES-192 Counter Mode with 80-bit HMAC-SHA1 authentication tag |
 | `AES_CM_128_HMAC_SHA1_80` | AES-128 Counter Mode with 80-bit HMAC-SHA1 authentication tag (SRTP default) |

--- a/docs/media/media-handling.mdx
+++ b/docs/media/media-handling.mdx
@@ -536,4 +536,4 @@ The following table consolidates all NAT-related profile parameters.
 | `disable-rtp-auto-adjust` | Disable automatic update of the remote RTP address from observed packet source | `true`, `false` | `false` |
 | `local-network-acl` | ACL defining the local network; endpoints on this ACL are excluded from NAT detection | ACL name, `none` | `localnet.auto` |
 
-**WebRTC note:** Browser-based WebRTC clients use ICE for NAT traversal and do not rely on the `ext-sip-ip`/`ext-rtp-ip` mechanism. For ICE, STUN, and TURN configuration for WebRTC endpoints, see Chapter 18: WebRTC and Verto and the related WebRTC configuration chapters of this manual.
+**WebRTC note:** Browser-based WebRTC clients use ICE for NAT traversal and do not rely on the `ext-sip-ip`/`ext-rtp-ip` mechanism. For ICE, STUN, and TURN configuration for WebRTC endpoints, see [Chapter 9: WebRTC with Verto](../users-endpoints/webrtc-verto.mdx) and [Chapter 10: WebRTC over SIP (WSS)](../users-endpoints/webrtc-sip-wss.mdx).

--- a/docs/module-reference/applications/mod_avmd.mdx
+++ b/docs/module-reference/applications/mod_avmd.mdx
@@ -165,7 +165,7 @@ avmd show
 
 `mod_avmd` registers and fires three custom event subclasses under `SWITCH_EVENT_CUSTOM`:
 
-| Event subclass | When fired | Notable headers |
+| Event Subclass | Fired When | Extra Headers |
 |---|---|---|
 | `avmd::start` | When `avmd_start` (or `avmd <uuid> start`) successfully attaches the media bug | `Unique-ID`, `Start-time` |
 | `avmd::beep` | When a beep is detected on the audio stream | `Unique-ID`, `Beep-Status` (`DETECTED`), `Frequency`, `Frequency-variance`, `Amplitude`, `Amplitude-variance`, `Detection-time`, `Detector-resolution`, `Detector-offset`, `Detector-index` |

--- a/docs/module-reference/applications/mod_avmd.mdx
+++ b/docs/module-reference/applications/mod_avmd.mdx
@@ -13,6 +13,15 @@ sidebar_label: "mod_avmd"
 
 Operators reach for this module when building progressive-dialer or click-to-call flows that need to skip over voicemail greetings and respond as soon as the recording beep sounds — for example, to play a pre-recorded message or disconnect before leaving an unwanted recording.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: avmd.conf.xml](#configuration-avmdconfxml)
+- [Dialplan Applications](#dialplan-applications)
+- [API Commands](#api-commands)
+- [Channel Variables](#channel-variables)
+- [Events](#events)
+
 ## Loading the Module
 
 The module name is `mod_avmd`. It is **not** included in the vanilla `modules.conf.xml` load list and must be added manually:

--- a/docs/module-reference/applications/mod_bert.mdx
+++ b/docs/module-reference/applications/mod_bert.mdx
@@ -13,6 +13,14 @@ sidebar_label: "mod_bert"
 
 Operators reach for `mod_bert` when qualifying interconnects, verifying codec pass-through, or stress-testing media paths. It fires custom events on sync acquisition, sync loss, and timeout so external tooling can record pass/fail state without inspecting logs.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: bert.conf.xml](#configuration-bertconfxml)
+- [Dialplan Applications](#dialplan-applications)
+- [Channel Variables](#channel-variables)
+- [Events](#events)
+
 ## Loading the Module
 
 The module name for `load` and `modules.conf.xml` is `mod_bert`. It is **not** present in the default vanilla `autoload_configs/modules.conf.xml` and must be added manually:

--- a/docs/module-reference/applications/mod_blacklist.mdx
+++ b/docs/module-reference/applications/mod_blacklist.mdx
@@ -13,6 +13,12 @@ sidebar_label: "mod_blacklist"
 
 Reach for this module when you need simple, fast membership tests against a set of strings — for example, blocking spam callers, allowing only known numbers, or flagging specific destination prefixes — and you want to manage that set through `fs_cli` or ESL without editing dialplan XML.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: blacklist.conf.xml](#configuration-blacklistconfxml)
+- [API Commands](#api-commands)
+
 ## Loading the Module
 
 The module name for `load` and `modules.conf.xml` is `mod_blacklist`. It is **not** present in the default vanilla `autoload_configs/modules.conf.xml` and must be added manually:

--- a/docs/module-reference/applications/mod_cidlookup.mdx
+++ b/docs/module-reference/applications/mod_cidlookup.mdx
@@ -13,6 +13,14 @@ sidebar_label: "mod_cidlookup"
 
 Operators reach for this module when they want to enrich inbound calls with a human-readable name before routing, announcements, or screen-pop. It is equally usable from a dialplan `<action>` or from `fs_cli` for ad-hoc testing.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: cidlookup.conf.xml](#configuration-cidlookupconfxml)
+- [Dialplan Applications](#dialplan-applications)
+- [API Commands](#api-commands)
+- [Channel Variables](#channel-variables)
+
 ## Loading the Module
 
 The module name to load is `mod_cidlookup`. It is **not** present in the vanilla `autoload_configs/modules.conf.xml` and must be added manually:

--- a/docs/module-reference/applications/mod_curl.mdx
+++ b/docs/module-reference/applications/mod_curl.mdx
@@ -13,6 +13,15 @@ sidebar_label: "mod_curl"
 
 Operators reach for `mod_curl` when a dialplan needs to query a REST API mid-call—for example, to look up caller data, post call-detail to a webhook, or drive call routing from an external service—without leaving the dialplan context.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: curl.conf.xml](#configuration-curlconfxml)
+- [Dialplan Applications](#dialplan-applications)
+- [API Commands](#api-commands)
+- [Channel Variables](#channel-variables)
+- [Events](#events)
+
 ## Loading the Module
 
 The module is **not loaded by default**. In `conf/vanilla/autoload_configs/modules.conf.xml` the entry is commented out:

--- a/docs/module-reference/applications/mod_cv.mdx
+++ b/docs/module-reference/applications/mod_cv.mdx
@@ -13,6 +13,16 @@ sidebar_label: "mod_cv"
 
 Reach for this module when you need automated detection of objects in a video call — for example, to apply a logo overlay over a speaker's face, to trigger dialplan actions on presence/absence events, or to add a scrolling ticker band to a video stream. It is categorized under `src/mod/applications`.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration](#configuration)
+- [Dialplan Applications](#dialplan-applications)
+- [API Commands](#api-commands)
+- [Channel Variables](#channel-variables)
+- [Events](#events)
+- [Dependencies](#dependencies)
+
 ## Loading the Module
 
 The module is **not** included in the vanilla `autoload_configs/modules.conf.xml` and must be added manually. To enable it, add the following line to `modules.conf.xml` under the Applications section:

--- a/docs/module-reference/applications/mod_directory.mdx
+++ b/docs/module-reference/applications/mod_directory.mdx
@@ -124,4 +124,8 @@ The following channel variables are **read** by `mod_directory` during execution
 | `directory_voicemail_profile` | Read | Voicemail profile used when looking up pre-recorded names via `mod_voicemail`; defaults to the directory profile name |
 | `directory_search_order` | Read | Overrides the profile `search-order` parameter for this call; accepts `last_name`, `first_name`, or `first_and_last_name` |
 
+## See also
+
+- [Chapter 21: IVR Menus](../../applications/ivr-menus.mdx)
+
 **Source:** `src/mod/applications/mod_directory`

--- a/docs/module-reference/applications/mod_directory.mdx
+++ b/docs/module-reference/applications/mod_directory.mdx
@@ -13,6 +13,14 @@ sidebar_label: "mod_directory"
 
 Reach for this module when you need an automated corporate directory — callers who do not know an extension can spell part of a name and be connected without operator assistance.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: directory.conf.xml](#configuration-directoryconfxml)
+- [Dialplan Applications](#dialplan-applications)
+- [Channel Variables](#channel-variables)
+- [See also](#see-also)
+
 ## Loading the Module
 
 The module name is `mod_directory`. In the vanilla `autoload_configs/modules.conf.xml` the entry is commented out:

--- a/docs/module-reference/applications/mod_directory.mdx
+++ b/docs/module-reference/applications/mod_directory.mdx
@@ -96,7 +96,7 @@ The module reads `autoload_configs/directory.conf.xml`. The file has two section
 
 Two user-level `<param>` elements in the XML directory control whether a user appears in search results:
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |-----------|---------|--------|---------|
 | `directory-visible` | Include user in name search results | `true`, `false` | `true` |
 | `directory-exten-visible` | Announce the extension when reading the entry | `true`, `false` | `true` |

--- a/docs/module-reference/applications/mod_distributor.mdx
+++ b/docs/module-reference/applications/mod_distributor.mdx
@@ -13,6 +13,14 @@ sidebar_label: "mod_distributor"
 
 Operators reach for `mod_distributor` when they need to send, for example, 10 % of traffic to one gateway and 90 % to another, or to split load among several SIP trunks in any arbitrary ratio. It is not a round-robin or least-cost router; it is a ratio-based traffic shaper that can also skip specific nodes at call time via an exception list.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: distributor.conf.xml](#configuration-distributorconfxml)
+- [Dialplan Applications](#dialplan-applications)
+- [API Commands](#api-commands)
+- [Channel Variables](#channel-variables)
+
 ## Loading the Module
 
 The module name for `load` and `modules.conf.xml` is `mod_distributor`.

--- a/docs/module-reference/applications/mod_easyroute.mdx
+++ b/docs/module-reference/applications/mod_easyroute.mdx
@@ -13,6 +13,15 @@ sidebar_label: "mod_easyroute"
 
 Operators reach for this module when they need carrier-grade DID routing driven by a central database — for example, to enforce per-DID channel limits, populate billing account codes, or fan calls out to different SIP gateways without hard-coding routes in the dialplan.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: easyroute.conf.xml](#configuration-easyrouteconfxml)
+- [Dialplan Applications](#dialplan-applications)
+- [API Commands](#api-commands)
+- [Channel Variables](#channel-variables)
+- [Dependencies](#dependencies)
+
 ## Loading the Module
 
 The module name for `load` and `modules.conf.xml` is `mod_easyroute`. In the vanilla configuration it is **not** loaded by default — its entry is commented out:

--- a/docs/module-reference/applications/mod_esl.mdx
+++ b/docs/module-reference/applications/mod_esl.mdx
@@ -13,6 +13,13 @@ sidebar_label: "mod_esl"
 
 Reach for this module when a dialplan or script running on one FreeSWITCH instance needs to invoke an API command on a different FreeSWITCH instance (or any ESL-compatible server) without maintaining a persistent inbound ESL connection. It is a lightweight alternative to mod_event_socket for fire-and-forget remote control use cases.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: No conf file](#configuration-no-conf-file)
+- [API Commands](#api-commands)
+- [See also](#see-also)
+
 ## Loading the Module
 
 The module name is `mod_esl`. It is **not** present in the default vanilla `autoload_configs/modules.conf.xml` and must be added manually before it will load at startup.

--- a/docs/module-reference/applications/mod_esl.mdx
+++ b/docs/module-reference/applications/mod_esl.mdx
@@ -90,4 +90,8 @@ single_esl admin|mypassword 192.168.1.10 5000 show channels
 <action application="set" data="remote_result=${single_esl(|ClueCon 192.168.1.10 5000 status)}"/>
 ```
 
+## See also
+
+- [Chapter 25: The Event Socket](../../integration/event-socket.mdx)
+
 **Source:** `src/mod/applications/mod_esl`

--- a/docs/module-reference/applications/mod_fsk.mdx
+++ b/docs/module-reference/applications/mod_fsk.mdx
@@ -13,6 +13,12 @@ sidebar_label: "mod_fsk"
 
 Operators reach for this module when working with analog telephone adapters, FXS/FXO gateways, or SIP trunks that pass caller ID in-band as FSK audio rather than through SIP headers. It is also used for proprietary in-band data transfer between endpoints that speak FSK.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Dialplan Applications](#dialplan-applications)
+- [Channel Variables](#channel-variables)
+
 ## Loading the Module
 
 The module name for `load` and `modules.conf.xml` is `mod_fsk`. It is **not** loaded by default in the vanilla configuration — the entry is present but commented out:

--- a/docs/module-reference/applications/mod_http_cache.mdx
+++ b/docs/module-reference/applications/mod_http_cache.mdx
@@ -145,4 +145,8 @@ When `enable-file-formats` is `true`, the bare `http://` and `https://` forms wo
 
 Requires **libcurl**. AWS S3 request signing and Azure Blob support are compiled into the module.
 
+## See also
+
+- [Chapter 18: Audio Files and Streaming Sources](../../media/audio-files-and-streaming.mdx)
+
 **Source:** `src/mod/applications/mod_http_cache`, `conf/vanilla/autoload_configs/http_cache.conf.xml`

--- a/docs/module-reference/applications/mod_http_cache.mdx
+++ b/docs/module-reference/applications/mod_http_cache.mdx
@@ -15,6 +15,15 @@ Beyond plain HTTP, the module can read from and write to object storage: it sign
 
 Operators reach for `mod_http_cache` to play media referenced by URL in the dialplan without re-downloading it on every call, and to move recordings to and from cloud storage.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: http_cache.conf.xml](#configuration-http_cacheconfxml)
+- [API Commands](#api-commands)
+- [Dialplan Usage](#dialplan-usage)
+- [Dependencies](#dependencies)
+- [See also](#see-also)
+
 ## Loading the Module
 
 The module is **not in the default load set**; it has no entry in `conf/vanilla/autoload_configs/modules.conf.xml`. Add a load line and restart, or load it at runtime:

--- a/docs/module-reference/applications/mod_http_cache.mdx
+++ b/docs/module-reference/applications/mod_http_cache.mdx
@@ -36,8 +36,8 @@ The `<settings>` section controls the cache and the HTTP client.
 | Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `enable-file-formats` | Register the `http://` and `https://` file formats so URLs can be passed directly to `playback`, `record`, and similar applications. The `http_cache://` format is always available regardless of this setting. **Do not enable when `mod_httapi` is loaded** — both modules claim the `http`/`https` formats. | `true` / `false` | `false` |
-| `max-urls` | Maximum number of URLs tracked in the cache index. | Integer | `10000` |
-| `location` | Local directory where cached documents are stored. | Filesystem path | `$${cache_dir}` |
+| `max-urls` | Maximum number of URLs tracked in the cache index. | Integer | `4000` (vanilla conf ships `10000`) |
+| `location` | Local directory where cached documents are stored. | Filesystem path | `${base_dir}/http_cache` (vanilla conf ships `$${cache_dir}`) |
 | `default-max-age` | Cache lifetime, in seconds, applied when the origin server does not specify one. | Integer (seconds) | `86400` |
 | `prefetch-thread-count` | Number of background threads that service `http_prefetch` requests. Must be greater than 0. | Integer | `8` |
 | `prefetch-queue-size` | Maximum number of queued prefetch requests. Must be greater than 0. | Integer | `100` |

--- a/docs/module-reference/applications/mod_lcr.mdx
+++ b/docs/module-reference/applications/mod_lcr.mdx
@@ -13,6 +13,16 @@ sidebar_label: "mod_lcr"
 
 The module is appropriate for carriers or resellers who maintain a rate deck in MySQL or PostgreSQL and want FreeSWITCH to automatically select among multiple upstream providers. It also registers a custom dialplan so that the context name in a SIP profile can be set to an LCR profile name, directing all calls through the LCR engine without explicit dialplan entries. In addition, it registers a `lcr://` endpoint that can be dialed directly from a bridge application.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: lcr.conf.xml](#configuration-lcrconfxml)
+- [Dialplan Applications](#dialplan-applications)
+- [Endpoint and Custom Dialplan](#endpoint-and-custom-dialplan)
+- [API Commands](#api-commands)
+- [Channel Variables](#channel-variables)
+- [Dependencies](#dependencies)
+
 ## Loading the Module
 
 The module name for `load` and `modules.conf.xml` is `mod_lcr`. In the vanilla default configuration it is **not** loaded; the entry is commented out:

--- a/docs/module-reference/applications/mod_nibblebill.mdx
+++ b/docs/module-reference/applications/mod_nibblebill.mdx
@@ -13,6 +13,14 @@ sidebar_label: "mod_nibblebill"
 
 Reach for this module when you need prepaid calling card or wholesale VoIP billing where you must cap expenditure per call, warn callers at a low-balance threshold, and guarantee that a zero-balance account cannot run indefinitely.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: nibblebill.conf.xml](#configuration-nibblebillconfxml)
+- [Dialplan Applications](#dialplan-applications)
+- [API Commands](#api-commands)
+- [Channel Variables](#channel-variables)
+
 ## Loading the Module
 
 The module name is `mod_nibblebill`. In the vanilla FreeSWITCH installation it is **commented out** in `conf/vanilla/autoload_configs/modules.conf.xml` and is not loaded by default. To enable it, uncomment the entry:

--- a/docs/module-reference/applications/mod_osp.mdx
+++ b/docs/module-reference/applications/mod_osp.mdx
@@ -13,6 +13,15 @@ sidebar_label: "mod_osp"
 
 The module is appropriate when interconnect partners or a wholesale carrier require OSP-based authorization and CDR reporting. It supports SIP, H.323, IAX, and Skype signaling protocols and can operate in either direct (FreeSWITCH is the originating device) or indirect (FreeSWITCH sits behind an access proxy) work mode.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: osp.conf.xml](#configuration-ospconfxml)
+- [Dialplan Applications](#dialplan-applications)
+- [API Commands](#api-commands)
+- [Channel Variables](#channel-variables)
+- [Dependencies](#dependencies)
+
 ## Loading the Module
 
 The module is **not** present in the default vanilla `modules.conf.xml` and is not loaded automatically. Add the following line to `autoload_configs/modules.conf.xml` to enable it at startup, or load it at runtime from `fs_cli`:

--- a/docs/module-reference/applications/mod_prefix.mdx
+++ b/docs/module-reference/applications/mod_prefix.mdx
@@ -13,6 +13,12 @@ sidebar_label: "mod_prefix"
 
 Use this module when you need sub-millisecond, read-heavy prefix lookups on datasets that fit comfortably in memory and can be atomically reloaded at runtime without dropping active calls.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: prefix.conf.xml](#configuration-prefixconfxml)
+- [API Commands](#api-commands)
+
 ## Loading the Module
 
 The module name for `modules.conf.xml` and the `load` command is `mod_prefix`. It is **not** included in the default vanilla `autoload_configs/modules.conf.xml` and must be added manually:

--- a/docs/module-reference/applications/mod_random.mdx
+++ b/docs/module-reference/applications/mod_random.mdx
@@ -13,6 +13,11 @@ sidebar_label: "mod_random"
 
 Operators running FreeSWITCH on virtual machines or embedded hardware where the kernel entropy pool drains quickly — causing `getrandom()` or `/dev/urandom` reads to block — can load this module to keep the pool supplied with call-derived randomness. It requires no configuration and exposes no dialplan applications or API commands.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Dependencies](#dependencies)
+
 ## Loading the Module
 
 The module name for `load` and `modules.conf.xml` is `mod_random`.

--- a/docs/module-reference/applications/mod_snapshot.mdx
+++ b/docs/module-reference/applications/mod_snapshot.mdx
@@ -13,6 +13,13 @@ sidebar_label: "mod_snapshot"
 
 Use this module when you need to capture audio that already happened — for example, capturing the few seconds before a caller pressed a key — without recording the entire call from the beginning. Once started, the buffer rolls continuously; a snap action writes whatever is currently in it to a timestamped WAV file in the FreeSWITCH sounds directory.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Dialplan Applications](#dialplan-applications)
+- [API Commands](#api-commands)
+- [Channel Variables](#channel-variables)
+
 ## Loading the Module
 
 The module name is `mod_snapshot`. It is **not** present in the default vanilla `autoload_configs/modules.conf.xml` and must be added manually:

--- a/docs/module-reference/applications/mod_translate.mdx
+++ b/docs/module-reference/applications/mod_translate.mdx
@@ -13,6 +13,15 @@ sidebar_label: "mod_translate"
 
 Operators reach for this module when numbers arrive in mixed or non-canonical formats — local short-dial, E.164 with a `+`, 10-digit NANP, or international prefixes — and need a single, configurable place to canonicalize them before routing. It is also registered as a dialplan driver so it can rewrite destination number, caller ID number, and ANI atomically before the main dialplan runs.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: translate.conf.xml](#configuration-translateconfxml)
+- [Dialplan Applications](#dialplan-applications)
+- [API Commands](#api-commands)
+- [Dialplan Driver](#dialplan-driver)
+- [Channel Variables](#channel-variables)
+
 ## Loading the Module
 
 The module name for `load` / `modules.conf.xml` is `mod_translate`. In the vanilla distribution it is **commented out** and must be explicitly enabled:

--- a/docs/module-reference/applications/mod_video_filter.mdx
+++ b/docs/module-reference/applications/mod_video_filter.mdx
@@ -13,6 +13,13 @@ sidebar_label: "mod_video_filter"
 
 Reach for this module when you need virtual backgrounds in a video conference, green-screen compositing in a conferencing bridge, or transparent-overlay watermarks on a live video stream. It lives under `src/mod/applications` and operates entirely through media bugs — no extra media processing threads are started.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Dialplan Applications](#dialplan-applications)
+- [API Commands](#api-commands)
+- [Channel Variables](#channel-variables)
+
 ## Loading the Module
 
 The module load name is `mod_video_filter`. It is **not** present in the vanilla `autoload_configs/modules.conf.xml` and must be added manually. Add the following line to the Applications section of `modules.conf.xml`:

--- a/docs/module-reference/applications/mod_vmd.mdx
+++ b/docs/module-reference/applications/mod_vmd.mdx
@@ -15,6 +15,15 @@ Operators use this module when originating calls that may land on a voicemail bo
 
 > **Note:** The FreeSWITCH source logs a deprecation notice at CRITICAL log level (`SWITCH_LOG_CRIT`) at load time and directs operators to migrate to `mod_avmd`, which is the actively maintained successor.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration](#configuration)
+- [Dialplan Applications](#dialplan-applications)
+- [API Commands](#api-commands)
+- [Channel Variables](#channel-variables)
+- [Events](#events)
+
 ## Loading the Module
 
 The module name is `mod_vmd`. It is **not** present in the default vanilla `autoload_configs/modules.conf.xml` and must be added manually:

--- a/docs/module-reference/applications/mod_voicemail_ivr.mdx
+++ b/docs/module-reference/applications/mod_voicemail_ivr.mdx
@@ -148,4 +148,8 @@ The application runs three sequential phases, each resolved to a named menu func
 |---|---|---|
 | `voicemail_authorized` | Read | When set to `true` on the channel before calling `voicemail_ivr`, the authentication screen is skipped and the caller proceeds directly to the main menu. |
 
+## See also
+
+- [Chapter 19: Voicemail](../../applications/voicemail.mdx)
+
 **Source:** `src/mod/applications/mod_voicemail_ivr`, `conf/vanilla/autoload_configs/voicemail_ivr.conf.xml`

--- a/docs/module-reference/applications/mod_voicemail_ivr.mdx
+++ b/docs/module-reference/applications/mod_voicemail_ivr.mdx
@@ -13,6 +13,14 @@ sidebar_label: "mod_voicemail_ivr"
 
 The module delegates all storage operations to configurable back-end API commands — by default the `vm_fsdb_*` family provided by `mod_voicemail` — so the IVR logic is decoupled from the storage layer. Reach for this module when you need a phone-based voicemail retrieval experience on top of an existing voicemail store.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: voicemail_ivr.conf.xml](#configuration-voicemail_ivrconfxml)
+- [Dialplan Applications](#dialplan-applications)
+- [Channel Variables](#channel-variables)
+- [See also](#see-also)
+
 ## Loading the Module
 
 The module name for `load` and `modules.conf.xml` is `mod_voicemail_ivr`. It is **not** present in the vanilla `modules.conf.xml` load list (only `mod_voicemail` appears there); you must add the entry manually and then either restart FreeSWITCH or run `load mod_voicemail_ivr` from `fs_cli`.

--- a/docs/module-reference/asr-tts/mod_pocketsphinx.mdx
+++ b/docs/module-reference/asr-tts/mod_pocketsphinx.mdx
@@ -13,6 +13,14 @@ sidebar_label: "mod_pocketsphinx"
 
 Reach for this module when you need basic, low-latency, fully on-premise speech recognition with a tightly constrained vocabulary. It supports 8 kHz (narrowband) and 16 kHz (wideband) audio and returns results as an XML result block including a confidence score.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: pocketsphinx.conf.xml](#configuration-pocketsphinxconfxml)
+- [Dialplan Applications](#dialplan-applications)
+- [Runtime Parameters (per-session)](#runtime-parameters-per-session)
+- [Dependencies](#dependencies)
+
 ## Loading the Module
 
 The module name is `mod_pocketsphinx`. In the vanilla `modules.conf.xml` it is commented out and is **not** loaded by default:

--- a/docs/module-reference/asr-tts/mod_pocketsphinx.mdx
+++ b/docs/module-reference/asr-tts/mod_pocketsphinx.mdx
@@ -42,7 +42,7 @@ Model files are resolved relative to `$${grammar_dir}/model/<model-name>`. The d
 | `start-input-timers` | If `true`, input timers (`no-input-timeout` and `speech-timeout`) start immediately when the grammar is loaded rather than waiting for a caller-side start command. | `true` / `false` | `false` |
 | `no-input-timeout` | Milliseconds of silence before the engine reports a no-input result (requires input timers to be active). | Integer (ms) | `4000` |
 | `speech-timeout` | Milliseconds after speech onset before the engine forces end-of-utterance processing (requires input timers to be active). | Integer (ms) | `1000` |
-| `confidence_threshold` | Minimum confidence score (0–100 integer) required to return a match; results below this value produce a no-match result instead. `0` disables the check. Note the underscore: in the config file this parameter is parsed as `confidence_threshold`, so a hyphenated `confidence-threshold` entry is silently ignored. (The per-session runtime parameter set via `detect_speech set` uses the hyphenated `confidence-threshold`.) | Integer (0–100) | `0` |
+| `confidence_threshold` | Minimum confidence score (0–100 integer) required to return a match; results below this value produce a no-match result instead. `0` disables the check. Note the underscore: in the config file this parameter is parsed as `confidence_threshold`, so a hyphenated `confidence-threshold` entry is silently ignored. (The per-session runtime parameter set via `detect_speech param` uses the hyphenated `confidence-threshold`.) | Integer (0–100) | `0` |
 
 Example excerpt from the shipped `pocketsphinx.conf.xml`:
 
@@ -69,17 +69,17 @@ Example excerpt from the shipped `pocketsphinx.conf.xml`:
 |---|---|---|
 | `detect_speech` | Open a PocketSphinx recognition session, load a grammar, and begin listening | `pocketsphinx <grammar-name> <grammar-name> [<param>=<value> ...]` |
 
-The grammar argument is a name or path resolved to a `.gram` JSGF file. Per-session parameters (`no-input-timeout`, `speech-timeout`, `start-input-timers`, `confidence-threshold`) can be set after opening by calling `detect_speech` with the `set` sub-command.
+The grammar argument is a name or path resolved to a `.gram` JSGF file. Per-session parameters (`no-input-timeout`, `speech-timeout`, `start-input-timers`, `confidence-threshold`) can be set after opening by calling `detect_speech` with the `param` sub-command.
 
 ```xml
 <!-- Open a recognition session with grammar "menu" -->
 <action application="detect_speech" data="pocketsphinx menu menu"/>
 
 <!-- Override the no-input timeout for this session -->
-<action application="detect_speech" data="set no-input-timeout 5000"/>
+<action application="detect_speech" data="param no-input-timeout 5000"/>
 
 <!-- Start input timers explicitly -->
-<action application="detect_speech" data="start_input_timers"/>
+<action application="detect_speech" data="start-input-timers"/>
 
 <!-- Pause recognition -->
 <action application="detect_speech" data="pause"/>
@@ -95,7 +95,7 @@ Results are delivered to the dialplan as `DETECTED_SPEECH` events. The result pa
 
 ## Runtime Parameters (per-session)
 
-The following parameters can be adjusted per-session via `detect_speech set <param> <value>` after the session is opened. They override the global defaults for that session only.
+The following parameters can be adjusted per-session via `detect_speech param <name> <value>` after the session is opened. They override the global defaults for that session only.
 
 | Parameter | Purpose | Accepted Values |
 |---|---|---|

--- a/docs/module-reference/asr-tts/mod_tts_commandline.mdx
+++ b/docs/module-reference/asr-tts/mod_tts_commandline.mdx
@@ -13,6 +13,15 @@ sidebar_label: "mod_tts_commandline"
 
 Reach for this module when you want to integrate a TTS engine that ships its own CLI tool (for example `text2wave` from Festival, `espeak`, `flite`, or any custom synthesizer) without writing a native FreeSWITCH module. It imposes no library dependency beyond the external program itself.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: tts_commandline.conf.xml](#configuration-tts_commandlineconfxml)
+- [Dialplan Applications](#dialplan-applications)
+- [API Commands](#api-commands)
+- [Channel Variables](#channel-variables)
+- [Events](#events)
+
 ## Loading the Module
 
 The module name is `mod_tts_commandline`. In the vanilla distribution it is present but **commented out** — it is not loaded by default:

--- a/docs/module-reference/data-stores/mod_hiredis.mdx
+++ b/docs/module-reference/data-stores/mod_hiredis.mdx
@@ -13,6 +13,16 @@ sidebar_label: "mod_hiredis"
 
 Reach for this module when you need per-resource call counts or rate-limited bridges that survive across multiple FreeSWITCH instances — Redis provides the shared, atomic counter store. It also exposes a general-purpose raw Redis command interface usable from both the dialplan and the FreeSWITCH API.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: hiredis.conf.xml](#configuration-hiredisconfxml)
+- [Dialplan Applications](#dialplan-applications)
+- [API Commands](#api-commands)
+- [Channel Variables](#channel-variables)
+- [Dependencies](#dependencies)
+- [See also](#see-also)
+
 ## Loading the Module
 
 The module name to load is `mod_hiredis`. It is **not** present in the default vanilla `modules.conf.xml` and must be added manually:

--- a/docs/module-reference/data-stores/mod_hiredis.mdx
+++ b/docs/module-reference/data-stores/mod_hiredis.mdx
@@ -43,7 +43,7 @@ The configuration file is `autoload_configs/hiredis.conf.xml`. It defines one or
 | `hostname` | Redis server hostname or IP | string | `localhost` |
 | `port` | Redis server TCP port | integer | `6379` |
 | `password` | Redis `AUTH` password (optional) | string | *(none)* |
-| `timeout_ms` | Connect and command timeout in milliseconds | integer | `500` |
+| `timeout_ms` | Connect and command timeout in milliseconds (the hyphenated spelling `timeout-ms` is also accepted) | integer | `500` |
 | `max-connections` | Connection pool size per connection entry | positive integer | `3` |
 
 Multiple `<connection>` elements may be listed under a single profile. If the primary connection fails, the module tries each subsequent connection in order.

--- a/docs/module-reference/data-stores/mod_hiredis.mdx
+++ b/docs/module-reference/data-stores/mod_hiredis.mdx
@@ -127,4 +127,8 @@ OK
 
 `mod_hiredis` requires **libhiredis** (the official C client for Redis) which is not included in the FreeSWITCH source tree and is not built by default. Install `libhiredis-dev` (Debian/Ubuntu) or `hiredis-devel` (RHEL/CentOS) before compiling the module.
 
+## See also
+
+- [Chapter 23: Utility Applications](../../applications/utility-applications.mdx)
+
 **Source:** `src/mod/applications/mod_hiredis`, `conf/vanilla/autoload_configs/hiredis.conf.xml`

--- a/docs/module-reference/data-stores/mod_memcache.mdx
+++ b/docs/module-reference/data-stores/mod_memcache.mdx
@@ -13,6 +13,15 @@ sidebar_label: "mod_memcache"
 
 Reach for this module when you need a fast, shared, in-memory key–value store across multiple FreeSWITCH nodes — for example, to cache per-call data that other nodes must read, to implement cross-box counters, or to serve audio prompts from memory rather than disk.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: memcache.conf.xml](#configuration-memcacheconfxml)
+- [API Commands](#api-commands)
+- [File Format Interface](#file-format-interface)
+- [Dependencies](#dependencies)
+- [See also](#see-also)
+
 ## Loading the Module
 
 The module name for `load` and `modules.conf.xml` is `mod_memcache`. It is **not** present in the vanilla `autoload_configs/modules.conf.xml` and must be added manually before it will load at startup.

--- a/docs/module-reference/data-stores/mod_memcache.mdx
+++ b/docs/module-reference/data-stores/mod_memcache.mdx
@@ -35,7 +35,7 @@ The module reads a single settings block from `memcache.conf`. The file is reloa
 
 | Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
-| `memcache-servers` | Comma-separated list of Memcached server addresses. Each entry may be `host` or `host:port`. | String (one or more `host[:port]` entries) | `localhost` |
+| `memcache-servers` | Comma-separated list of Memcached server addresses. Each entry may be `host` or `host:port`. **Required** — the module flags this param as required and the compiled default is empty; `localhost` comes only from the shipped configuration. | String (one or more `host[:port]` entries) | `""` (vanilla conf ships `localhost`) |
 
 Real example from the shipped conf:
 

--- a/docs/module-reference/data-stores/mod_memcache.mdx
+++ b/docs/module-reference/data-stores/mod_memcache.mdx
@@ -115,4 +115,8 @@ The scheme does not support seeking (`offset_pos` is rejected at open time).
 
 ---
 
+## See also
+
+- [Chapter 23: Utility Applications](../../applications/utility-applications.mdx)
+
 **Source:** `src/mod/applications/mod_memcache`, `conf/vanilla/autoload_configs/memcache.conf.xml`

--- a/docs/module-reference/data-stores/mod_mongo.mdx
+++ b/docs/module-reference/data-stores/mod_mongo.mdx
@@ -120,4 +120,8 @@ The first token (`mongo`) selects this module's limit backend.
 
 `mod_mongo` requires **libmongoc** (the MongoDB C Driver, package `libmongoc-dev` on Debian/Ubuntu). The build system checks for this library via the `HAVE_MONGOC` autoconf flag and refuses to compile the module if it is absent. libmongoc is not included in the FreeSWITCH source tree and must be installed separately before building this module.
 
+## See also
+
+- [Chapter 23: Utility Applications](../../applications/utility-applications.mdx)
+
 **Source:** `src/mod/applications/mod_mongo`, `conf/vanilla/autoload_configs/mongo.conf.xml`

--- a/docs/module-reference/data-stores/mod_mongo.mdx
+++ b/docs/module-reference/data-stores/mod_mongo.mdx
@@ -13,6 +13,15 @@ sidebar_label: "mod_mongo"
 
 Reach for this module when you need to look up caller data, routing tables, or other records stored in MongoDB from within the dialplan, or when you need a distributed concurrency counter that survives across multiple FreeSWITCH instances.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: mongo.conf.xml](#configuration-mongoconfxml)
+- [API Commands](#api-commands)
+- [Limit Backend](#limit-backend)
+- [Dependencies](#dependencies)
+- [See also](#see-also)
+
 ## Loading the Module
 
 The module name for the `load` command and `modules.conf.xml` is `mod_mongo`.

--- a/docs/module-reference/data-stores/mod_redis.mdx
+++ b/docs/module-reference/data-stores/mod_redis.mdx
@@ -13,6 +13,16 @@ sidebar_label: "mod_redis"
 
 **This module is deprecated.** The source emits a `SWITCH_LOG_CRIT` warning on every call: "mod_redis is deprecated and will be removed in FS 1.8. Check out mod_hiredis." For new deployments use `mod_hiredis` instead.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: redis.conf.xml](#configuration-redisconfxml)
+- [Dialplan Applications](#dialplan-applications)
+- [API Commands](#api-commands)
+- [Channel Variables](#channel-variables)
+- [Dependencies](#dependencies)
+- [See also](#see-also)
+
 ## Loading the Module
 
 The module name is `mod_redis`. It does **not** appear in the vanilla `autoload_configs/modules.conf.xml` and is not loaded by default. To enable it, add the following line to the `<modules>` section of `autoload_configs/modules.conf.xml`:

--- a/docs/module-reference/data-stores/mod_redis.mdx
+++ b/docs/module-reference/data-stores/mod_redis.mdx
@@ -79,4 +79,8 @@ The module increments a Redis key named `realm_resource` on call start and decre
 
 `mod_redis` bundles the `credis` C client library (files `credis.c` and `credis.h` in the module source directory). No external Redis client library such as `hiredis` is required. A running Redis server reachable at the configured `host` and `port` is required at runtime.
 
+## See also
+
+- [Chapter 23: Utility Applications](../../applications/utility-applications.mdx)
+
 **Source:** `src/mod/applications/mod_redis`, `conf/vanilla/autoload_configs/redis.conf.xml`

--- a/docs/module-reference/dialplans/mod_dialplan_asterisk.mdx
+++ b/docs/module-reference/dialplans/mod_dialplan_asterisk.mdx
@@ -13,6 +13,14 @@ sidebar_label: "mod_dialplan_asterisk"
 
 Operators reach for this module when migrating an existing Asterisk deployment to FreeSWITCH without rewriting the entire dialplan at once. It is also useful for teams already comfortable with Asterisk's `exten =>` notation who want to keep that style while gaining FreeSWITCH's media capabilities.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Selecting the Dialplan](#selecting-the-dialplan)
+- [Configuration: extensions.conf](#configuration-extensionsconf)
+- [Dialplan Applications](#dialplan-applications)
+- [Channel Variables](#channel-variables)
+
 ## Loading the Module
 
 The module name for `load` and `modules.conf.xml` is `mod_dialplan_asterisk`. It is included in the default vanilla load set — `/Users/brian/workdir/freeswitch-docs/freeswitch/conf/vanilla/autoload_configs/modules.conf.xml` contains an uncommented `<load module="mod_dialplan_asterisk"/>` entry, so it loads automatically on a stock build.

--- a/docs/module-reference/dialplans/mod_dialplan_directory.mdx
+++ b/docs/module-reference/dialplans/mod_dialplan_directory.mdx
@@ -13,6 +13,14 @@ sidebar_label: "mod_dialplan_directory"
 
 Use this module when call-routing data already lives in a directory service or when you need dial-plan changes to take effect instantly across a cluster without reloading XML on each node. Each inbound call triggers a directory query filtered by the dialed extension and, optionally, the context; the module then executes each returned `callflow` value as a FreeSWITCH application invocation.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: dialplan_directory.conf.xml](#configuration-dialplan_directoryconfxml)
+- [Selecting This Dialplan](#selecting-this-dialplan)
+- [How Routing Works](#how-routing-works)
+- [Dependencies](#dependencies)
+
 ## Loading the Module
 
 The module name for `load` / `modules.conf.xml` is `mod_dialplan_directory`. It is **not** loaded by default in the vanilla configuration — the entry in `conf/vanilla/autoload_configs/modules.conf.xml` is commented out:

--- a/docs/module-reference/endpoints/mod_h323.mdx
+++ b/docs/module-reference/endpoints/mod_h323.mdx
@@ -13,6 +13,15 @@ sidebar_label: "mod_h323"
 
 Reach for this module when you need to interoperate with legacy H.323 equipment — PBXs, gatekeepers, video-conferencing endpoints, or H.323 trunks — and need gatekeeper registration, FastStart, H.245 tunneling, or T.38 fax relay over an H.323 leg.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: h323.conf.xml](#configuration-h323confxml)
+- [Originating and Receiving Calls](#originating-and-receiving-calls)
+- [Channel Variables](#channel-variables)
+- [Dependencies](#dependencies)
+- [See also](#see-also)
+
 ## Loading the Module
 
 The module name to load is `mod_h323`. It is **not** present in the vanilla `autoload_configs/modules.conf.xml` and must be added manually before it will load at startup.

--- a/docs/module-reference/endpoints/mod_h323.mdx
+++ b/docs/module-reference/endpoints/mod_h323.mdx
@@ -129,4 +129,8 @@ The following channel variables are read by the module at runtime:
 
 `mod_h323` requires **PTLib** and **ooH323c** (the Open H.323 C library) to be installed and discoverable by the build system before compilation. These libraries are not included with FreeSWITCH and are not built by default. Install them from your distribution's package manager or build from source before running `./configure` and `make mod_h323`.
 
+## See also
+
+- [Chapter 11: Other Endpoints](../../users-endpoints/other-endpoints.mdx)
+
 **Source:** `src/mod/endpoints/mod_h323`, `src/mod/endpoints/mod_h323/h323.conf.xml`

--- a/docs/module-reference/endpoints/mod_opal.mdx
+++ b/docs/module-reference/endpoints/mod_opal.mdx
@@ -126,4 +126,8 @@ Both are available from the [OPAL project](https://www.opalvoip.org/). The modul
 
 ---
 
+## See also
+
+- [Chapter 11: Other Endpoints](../../users-endpoints/other-endpoints.mdx)
+
 **Source:** `src/mod/endpoints/mod_opal`, `conf/vanilla/autoload_configs/opal.conf.xml`

--- a/docs/module-reference/endpoints/mod_opal.mdx
+++ b/docs/module-reference/endpoints/mod_opal.mdx
@@ -13,6 +13,19 @@ sidebar_label: "mod_opal"
 
 Reach for `mod_opal` when you need to interoperate with H.323 endpoints (hardware video-conferencing units, legacy PBXes, or gatekeepers) or IAX2 peers, without deploying a separate gateway. The module also supports T.38 fax relay on H.323 calls when built against a capable OPAL version.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: opal.conf.xml](#configuration-opalconfxml)
+- [Originating Calls](#originating-calls)
+- [Receiving Calls](#receiving-calls)
+- [Gatekeeper Registration](#gatekeeper-registration)
+- [Dialplan Applications](#dialplan-applications)
+- [API Commands](#api-commands)
+- [Channel Variables](#channel-variables)
+- [Dependencies](#dependencies)
+- [See also](#see-also)
+
 ## Loading the Module
 
 The module name for `load` and `modules.conf.xml` is **`mod_opal`**. It is **not** present in the default vanilla `modules.conf.xml` and must be added manually:

--- a/docs/module-reference/event-handlers/mod_amqp.mdx
+++ b/docs/module-reference/event-handlers/mod_amqp.mdx
@@ -197,4 +197,8 @@ Log records are captured from the FreeSWITCH logging subsystem and serialized to
 
 `mod_amqp` requires `librabbitmq` (the `rabbitmq-c` C client library) to compile and run. On Debian/Ubuntu this is typically available as the `librabbitmq-dev` package. The module includes header guards for both the legacy `amqp.h` layout and the newer `rabbitmq-c/amqp.h` layout (version 0.12 and above).
 
+## See also
+
+- [Chapter 25: The Event Socket](../../integration/event-socket.mdx)
+
 **Source:** `src/mod/event_handlers/mod_amqp`, `conf/vanilla/autoload_configs/amqp.conf.xml`

--- a/docs/module-reference/event-handlers/mod_amqp.mdx
+++ b/docs/module-reference/event-handlers/mod_amqp.mdx
@@ -13,6 +13,16 @@ sidebar_label: "mod_amqp"
 
 Each profile type connects over a prioritized list of connections and reconnects automatically on failure. Messages are queued internally so that a broker outage or back-pressure event does not block the FreeSWITCH core. A circuit-breaker drops new events for a configurable window when the internal queue fills.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: amqp.conf.xml](#configuration-amqpconfxml)
+- [API Commands](#api-commands)
+- [How the Command Consumer Works](#how-the-command-consumer-works)
+- [How the Logging Profile Works](#how-the-logging-profile-works)
+- [Dependencies](#dependencies)
+- [See also](#see-also)
+
 ## Loading the Module
 
 The module is **not** loaded by default. In the vanilla `modules.conf.xml` the entry is commented out:

--- a/docs/module-reference/event-handlers/mod_amqp.mdx
+++ b/docs/module-reference/event-handlers/mod_amqp.mdx
@@ -87,7 +87,7 @@ Up to four connections may be listed per profile. The module tries each in order
 | `exchange-durable` | Declare the exchange as durable | `true` / `false` | `true` |
 | `log-levels` | Comma-separated list of log levels to capture | `debug`, `info`, `notice`, `warning`, `err`, `crit`, `alert` | (none) |
 | `send_queue_size` | Maximum number of log messages to buffer | Integer | `5000` |
-| `reconnect_interval_ms` | Milliseconds to wait between reconnection attempts | Integer | `1000` |
+| `reconnect_interval_ms` | Milliseconds to wait between reconnection attempts. Unlike the producer and command profiles, the logging profile does not initialize this value, so the compiled default is `0` — with which the reconnect loop tight-spins. Set it explicitly. | Integer | `0` (vanilla conf ships `1000`) |
 
 ### Example configuration (trimmed from shipped file)
 

--- a/docs/module-reference/event-handlers/mod_cdr_pg_csv.mdx
+++ b/docs/module-reference/event-handlers/mod_cdr_pg_csv.mdx
@@ -53,7 +53,7 @@ The module links against `libpq` (the PostgreSQL C client library). Ensure the P
 
 Each `<field>` element in `<schema>` maps one FreeSWITCH channel variable to one database column. Three optional attributes control quoting and null handling:
 
-| Attribute | Purpose | Values | Default |
+| Attribute | Purpose | Accepted Values | Default |
 |-----------|---------|--------|---------|
 | `var` | FreeSWITCH channel variable name to read (required) | Any channel variable name | — |
 | `column` | PostgreSQL column name to write; defaults to `var` if omitted | Any valid column name | same as `var` |

--- a/docs/module-reference/event-handlers/mod_cdr_pg_csv.mdx
+++ b/docs/module-reference/event-handlers/mod_cdr_pg_csv.mdx
@@ -13,6 +13,16 @@ sidebar_label: "mod_cdr_pg_csv"
 
 Reach for this module when you need CDRs in a relational database for reporting, billing, or compliance without adding a middleware layer. On database failure the module automatically spools records to a local flat file (CSV values or full SQL statements) so no records are silently dropped.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: cdr_pg_csv.conf.xml](#configuration-cdr_pg_csvconfxml)
+- [Call Legs and Recording Trigger](#call-legs-and-recording-trigger)
+- [Database Schema](#database-schema)
+- [Disk Spool Fallback](#disk-spool-fallback)
+- [Dependencies](#dependencies)
+- [See also](#see-also)
+
 ## Loading the Module
 
 The module is **not** included in the default vanilla `autoload_configs/modules.conf.xml` and must be added manually. Add the following line to your `modules.conf.xml` under the `event_handlers` group, then reload or restart FreeSWITCH:

--- a/docs/module-reference/event-handlers/mod_cdr_pg_csv.mdx
+++ b/docs/module-reference/event-handlers/mod_cdr_pg_csv.mdx
@@ -135,4 +135,8 @@ Each spool file grows until it reaches the platform `UINT_MAX` byte limit, at wh
 - Debian/Ubuntu: `apt-get install libpq-dev`
 - RHEL/CentOS/Rocky: `dnf install postgresql-devel`
 
+## See also
+
+- [Chapter 27: Call Detail Records](../../integration/call-detail-records.mdx)
+
 **Source:** `src/mod/event_handlers/mod_cdr_pg_csv`, `conf/vanilla/autoload_configs/cdr_pg_csv.conf.xml`

--- a/docs/module-reference/event-handlers/mod_erlang_event.mdx
+++ b/docs/module-reference/event-handlers/mod_erlang_event.mdx
@@ -164,4 +164,8 @@ Events delivered to subscribed Erlang pids are encoded as Erlang terms tagged `e
 
 `mod_erlang_event` links against the Erlang `ei` (erl_interface) C library, which ships with Erlang/OTP but is not present on most systems by default. Install the `erlang-dev` (Debian/Ubuntu) or `erlang-devel` (RHEL/CentOS) package, or provide the OTP source tree, before building FreeSWITCH with this module enabled. The `epmd` daemon (Erlang Port Mapper Daemon) must also be reachable at runtime; the module attempts to start it automatically via `epmd -daemon` if it is in `$PATH`.
 
+## See also
+
+- [Chapter 25: The Event Socket](../../integration/event-socket.mdx)
+
 **Source:** `src/mod/event_handlers/mod_erlang_event`, `conf/vanilla/autoload_configs/erlang_event.conf.xml`

--- a/docs/module-reference/event-handlers/mod_erlang_event.mdx
+++ b/docs/module-reference/event-handlers/mod_erlang_event.mdx
@@ -13,6 +13,16 @@ sidebar_label: "mod_erlang_event"
 
 Reach for this module when your call-processing logic is written in Erlang or Elixir and you want to exchange structured Erlang terms with FreeSWITCH rather than parsing plain-text ESL or JSON. It sits in `src/mod/event_handlers` alongside `mod_event_socket` and serves the same general purpose but over the binary Erlang wire protocol.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: erlang_event.conf.xml](#configuration-erlang_eventconfxml)
+- [Dialplan Applications](#dialplan-applications)
+- [API Commands](#api-commands)
+- [Erlang Protocol Messages](#erlang-protocol-messages)
+- [Dependencies](#dependencies)
+- [See also](#see-also)
+
 ## Loading the Module
 
 The module name is `mod_erlang_event`. It is **not** loaded by default in the vanilla configuration — the entry in `conf/vanilla/autoload_configs/modules.conf.xml` is commented out:

--- a/docs/module-reference/event-handlers/mod_event_multicast.mdx
+++ b/docs/module-reference/event-handlers/mod_event_multicast.mdx
@@ -13,6 +13,14 @@ sidebar_label: "mod_event_multicast"
 
 Use this module when you need multiple FreeSWITCH nodes to share event state — for example, to drive a distributed CDR processor, a shared presence or BLF system, or a custom monitoring dashboard that aggregates events from a cluster — without requiring a centralized message broker.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: event_multicast.conf.xml](#configuration-event_multicastconfxml)
+- [API Commands](#api-commands)
+- [Events](#events)
+- [Dependencies](#dependencies)
+
 ## Loading the Module
 
 The module name is `mod_event_multicast`. It is **not** loaded by default in the vanilla configuration; the entry in `modules.conf.xml` is commented out:

--- a/docs/module-reference/event-handlers/mod_fail2ban.mdx
+++ b/docs/module-reference/event-handlers/mod_fail2ban.mdx
@@ -13,6 +13,12 @@ sidebar_label: "mod_fail2ban"
 
 Use this module when you want to integrate FreeSWITCH SIP registration security with system-level IP blocking without modifying dialplan or writing custom scripts.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: fail2ban.conf.xml](#configuration-fail2banconfxml)
+- [Events](#events)
+
 ## Loading the Module
 
 The module is **not** included in the default vanilla `autoload_configs/modules.conf.xml` and must be added manually. Add the following line to your `modules.conf.xml` under the `event_handlers` group, then reload or restart FreeSWITCH:

--- a/docs/module-reference/event-handlers/mod_format_cdr.mdx
+++ b/docs/module-reference/event-handlers/mod_format_cdr.mdx
@@ -41,7 +41,7 @@ The configuration file is `conf/autoload_configs/format_cdr.conf.xml`. It contai
 | `prefix-a-leg` | When `true`, prepend `a_` to the CDR filename for A-leg calls. Has no effect on B-legs. | `true`, `false` | `false` (code default; vanilla conf sets `true`) |
 | `log-http-and-disk` | When `true`, write to disk even when HTTP delivery succeeds. | `true`, `false` | `false` |
 | `encode` | HTTP POST body encoding. `true` = URL-encoded (`application/x-www-form-urlencoded`), `false` = plaintext, `base64` = base64-encoded, `textxml` = raw body with `Content-Type: text/xml`, `appljson` = raw body with `Content-Type: application/json`. | `true`, `false`, `base64`, `textxml`, `appljson` | _(none set; conf example uses `true`)_ |
-| `encode-values` | When `true`, URL-encode individual JSON field values when generating JSON CDRs. Set to `false` for standard unescaped JSON. | `true`, `false` | `true` |
+| `encode-values` | When `true`, URL-encode individual JSON field values when generating JSON CDRs. Set to `false` for standard unescaped JSON. | `true`, `false` | `false` (code default; vanilla conf sets `true`) |
 | `retries` | Number of additional POST attempts after the first failure (so `retries=2` means up to 3 total attempts). | Non-negative integer | `0` |
 | `delay` | Seconds to wait between retry attempts. Automatically set to `5` if `retries` is non-zero and `delay` is `0`. | Non-negative integer | `0` (→ `5` when retries set) |
 | `timeout` | libcurl transfer timeout in seconds. `0` means no timeout. | Non-negative integer | `0` |

--- a/docs/module-reference/event-handlers/mod_format_cdr.mdx
+++ b/docs/module-reference/event-handlers/mod_format_cdr.mdx
@@ -89,4 +89,8 @@ Multiple profiles may coexist. Assign each a unique `name` attribute to run para
 
 `mod_format_cdr` does not register any custom `SWITCH_EVENT_CUSTOM` subclasses. It consumes `SWITCH_EVENT_TRAP` internally to detect SIGHUP for log rotation.
 
+## See also
+
+- [Chapter 27: Call Detail Records](../../integration/call-detail-records.mdx)
+
 **Source:** `src/mod/event_handlers/mod_format_cdr`, `conf/vanilla/autoload_configs/format_cdr.conf.xml`

--- a/docs/module-reference/event-handlers/mod_format_cdr.mdx
+++ b/docs/module-reference/event-handlers/mod_format_cdr.mdx
@@ -13,6 +13,14 @@ sidebar_label: "mod_format_cdr"
 
 The module lives in `src/mod/event_handlers` and registers an `on_reporting` state-handler callback. On SIGHUP (`SWITCH_EVENT_TRAP` with `Trapped-Signal: HUP`) the module rotates its log directories if `rotate` is enabled.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: format_cdr.conf.xml](#configuration-format_cdrconfxml)
+- [Channel Variables](#channel-variables)
+- [Events](#events)
+- [See also](#see-also)
+
 ## Loading the Module
 
 The module name is `mod_format_cdr`. It is **not** included in the vanilla `modules.conf.xml` default load set and must be added manually:

--- a/docs/module-reference/event-handlers/mod_graylog2.mdx
+++ b/docs/module-reference/event-handlers/mod_graylog2.mdx
@@ -13,6 +13,12 @@ sidebar_label: "mod_graylog2"
 
 Operators reach for this module when they need centralised, structured log aggregation from one or more FreeSWITCH nodes into Graylog2 (or a compatible receiver such as Logstash with the `gelf.rb` input). Session-specific channel variables can be automatically promoted to top-level GELF fields, which makes per-call filtering and alerting straightforward inside Graylog.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: graylog2.conf.xml](#configuration-graylog2confxml)
+- [Channel Variables](#channel-variables)
+
 ## Loading the Module
 
 The module name for `load` / `unload` is `mod_graylog2`. It is **not** enabled in the default vanilla load set — the entry in `autoload_configs/modules.conf.xml` is commented out:

--- a/docs/module-reference/event-handlers/mod_json_cdr.mdx
+++ b/docs/module-reference/event-handlers/mod_json_cdr.mdx
@@ -157,4 +157,8 @@ When one or more `url` parameters are present, the module opens a libcurl handle
 4. If all retry attempts fail, the CDR is written to `err-log-dir` (when `log-errors-to-disk` is `true`).
 5. When `queue-capacity` is set, CDRs are pushed to an in-process queue and processed by a background thread, preventing delivery latency from blocking the call-teardown path.
 
+## See also
+
+- [Chapter 27: Call Detail Records](../../integration/call-detail-records.mdx)
+
 **Source:** `src/mod/event_handlers/mod_json_cdr`, `src/mod/event_handlers/mod_json_cdr/conf/autoload_configs/json_cdr.conf.xml`

--- a/docs/module-reference/event-handlers/mod_json_cdr.mdx
+++ b/docs/module-reference/event-handlers/mod_json_cdr.mdx
@@ -13,6 +13,18 @@ sidebar_label: "mod_json_cdr"
 
 Reach for `mod_json_cdr` when your billing platform, data warehouse, or analytics pipeline consumes JSON rather than CSV or XML. It supports up to 20 HTTP endpoints with per-attempt retry, configurable payload encoding (raw JSON, URL-encoded form data, or Base64), mutual TLS, and per-channel log-directory overrides.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: json_cdr.conf.xml](#configuration-json_cdrconfxml)
+- [Dialplan Applications](#dialplan-applications)
+- [API Commands](#api-commands)
+- [Channel Variables](#channel-variables)
+- [JSON Document Schema](#json-document-schema)
+- [File Delivery](#file-delivery)
+- [HTTP Delivery](#http-delivery)
+- [See also](#see-also)
+
 ## Loading the Module
 
 The module is **not** loaded by default. The vanilla `modules.conf.xml` does not include an entry for it. Add it manually:

--- a/docs/module-reference/event-handlers/mod_json_cdr.mdx
+++ b/docs/module-reference/event-handlers/mod_json_cdr.mdx
@@ -46,7 +46,7 @@ All parameters live inside a `<settings>` block. No parameter is strictly requir
 | `rotate` | On SIGHUP, rotate the log directories into timestamped subdirectories (`YYYY-MM-DD-HH-MM-SS`). | `true`, `false` | `false` |
 | `log-http-and-disk` | Write every record to disk even when HTTP POST succeeds. Normally disk writing is skipped when a `url` is configured and the POST returns 2xx. | `true`, `false` | `false` |
 | `url` | HTTP or HTTPS endpoint to POST records to. Repeat the parameter up to 20 times to specify additional failover URLs. The session UUID is appended as `?uuid=<uuid>`. | URL string | None |
-| `timeout` | Total HTTP transaction timeout in seconds. `0` disables the timeout. | Integer ≥ 0 | `5` |
+| `timeout` | Total HTTP transaction timeout in seconds. `0` disables the timeout. | Integer ≥ 0 | `0` (vanilla conf ships `5`) |
 | `cred` | HTTP credentials in `username:password` form. When set, HTTP authentication is enabled using the `auth-scheme` (default `basic`). | String | None |
 | `auth-scheme` | HTTP authentication scheme. Prefix the value with `=` to use that scheme exclusively (e.g. `=digest`); without the prefix, schemes are ORed (libcurl picks). | `basic`, `digest`, `NTLM`, `GSS-NEGOTIATE`, `any` | `basic` |
 | `encode` | Encoding applied to the JSON payload before POST. `true` sends URL-encoded form data (`Content-Type: application/x-www-form-urlencoded`); `base64` sends Base64-encoded data (`Content-Type: application/x-www-form-base64-encoded`); `false` sends the raw JSON document (`Content-Type: application/json`). | `true`, `false`, `base64` | `false` |

--- a/docs/module-reference/event-handlers/mod_odbc_cdr.mdx
+++ b/docs/module-reference/event-handlers/mod_odbc_cdr.mdx
@@ -13,6 +13,14 @@ sidebar_label: "mod_odbc_cdr"
 
 Operators reach for this module when they need CDR data in a relational database without the intermediate step of parsing flat CSV files. It supports separate tables for A-legs and B-legs, an optional CSV fallback for failed inserts, and any ODBC-compatible database — including PostgreSQL, MySQL, and SQLite — through FreeSWITCH's unified DSN layer.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: odbc_cdr.conf.xml](#configuration-odbc_cdrconfxml)
+- [Channel Variables](#channel-variables)
+- [Dependencies](#dependencies)
+- [See also](#see-also)
+
 ## Loading the Module
 
 The module name is `mod_odbc_cdr`. It is **not** present in the vanilla `modules.conf.xml` load list and must be added manually:

--- a/docs/module-reference/event-handlers/mod_odbc_cdr.mdx
+++ b/docs/module-reference/event-handlers/mod_odbc_cdr.mdx
@@ -127,4 +127,8 @@ Any channel variable listed as `chan-var-name` in a `<field>` element is read (n
 
 `mod_odbc_cdr` relies on FreeSWITCH's `switch_cache_db` layer for database access. That layer requires unixODBC (or iODBC) headers and libraries to be present at FreeSWITCH build time when targeting non-SQLite databases. The appropriate ODBC driver for the target database (e.g., `psqlodbc` for PostgreSQL, `libmyodbc` for MySQL) must be installed and registered in `/etc/odbc.ini` or the native DSN must be used instead.
 
+## See also
+
+- [Chapter 27: Call Detail Records](../../integration/call-detail-records.mdx)
+
 **Source:** `src/mod/event_handlers/mod_odbc_cdr`, `src/mod/event_handlers/mod_odbc_cdr/conf/autoload_configs/odbc_cdr.conf.xml`

--- a/docs/module-reference/event-handlers/mod_smpp.mdx
+++ b/docs/module-reference/event-handlers/mod_smpp.mdx
@@ -13,6 +13,16 @@ sidebar_label: "mod_smpp"
 
 Inbound `DELIVER_SM` PDUs are decoded into FreeSWITCH chat events and dispatched through the chatplan. Outbound messages can be triggered from the dialplan, the chatplan, or the `fs_cli` using the `smpp_send` API command.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: smpp.conf.xml](#configuration-smppconfxml)
+- [Dialplan Applications](#dialplan-applications)
+- [API Commands](#api-commands)
+- [Chat Interface](#chat-interface)
+- [Channel Variables](#channel-variables)
+- [Dependencies](#dependencies)
+
 ## Loading the Module
 
 The module name is `mod_smpp`. It is **not** loaded by default — both entries in `conf/vanilla/autoload_configs/modules.conf.xml` are commented out. To enable it, uncomment (or add) the load line:

--- a/docs/module-reference/event-handlers/mod_snmp.mdx
+++ b/docs/module-reference/event-handlers/mod_snmp.mdx
@@ -13,6 +13,14 @@ sidebar_label: "mod_snmp"
 
 Reach for this module when you need to integrate FreeSWITCH into an existing SNMP-based monitoring infrastructure — polling tools, NMS platforms, or alerting systems that speak SNMPv2c. All exposed objects are read-only; no SNMP SET operations are supported.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration](#configuration)
+- [MIB Structure](#mib-structure)
+- [Example SNMP Queries](#example-snmp-queries)
+- [Dependencies](#dependencies)
+
 ## Loading the Module
 
 The module is **not loaded by default**. In the vanilla `autoload_configs/modules.conf.xml` it appears as a commented-out entry. To enable it, uncomment or add the following line:

--- a/docs/module-reference/formats/mod_imagick.mdx
+++ b/docs/module-reference/formats/mod_imagick.mdx
@@ -13,6 +13,14 @@ sidebar_label: "mod_imagick"
 
 The primary use case is playing multi-page PDF documents or animated GIFs as a video source — for example, presenting fax content as a video call or driving a conference slide show via the `conference_play` API. Each page of the document becomes one video frame; playback timing is controlled by per-handle parameters rather than a configuration file.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [File Interface](#file-interface)
+- [Events](#events)
+- [Dependencies](#dependencies)
+- [See also](#see-also)
+
 ## Loading the Module
 
 The module name for `load` and `modules.conf.xml` is `mod_imagick`.

--- a/docs/module-reference/formats/mod_imagick.mdx
+++ b/docs/module-reference/formats/mod_imagick.mdx
@@ -80,4 +80,8 @@ This event can be caught with `event_bind` in a script or ESL consumer to know w
 - The `Makefile.am` guard `if HAVE_MAGICK` prevents building without it
 - ImageMagick 6 and 7 are both supported; the build system sets `-DHAVE_MAGIC7` when version 7 headers are detected
 
+## See also
+
+- [Chapter 24: Fax and T.38](../../applications/fax-t38.mdx)
+
 **Source:** `src/mod/formats/mod_imagick`

--- a/docs/module-reference/formats/mod_opusfile.mdx
+++ b/docs/module-reference/formats/mod_opusfile.mdx
@@ -13,6 +13,16 @@ sidebar_label: "mod_opusfile"
 
 Reach for this module when you need to play back recorded `.opus` audio files in the dialplan, record calls directly to `.opus` format (requires `libopusenc` at build time), or bridge a live OGG/Opus byte stream through the FreeSWITCH codec layer.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Dependencies](#dependencies)
+- [File Interface](#file-interface)
+- [Using the Module in the Dialplan](#using-the-module-in-the-dialplan)
+- [API Commands](#api-commands)
+- [Channel Variables](#channel-variables)
+- [Events](#events)
+
 ## Loading the Module
 
 The module name for `load` and `modules.conf.xml` is `mod_opusfile`. In the default vanilla configuration it is present but **commented out**:

--- a/docs/module-reference/formats/mod_png.mdx
+++ b/docs/module-reference/formats/mod_png.mdx
@@ -13,6 +13,13 @@ sidebar_label: "mod_png"
 
 The module also exposes the `uuid_write_png` API command, which captures a single video frame from an active call and writes it to disk as a PNG file. Together these two features make the module useful for: displaying a static logo or hold-screen on a video call, and for capturing screenshots from live video sessions for logging or monitoring purposes.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Using mod_png as a Video Source](#using-mod_png-as-a-video-source)
+- [API Commands](#api-commands)
+- [Dependencies](#dependencies)
+
 ## Loading the Module
 
 The module name for `modules.conf.xml` and `load` commands is `mod_png`.

--- a/docs/module-reference/formats/mod_shell_stream.mdx
+++ b/docs/module-reference/formats/mod_shell_stream.mdx
@@ -13,6 +13,13 @@ sidebar_label: "mod_shell_stream"
 
 Reach for this module when you need to synthesize or transform audio on the fly using an external program — for example, calling a TTS binary, running an audio encoder pipeline, or fetching audio from a networked source via a shell one-liner — without writing a dedicated FreeSWITCH module.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [File Interface](#file-interface)
+- [Dependencies](#dependencies)
+- [See also](#see-also)
+
 ## Loading the Module
 
 The module name is `mod_shell_stream`. It is **not** loaded by default; the vanilla `autoload_configs/modules.conf.xml` ships with the entry commented out.

--- a/docs/module-reference/formats/mod_shell_stream.mdx
+++ b/docs/module-reference/formats/mod_shell_stream.mdx
@@ -65,4 +65,8 @@ Multiple files may be chained using FreeSWITCH's `file_string://` file format if
 
 No external libraries beyond standard POSIX pipe and fork APIs are required.
 
+## See also
+
+- [Chapter 18: Audio Files and Streaming Sources](../../media/audio-files-and-streaming.mdx)
+
 **Source:** `src/mod/formats/mod_shell_stream`

--- a/docs/module-reference/formats/mod_vlc.mdx
+++ b/docs/module-reference/formats/mod_vlc.mdx
@@ -120,4 +120,8 @@ The `vlc_interval`, `vlc_rate`, and `vlc_channels` channel variables control cod
 
 `mod_vlc` requires the libvlc runtime and development headers. These are not included in the FreeSWITCH source tree and must be installed separately from the host distribution (e.g., `libvlc-dev` on Debian/Ubuntu, `vlc-devel` on RHEL/CentOS). Audio support requires libvlc >= 1.2; video requires libvlc >= 2.0.2.
 
+## See also
+
+- [Chapter 18: Audio Files and Streaming Sources](../../media/audio-files-and-streaming.mdx)
+
 **Source:** `src/mod/formats/mod_vlc`

--- a/docs/module-reference/formats/mod_vlc.mdx
+++ b/docs/module-reference/formats/mod_vlc.mdx
@@ -13,6 +13,16 @@ sidebar_label: "mod_vlc"
 
 Reach for `mod_vlc` when you need to serve container formats such as MP4 or MOV, ingest a live network stream as a playback source, or push recorded media to an external streaming server. For simple WAV/raw audio playback, the built-in file interfaces are more efficient; `mod_vlc` is the right tool when libvlc's codec and protocol breadth is required.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [File Interface](#file-interface)
+- [Dialplan Applications](#dialplan-applications)
+- [Channel Variables](#channel-variables)
+- [Endpoint Interface](#endpoint-interface)
+- [Dependencies](#dependencies)
+- [See also](#see-also)
+
 ## Loading the Module
 
 The module name to load is `mod_vlc`. It is **not** present in the vanilla `autoload_configs/modules.conf.xml` and must be added manually:

--- a/docs/module-reference/formats/mod_webm.mdx
+++ b/docs/module-reference/formats/mod_webm.mdx
@@ -13,6 +13,14 @@ sidebar_label: "mod_webm"
 
 Reach for this module when you need to record video calls — for example, browser-originated WebRTC sessions via `mod_verto` or `mod_rtc` — directly to a self-contained `.webm` file that can be played back in any modern browser or media player without transcoding.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [File Interface](#file-interface)
+- [Using the Module in the Dialplan](#using-the-module-in-the-dialplan)
+- [Channel Variables](#channel-variables)
+- [Dependencies](#dependencies)
+
 ## Loading the Module
 
 The module name is `mod_webm`. It is **not present** in the default vanilla `autoload_configs/modules.conf.xml` and must be added manually. Add the following line to the `<modules>` block in that file:

--- a/docs/module-reference/formats/mod_webm.mdx
+++ b/docs/module-reference/formats/mod_webm.mdx
@@ -33,6 +33,10 @@ load mod_webm
 
 The module supports **write-only** operation. The read path (`webm_file_read`) and seek (`webm_file_seek`) are not implemented and return `SWITCH_STATUS_FALSE`. Recording is the only supported use case.
 
+### Standalone VORBIS Codec
+
+In addition to the file interface, `mod_webm` also registers a standalone `VORBIS` codec interface (via `SWITCH_ADD_CODEC`). This codec is not limited to encoding the audio track inside a WebM container — it is a full codec implementation that can be negotiated and used independently for RTP and calls, at sample rates of 8000, 44100, and 48000 Hz.
+
 When a file is opened for writing:
 
 - An audio track is added using the session sample rate and channel count. Audio is encoded with Vorbis at 20 ms packetization.

--- a/docs/module-reference/languages/mod_basic.mdx
+++ b/docs/module-reference/languages/mod_basic.mdx
@@ -13,6 +13,15 @@ sidebar_label: "mod_basic"
 
 Operators reach for `mod_basic` when they want to write simple call-control logic in a procedural BASIC dialect without pulling in a heavier scripting runtime such as Lua or Python. Scripts read and write channel variables, invoke dialplan applications, and call FreeSWITCH API commands — all through a small set of built-in BASIC functions registered by the module.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration](#configuration)
+- [Dialplan Applications](#dialplan-applications)
+- [API Commands](#api-commands)
+- [BASIC Built-in Functions](#basic-built-in-functions)
+- [See also](#see-also)
+
 ## Loading the Module
 
 The module is **not** included in the vanilla autoload set. Add it to `autoload_configs/modules.conf.xml` under the `<modules>` section:

--- a/docs/module-reference/languages/mod_basic.mdx
+++ b/docs/module-reference/languages/mod_basic.mdx
@@ -73,4 +73,8 @@ The following functions are registered into the MY-BASIC interpreter for every s
 
 `level$` passed to `FS_LOG` is a standard FreeSWITCH log-level string such as `"DEBUG"`, `"INFO"`, `"WARNING"`, or `"ERROR"`.
 
+## See also
+
+- [Chapter 28: Scripting Integration](../../integration/scripting.mdx)
+
 **Source:** `src/mod/languages/mod_basic`

--- a/docs/module-reference/languages/mod_managed.mdx
+++ b/docs/module-reference/languages/mod_managed.mdx
@@ -13,6 +13,15 @@ sidebar_label: "mod_managed"
 
 Reach for this module when your team prefers the .NET ecosystem, needs to share business logic between FreeSWITCH and other .NET services, or wants the live-reload behaviour that comes from dropping a new `.dll` or script file into the `managed/` directory while the switch is running.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration](#configuration)
+- [Dialplan Applications](#dialplan-applications)
+- [API Commands](#api-commands)
+- [Dependencies](#dependencies)
+- [See also](#see-also)
+
 ## Loading the Module
 
 `mod_managed` is **not** in the vanilla default load set. It does not appear anywhere in `conf/vanilla/autoload_configs/modules.conf.xml` (commented-out or otherwise). To load it, add the entry below and restart, or use `load` from the `fs_cli`.

--- a/docs/module-reference/languages/mod_managed.mdx
+++ b/docs/module-reference/languages/mod_managed.mdx
@@ -33,7 +33,8 @@ The module requires that `FreeSWITCH.Managed.dll` be present in the FreeSWITCH m
 
 - **Plugin directory:** `{modules_dir}/managed/` — the loader scans every file in this directory at startup and watches it for changes at runtime.
 - **Shadow copy directory:** `{modules_dir}/managed/shadow/` — if this directory already exists at load time, the loader deletes and re-creates it; it is used by the .NET AppDomain shadow-copy mechanism to stage assemblies.
-- **Per-plugin config:** a `.config` file alongside a `.dll` or `.exe` (e.g. `MyPlugin.dll.config`) is read as the `AppDomain` configuration for that plugin's isolated domain.
+- **Per-plugin config:** a `.config` file alongside a `.dll` or `.exe` (e.g. `MyPlugin.dll.config`) is read as the `AppDomain` configuration for that plugin's isolated domain. Editing this `.config` file while the switch is running triggers an automatic reload of the associated plugin.
+- **Per-plugin reference directory:** `{modules_dir}/managed/<modulename>/` — for a plugin file named `<modulename>.<ext>`, this directory is added to the plugin's AppDomain `PrivateBinPath` (alongside `managed` itself), so private dependency assemblies can be kept in a per-plugin subdirectory rather than the shared `managed/` directory.
 
 ## Dialplan Applications
 
@@ -42,6 +43,8 @@ The module requires that `FreeSWITCH.Managed.dll` be present in the FreeSWITCH m
 | `managed` | Run a .NET `IAppPlugin` implementation (or script) on an active channel | `<plugin-name> [<args>]` |
 
 `<plugin-name>` is either the fully-qualified type name (`Namespace.ClassName`) or the short class name (`ClassName`) for compiled assemblies, or the filename (e.g. `Demo.csx`) for script files.
+
+The loader recognizes compiled assemblies by the `.dll` extension and dispatches the following extensions to the script plugin manager (compiled on the fly via the CodeDOM providers): `.csx` (C#), `.fsx` (F#), `.vbx` (VB.NET), `.jsx` (JScript), and `.exe`. A file whose extension is none of these is ignored.
 
 ```xml
 <action application="managed" data="AppDemo"/>

--- a/docs/module-reference/languages/mod_managed.mdx
+++ b/docs/module-reference/languages/mod_managed.mdx
@@ -80,4 +80,8 @@ On Linux, the build also requires **SWIG** to regenerate `freeswitch_wrap.cxx` a
 
 ---
 
+## See also
+
+- [Chapter 28: Scripting Integration](../../integration/scripting.mdx)
+
 **Source:** `src/mod/languages/mod_managed`

--- a/docs/module-reference/say-modules.mdx
+++ b/docs/module-reference/say-modules.mdx
@@ -2,12 +2,12 @@
 sidebar_position: 11
 id: say-modules
 slug: /module-reference/say
-title: "Say Modules: Number, Date, and Money Pronunciation"
+title: "Say Modules — Number, Date, and Money Pronunciation"
 description: "Per-language modules that convert numbers, dates, currency, and time values into spoken audio using pre-recorded sound files."
-sidebar_label: "Say (i18n)"
+sidebar_label: "Say Modules"
 ---
 
-# Say Modules: Number, Date, and Money Pronunciation
+# Say Modules — Number, Date, and Money Pronunciation
 
 The say subsystem converts structured data — integers, monetary amounts, timestamps, IP addresses, and spelled names — into spoken audio by assembling sequences of pre-recorded sound files. Each `mod_say_*` module implements a language-specific pronunciation algorithm that determines which sound files to play and in what order. The `say` dialplan application and the `say_string` API command both invoke these modules at runtime.
 

--- a/docs/module-reference/say-modules.mdx
+++ b/docs/module-reference/say-modules.mdx
@@ -37,6 +37,7 @@ The following modules ship in `src/mod/say`. Each module registers a say interfa
 | `mod_say_sv` | `sv` | Swedish |
 | `mod_say_th` | `th` | Thai |
 | `mod_say_zh` | `zh` | Chinese |
+| `mod_say_zh` | `zh_CN` | Chinese (mainland; distinct currency pronunciation) |
 
 **Default load:** Only `mod_say_en` is enabled by default in `autoload_configs/modules.conf.xml`. All other say modules are commented out and must be explicitly added:
 

--- a/docs/module-reference/say-modules.mdx
+++ b/docs/module-reference/say-modules.mdx
@@ -13,6 +13,12 @@ The say subsystem converts structured data — integers, monetary amounts, times
 
 Sound files are located under the path set by `sound_prefix` for the active language (configured in the `<languages>` section of `freeswitch.xml`). The modules use sub-directories such as `digits/`, `currency/`, and `time/` relative to that prefix.
 
+## Table of Contents
+
+- [Supported Languages](#supported-languages)
+- [The say Application and say_string](#the-say-application-and-say_string)
+- [Selecting the Language](#selecting-the-language)
+
 ## Supported Languages
 
 The following modules ship in `src/mod/say`. Each module registers a say interface under its interface name; that name is what you pass as `<module_name>` in the `say` application.

--- a/docs/module-reference/timers.mdx
+++ b/docs/module-reference/timers.mdx
@@ -13,6 +13,12 @@ FreeSWITCH uses a **timing source** to schedule media frames — RTP packets, mu
 
 Neither module has a configuration file. Both register a named timer interface that other FreeSWITCH subsystems request by name. Supported intervals are 1–2000 ms.
 
+## Table of Contents
+
+- [mod_timerfd](#mod_timerfd)
+- [mod_posix_timer](#mod_posix_timer)
+- [Selecting a Timer](#selecting-a-timer)
+
 ## mod_timerfd
 
 `mod_timerfd` implements a timer using the Linux `timerfd_create(2)` / `epoll(7)` API. A single `epoll` file descriptor monitors all active interval timers. When a `timerfd` fires, the runtime thread reads the expiration count and broadcasts to all sessions waiting on that interval.

--- a/docs/module-reference/timers.mdx
+++ b/docs/module-reference/timers.mdx
@@ -2,12 +2,12 @@
 sidebar_position: 10
 id: timers
 slug: /module-reference/timers
-title: "Timers: mod_timerfd and mod_posix_timer"
+title: "Timers — mod_timerfd and mod_posix_timer"
 description: "Loadable timer modules providing kernel-backed high-precision media scheduling as an alternative to the built-in soft timer."
 sidebar_label: "Timers"
 ---
 
-# Timers: mod_timerfd and mod_posix_timer
+# Timers — mod_timerfd and mod_posix_timer
 
 FreeSWITCH uses a **timing source** to schedule media frames — RTP packets, music-on-hold chunks, conference audio mixing, and file streaming all depend on a timer firing at a precise interval (typically every 20 ms). The core ships a built-in software timer called `soft` that is always available. `mod_timerfd` and `mod_posix_timer` are optional loadable modules that register additional timer names backed by kernel timer facilities; they can deliver lower latency and tighter jitter than the `soft` timer on systems where the kernel timer API is available.
 

--- a/docs/module-reference/timers.mdx
+++ b/docs/module-reference/timers.mdx
@@ -23,7 +23,7 @@ Neither module has a configuration file. Both register a named timer interface t
 
 `mod_timerfd` implements a timer using the Linux `timerfd_create(2)` / `epoll(7)` API. A single `epoll` file descriptor monitors all active interval timers. When a `timerfd` fires, the runtime thread reads the expiration count and broadcasts to all sessions waiting on that interval.
 
-| Attribute | Value |
+| Attribute | Accepted Values |
 |---|---|
 | Module name | `mod_timerfd` |
 | Timer interface name | `timerfd` |
@@ -45,7 +45,7 @@ Neither module has a configuration file. Both register a named timer interface t
 
 `mod_posix_timer` implements a timer using the POSIX `timer_create(2)` / `timer_settime(2)` API with `CLOCK_MONOTONIC` and `SIGEV_SIGNAL` delivery. Each armed timer sends a real-time signal (`SIGRTMAX - 1`) to a dedicated runtime thread, which reads timer IDs from a self-pipe and broadcasts to waiting sessions. Up to 4 POSIX timers can be active per interval value (`TIMERS_PER_INTERVAL = 4`), and up to 256 timers can be active across all intervals at once (`MAX_ACTIVE_TIMERS = 256`).
 
-| Attribute | Value |
+| Attribute | Accepted Values |
 |---|---|
 | Module name | `mod_posix_timer` |
 | Timer interface name | `posix` |

--- a/docs/module-reference/xml-interfaces/mod_ldap.mdx
+++ b/docs/module-reference/xml-interfaces/mod_ldap.mdx
@@ -13,6 +13,12 @@ sidebar_label: "mod_ldap"
 
 Reach for `mod_ldap` when your organization already maintains user or extension records in an LDAP-compatible directory (OpenLDAP, Active Directory, 389 DS) and you want FreeSWITCH to pull routing data from that single source of truth rather than duplicating it in flat configuration files.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: dialplan_directory.conf.xml](#configuration-dialplan_directoryconfxml)
+- [Dependencies](#dependencies)
+
 ## Loading the Module
 
 The module name for `fs_cli` and `modules.conf.xml` is `mod_ldap`. It is **not** enabled in the default vanilla load set — the entry in `conf/vanilla/autoload_configs/modules.conf.xml` is commented out:

--- a/docs/module-reference/xml-interfaces/mod_xml_ldap.mdx
+++ b/docs/module-reference/xml-interfaces/mod_xml_ldap.mdx
@@ -13,6 +13,13 @@ sidebar_label: "mod_xml_ldap"
 
 Reach for this module when user accounts already live in an LDAP/Active-Directory tree and you want FreeSWITCH to look up SIP credentials, voicemail settings, and caller-ID values directly from that source of truth, without exporting or duplicating the data into flat `directory/*.xml` files.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: xml_ldap.conf.xml](#configuration-xml_ldapconfxml)
+- [API Commands](#api-commands)
+- [Dependencies](#dependencies)
+
 ## Loading the Module
 
 The module name for `modules.conf.xml` and `fs_cli` is `mod_xml_ldap`. It is **not** present in the vanilla `autoload_configs/modules.conf.xml` and must be added manually:

--- a/docs/module-reference/xml-interfaces/mod_xml_rpc.mdx
+++ b/docs/module-reference/xml-interfaces/mod_xml_rpc.mdx
@@ -137,4 +137,8 @@ The module reserves and fires one custom event subclass:
 
 `mod_xml_rpc` requires **xmlrpc-c** (including its bundled Abyss HTTP library). On most Linux distributions this is available as `libxmlrpc-c3-dev` (Debian/Ubuntu) or `xmlrpc-c-devel` (RHEL/CentOS). It is not part of the FreeSWITCH core and must be present at build time.
 
+## See also
+
+- [Chapter 26: HTTP Integration: XML Curl and HTTAPI](../../integration/xml-curl.mdx)
+
 **Source:** `src/mod/xml_int/mod_xml_rpc`, `conf/vanilla/autoload_configs/xml_rpc.conf.xml`

--- a/docs/module-reference/xml-interfaces/mod_xml_rpc.mdx
+++ b/docs/module-reference/xml-interfaces/mod_xml_rpc.mdx
@@ -13,6 +13,15 @@ sidebar_label: "mod_xml_rpc"
 
 Operators reach for this module when they need a simple, credential-protected HTTP gateway to FreeSWITCH API commands — for example, a web-based admin portal, AJAX polling from a browser, or an integration that speaks XML-RPC rather than ESL.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: xml_rpc.conf.xml](#configuration-xml_rpcconfxml)
+- [API Commands](#api-commands)
+- [Events](#events)
+- [Dependencies](#dependencies)
+- [See also](#see-also)
+
 ## Loading the Module
 
 The module name for `load` and `modules.conf.xml` is `mod_xml_rpc`. It is **not** loaded by default in the vanilla configuration — the entry in `conf/vanilla/autoload_configs/modules.conf.xml` is commented out:

--- a/docs/module-reference/xml-interfaces/mod_xml_rpc.mdx
+++ b/docs/module-reference/xml-interfaces/mod_xml_rpc.mdx
@@ -44,9 +44,13 @@ The module reads `xml_rpc.conf` from the FreeSWITCH configuration directory. All
 | `enable-websocket` | Enable WebSocket event subscription endpoint at `/socket` | `true` / `false` | `false` |
 | `commands-to-log` | Regex pattern; matching API commands executed via HTTP are logged at INFO level | PCRE regex string | _(none)_ |
 
-Authentication logic: if `auth-realm`, `auth-user`, and `auth-pass` are all non-empty, every request requires HTTP Basic Auth matching those static credentials. Alternatively, a user can authenticate as `user@domain` and the module looks up their `password` and `http-allowed-api` params in the FreeSWITCH XML directory. The `http-allowed-api` directory param is a comma-separated list of API command names (or `any`) that the directory user is permitted to call.
+Authentication logic: if `auth-realm`, `auth-user`, and `auth-pass` are all non-empty, every request requires HTTP Basic Auth matching those static credentials. Alternatively, a user can authenticate as `user@domain` and the module looks up their directory params. The `http-allowed-api` directory param is a comma-separated list of API command names (or `any`) that the directory user is permitted to call.
+
+For the directory password check, the module accepts more than just the `password` param. It will authenticate the supplied credentials against the user's `password`, their `vm-password`, and (so long as one of those passwords matches) the same passwords paired with the user's `number-alias` / mailbox in place of the login name. This lets a directory user log in with their voicemail PIN, or with their mailbox number instead of their user id.
 
 The `/pub` URI prefix bypasses authentication and serves files directly from `htdocs`. The `/domains/<domain>/` URI prefix triggers per-domain directory auth.
+
+A bare request to `/portal` (with no trailing path) is answered with a `302` redirect to `/portal/index.html` before auth is evaluated.
 
 Example excerpt from the shipped configuration:
 
@@ -85,6 +89,8 @@ Once the module is loaded, API commands are reachable at the following URL patte
 | `http://host:port/RPC2` | XML-RPC | Accepts `freeswitch.api` / `freeswitch_api` and `freeswitch.management` / `freeswitch_management` methods |
 
 Query string key-value pairs (separated by `&`) are passed to the API command as FreeSWITCH event headers. The special key `refresh=N` causes the module to inject an HTML meta-refresh header (for `/webapi/` responses only, when the API command sets the `HTTP-REFRESH` event header).
+
+If an HTTP (or XML-RPC) request would run `unload mod_xml_rpc` or `reload mod_xml_rpc`, the module rewrites the call to `bgapi` so it runs in a background thread. This is a self-unload guard: unloading the module synchronously from inside its own HTTP request handler would tear down the thread servicing the request.
 
 Examples using `curl`:
 

--- a/docs/module-reference/xml-interfaces/mod_xml_scgi.mdx
+++ b/docs/module-reference/xml-interfaces/mod_xml_scgi.mdx
@@ -13,6 +13,13 @@ sidebar_label: "mod_xml_scgi"
 
 Use this module when you want to serve dynamic XML from a long-running backend process (Python, Perl, Ruby, etc.) that can stay resident and handle multiple requests without the per-request fork overhead of a traditional CGI gateway. The SCGI server listens on a TCP socket; `mod_xml_scgi` connects, sends the request, reads the XML response, and parses it into the FreeSWITCH XML tree.
 
+## Table of Contents
+
+- [Loading the Module](#loading-the-module)
+- [Configuration: xml_scgi.conf.xml](#configuration-xml_scgiconfxml)
+- [API Commands](#api-commands)
+- [See also](#see-also)
+
 ## Loading the Module
 
 The module name is `mod_xml_scgi`. In the vanilla distribution the entry in `autoload_configs/modules.conf.xml` is commented out:

--- a/docs/module-reference/xml-interfaces/mod_xml_scgi.mdx
+++ b/docs/module-reference/xml-interfaces/mod_xml_scgi.mdx
@@ -87,4 +87,8 @@ freeswitch@> xml_scgi debug_off
 OK
 ```
 
+## See also
+
+- [Chapter 26: HTTP Integration: XML Curl and HTTAPI](../../integration/xml-curl.mdx)
+
 **Source:** `src/mod/xml_int/mod_xml_scgi`, `conf/vanilla/autoload_configs/xml_scgi.conf.xml`

--- a/docs/reference/appendix-codec-table.mdx
+++ b/docs/reference/appendix-codec-table.mdx
@@ -9,6 +9,8 @@ sidebar_label: "Appendix B: Codec Reference"
 
 # Appendix B: Codec Reference Table
 
+> This appendix is the canonical, exhaustive reference for the bundled codec modules. Chapter 16: Codecs and Negotiation links here as the source of truth for the full codec list, sample rates, and per-module configuration files.
+
 FreeSWITCH bundles a set of codec modules that cover the most common audio and video formats used in SIP, WebRTC, and media bridging scenarios. This appendix lists every bundled codec module, the codec or codecs it provides, confirmed sample rates, the configuration file (if any), and whether the module loads by default in the vanilla `modules.conf.xml`. Licensing and external-library requirements are noted where they affect whether a module can encode and decode or must fall back to passthrough-only operation.
 
 ## Table of Contents

--- a/docs/reference/appendix-vanilla-config-map.mdx
+++ b/docs/reference/appendix-vanilla-config-map.mdx
@@ -65,7 +65,7 @@ Each file in `autoload_configs/` is read by the module or core subsystem whose n
 | `blacklist.conf.xml` | `mod_blacklist` caller-ID blacklist configuration. | Part 9: [`mod_blacklist`](/module-reference/applications/mod_blacklist) |
 | `callcenter.conf.xml` | `mod_callcenter` ACD queues, agents, and tier definitions. | Chapter 22: Queues: FIFO and Call Center |
 | `cdr_csv.conf.xml` | `mod_cdr_csv` CDR flat-file output; templates, legs, and rotation. | Chapter 27: Call Detail Records |
-| `cdr_pg_csv.conf.xml` | `mod_cdr_pg_csv` CDR output to PostgreSQL. | Chapter 27: Call Detail Records |
+| `cdr_pg_csv.conf.xml` | `mod_cdr_pg_csv` CDR output to PostgreSQL. | Part 9: [`mod_cdr_pg_csv`](/module-reference/event-handlers/mod_cdr_pg_csv) |
 | `cdr_sqlite.conf.xml` | `mod_cdr_sqlite` CDR output to a SQLite database. | Chapter 27: Call Detail Records |
 | `cidlookup.conf.xml` | `mod_cidlookup` caller-ID name lookup via HTTP or local cache. | Part 9: [`mod_cidlookup`](/module-reference/applications/mod_cidlookup) |
 | `conference.conf.xml` | `mod_conference` conference profiles and per-profile parameter set. | Chapter 20: Conferencing |
@@ -83,7 +83,7 @@ Each file in `autoload_configs/` is read by the module or core subsystem whose n
 | `event_socket.conf.xml` | `mod_event_socket` inbound ESL listener; `listen-ip`, `listen-port`, `password`. | Chapter 25: The Event Socket |
 | `fax.conf.xml` | Alternate configuration filename accepted by `mod_spandsp` for backward compatibility; contains T.30/T.38 fax parameters. | Chapter 24: Fax and T.38 |
 | `fifo.conf.xml` | `mod_fifo` FIFO queue definitions and consumer/caller settings. | Chapter 22: Queues: FIFO and Call Center |
-| `format_cdr.conf.xml` | `mod_format_cdr` CDR formatter; output format and HTTP posting options. | Chapter 27: Call Detail Records |
+| `format_cdr.conf.xml` | `mod_format_cdr` CDR formatter; output format and HTTP posting options. | Part 9: [`mod_format_cdr`](/module-reference/event-handlers/mod_format_cdr) |
 | `graylog2.conf.xml` | `mod_graylog2` GELF log shipper; host, port, and log level. | Part 9: [`mod_graylog2`](/module-reference/event-handlers/mod_graylog2) |
 | `hash.conf.xml` | `mod_hash` shared in-memory hash table; realm definitions. | Chapter 23: Utility Applications |
 | `hiredis.conf.xml` | `mod_hiredis` Redis client via hiredis; host, port, and pool settings. | Part 9: [`mod_hiredis`](/module-reference/data-stores/mod_hiredis) |

--- a/docs/reference/channel-variables.mdx
+++ b/docs/reference/channel-variables.mdx
@@ -176,6 +176,7 @@ These variables expose SIP message fields and control SIP header injection. They
 | `sip_via_port` | Port from the topmost Via header in the incoming SIP request. |
 | `sip_via_rport` | rport parameter from the topmost Via header, if present. |
 | `sip_via_protocol` | Transport protocol from the topmost Via header (e.g., `UDP`, `TCP`, `TLS`). |
+| `sip_cid_type` | The caller-ID presentation type derived from the inbound identity headers. Set by `mod_sofia` in `sofia.c` to `rpid` when a Remote-Party-ID header is present, or `pid` when a P-Asserted-Identity or P-Preferred-Identity header is present. |
 
 ### Authentication Fields {#sip-auth}
 
@@ -195,6 +196,7 @@ These variables expose SIP message fields and control SIP header injection. They
 | `sip_redirect_dialplan` | Dialplan module to use when routing a redirected call. Defaults to `XML`. |
 | `sip_redirect_fork` | When `true`, a 3xx redirect with multiple Contact headers causes FreeSWITCH to originate all contacts simultaneously rather than sequentially. |
 | `sip_redirected_to` | Set by `mod_sofia` to the full Contact URI that was selected when following a 3xx redirect. Read-only; set after redirect processing. |
+| `sip_contact_params` | Extra parameters appended (after a `;`) to the outbound Contact URI built by `mod_sofia` when routing an inbound or redirected call. Read by `sofia_glue.c`. |
 
 ### Custom Headers {#sip-custom-headers}
 

--- a/docs/reference/cli-and-api.mdx
+++ b/docs/reference/cli-and-api.mdx
@@ -17,12 +17,16 @@ This chapter covers the operator-facing command set. FreeSWITCH registers over 1
 
 - [Connecting with fs\_cli](#connecting-with-fs_cli)
 - [Status and Inspection](#status-and-inspection)
+- [Directory and Interface Lookups](#directory-and-interface-lookups)
 - [Call Control](#call-control)
 - [Configuration Control](#configuration-control)
 - [System Control](#system-control)
+- [Process and Shell Execution](#process-and-shell-execution)
+- [NAT Mapping](#nat-mapping)
 - [Variables and Evaluation](#variables-and-evaluation)
 - [Scheduling](#scheduling)
 - [Background Execution](#background-execution)
+- [CLI Aliases and ACLs](#cli-aliases-and-acls)
 - [Sofia Command Tree](#sofia-command-tree)
 - [Example fs\_cli Session](#example-fs_cli-session)
 
@@ -95,6 +99,31 @@ nat_map|say|interfaces|interface_types|tasks|limits|status
 
 ---
 
+## Directory and Interface Lookups {#directory-and-interface-lookups}
+
+These commands query the XML user directory, check for the existence of modules and files, and resolve interface addresses. They are commonly used from scripts and the dialplan to make routing decisions.
+
+| Command | Purpose | Syntax |
+|---------|---------|--------|
+| `list_users` | List users configured in the directory, optionally filtered by group, domain, user, or context | `list_users [group <group>] [domain <domain>] [user <user>] [context <context>]` |
+| `user_exists` | Test whether a user matches a directory key/value (returns `true`/`false`) | `user_exists <key> <user> <domain>` |
+| `user_data` | Return a variable, parameter, or attribute value for a directory user | `user_data <user>@<domain> [var\|param\|attr] <name>` |
+| `domain_exists` | Test whether a domain is configured in the directory (returns `true`/`false`) | `domain_exists <domain>` |
+| `domain_data` | Return a variable, parameter, or attribute value for a directory domain | `domain_data <domain> [var\|param\|attr] <name>` |
+| `module_exists` | Test whether a module is loaded (returns `true`/`false`) | `module_exists <module>` |
+| `file_exists` | Test whether a file exists on the server filesystem (returns `true`/`false`) | `file_exists <file>` |
+| `interface_ip` | Return the primary IP address of a named network interface | `interface_ip [auto\|ipv4\|ipv6] <ifname>` |
+
+**Notes on `user_exists`:**
+
+The `<key>` argument selects which directory field is matched against `<user>`, for example `id` to match on the user ID.
+
+**Notes on `interface_ip`:**
+
+`ipv4` and `ipv6` force the address family; `auto` returns whichever family is available for the interface named by `<ifname>`.
+
+---
+
 ## Call Control {#call-control}
 
 These commands act on active channels, identified by their UUID. Obtain UUIDs from `show channels` or `show calls`.
@@ -126,6 +155,7 @@ These commands act on active channels, identified by their UUID. Obtain UUIDs fr
 | `uuid_recv_dtmf` | Inject received DTMF digits into a channel | `uuid_recv_dtmf <uuid> <dtmf_data>` |
 | `uuid_flush_dtmf` | Flush buffered DTMF from a channel | `uuid_flush_dtmf <uuid>` |
 | `uuid_media` | Reinvite FreeSWITCH in or out of the media path | `uuid_media [off] <uuid>` |
+| `uuid_media_3p` | Reinvite FreeSWITCH in or out of the media path using 3PCC (third-party call control) | `uuid_media_3p [off] <uuid>` |
 | `uuid_media_reneg` | Trigger a media renegotiation on a channel | `uuid_media_reneg <uuid>[ <codec_string>]` |
 | `uuid_deflect` | Send a SIP REFER to redirect a call | `uuid_deflect <uuid> <uri>` |
 | `uuid_redirect` | Send a SIP redirect response | `uuid_redirect <uuid> <uri>` |
@@ -135,6 +165,11 @@ These commands act on active channels, identified by their UUID. Obtain UUIDs fr
 | `uuid_session_heartbeat` | Enable or set a heartbeat interval on a channel | `uuid_session_heartbeat <uuid> [sched] [0\|<seconds>]` |
 | `uuid_simplify` | Attempt to cut FreeSWITCH out of the media path | `uuid_simplify <uuid>` |
 | `uuid_fileman` | Control file playback on a channel | `uuid_fileman <uuid> <cmd>:<val>` |
+| `uuid_send_message` | Send a SIP MESSAGE to the endpoint on a channel | `uuid_send_message <uuid> <message>` |
+| `uuid_send_info` | Send a SIP INFO request to the endpoint on a channel | `uuid_send_info <uuid> [<mime_type> <mime_subtype>] <message>` |
+| `uuid_limit` | Apply a usage-limit resource against a channel through a limit backend | `uuid_limit <uuid> <backend> <realm> <resource> [<max>[/interval]] [number [dialplan [context]]]` |
+| `uuid_limit_release` | Release a limit resource previously applied to a channel | `uuid_limit_release <uuid> <backend> [realm] [resource]` |
+| `tone_detect` | Start tone detection on a channel, optionally firing an application on match | `tone_detect <uuid> <key> <tone_spec> [<flags> <timeout> <app> <args> <hits>]` |
 | `hupall` | Hang up all channels, optionally filtered by variable value | `hupall <cause> [<var> <value>] [<var2> <value2>]` |
 
 **Notes on `originate`:**
@@ -203,11 +238,24 @@ The `fsctl` command sends control messages to the FreeSWITCH core. All subcomman
 | `fsctl api_expansion` | Enable or disable API expansion in dialplan | `fsctl api_expansion [on\|off]` |
 | `fsctl reclaim_mem` | Reclaim unused memory from core memory pools | `fsctl reclaim_mem` |
 | `fsctl mdns_resolve` | Enable or disable mDNS resolution | `fsctl mdns_resolve [enable\|disable]` |
+| `fsctl flush_db_handles` | Flush idle core database connection handles from the pool | `fsctl flush_db_handles` |
+| `fsctl calibrate_clock` | Recalibrate the internal monotonic clock | `fsctl calibrate_clock` |
+| `fsctl crash` | Force an immediate process crash (for debugging core dumps) | `fsctl crash` |
+| `fsctl verbose_events` | Enable or disable verbose event generation globally | `fsctl verbose_events [on\|off]` |
+| `fsctl threaded_system_exec` | Toggle whether `system`/`bg_system` shell commands run in a dedicated thread | `fsctl threaded_system_exec [on\|off]` |
+| `fsctl save_history` | Persist the CLI command history to disk | `fsctl save_history` |
+| `fsctl pause_check` | Report whether call processing is paused (returns `true`/`false`) | `fsctl pause_check [inbound\|outbound]` |
+| `fsctl ready_check` | Report whether the system is ready (returns `true`/`false`) | `fsctl ready_check` |
+| `fsctl shutdown_check` | Report whether a shutdown is in progress (returns `true`/`false`) | `fsctl shutdown_check` |
+| `fsctl debug_pool` | Print core memory pool debug statistics | `fsctl debug_pool` |
+| `fsctl debug_sql` | Toggle SQL debug logging | `fsctl debug_sql` |
+| `fsctl sql` | Start or stop the core SQL queue thread | `fsctl sql [start\|stop]` |
+| `fsctl last_sps` | Report the last sessions-per-second value | `fsctl last_sps` |
 | `shutdown` | Initiate immediate shutdown (no modifier flags) | `shutdown` |
 
 FreeSWITCH log levels, from least to most verbose: `console`, `alert`, `crit`, `err`, `warning`, `notice`, `info`, `debug`.
 
-The full `fsctl` syntax string from source:
+The `CTL_SYNTAX` usage string published by `mod_commands` lists the most common subcommands:
 
 ```
 fsctl [api_expansion [on|off]|recover|send_sighup|hupall|
@@ -221,9 +269,55 @@ fsctl [api_expansion [on|off]|recover|send_sighup|hupall|
        mdns_resolve [enable|disable]]
 ```
 
+The handler accepts additional subcommands beyond this string, documented in the table above: `flush_db_handles`, `calibrate_clock`, `crash`, `verbose_events`, `threaded_system_exec`, `save_history`, `pause_check`, `ready_check`, `shutdown_check`, `debug_pool`, `debug_sql`, `sql`, and `last_sps`.
+
 **Notes on `fsctl shutdown`:**
 
-`cancel` aborts a pending shutdown. `elegant` waits for all active sessions to complete. `asap` waits only until no sessions are active (does not wait for existing sessions to finish). `now` terminates immediately. Adding `restart` to `elegant`, `asap`, or `now` causes a restart after shutdown.
+`cancel` aborts a pending shutdown. `elegant` waits for all active sessions to complete. `asap` waits only until no sessions are active (does not wait for existing sessions to finish). `now` terminates immediately. Adding `restart` to `elegant`, `asap`, or `now` causes a restart after shutdown. The `reincarnate now` modifier (`fsctl shutdown reincarnate now`) terminates the process immediately and relaunches it, equivalent to a restart with the watchdog/reincarnate path.
+
+**Diagnostic subcommands:**
+
+`pause_check`, `ready_check`, and `shutdown_check` return a bare `true`/`false` for use in scripts. `crash` deliberately aborts the process and is intended only for generating a core dump during debugging.
+
+---
+
+## Process and Shell Execution {#process-and-shell-execution}
+
+These commands run external programs from the FreeSWITCH process. They are disabled when the core is started with the command execution restriction (the `-nonat`/restricted modes or `switch.conf.xml` `<param name="enable-use-system-commands" value="false"/>` policy), so confirm they are permitted before relying on them in production.
+
+| Command | Purpose | Syntax |
+|---------|---------|--------|
+| `system` | Run a shell command in the foreground and write its output to the stream | `system <command>` |
+| `bg_system` | Run a shell command in the background; returns `+OK` immediately without capturing output | `bg_system <command>` |
+| `spawn` | Run an external program directly (no shell) without capturing its output | `spawn <command>` |
+| `bg_spawn` | Run an external program directly in the background; returns `+OK` immediately | `bg_spawn <command>` |
+| `spawn_stream` | Run an external program directly and capture its output to the stream | `spawn_stream <command>` |
+| `log` | Write a message to the FreeSWITCH log at a given level | `log <level> <message>` |
+| `memory` | Report core memory usage statistics | `memory` |
+| `pool_stats` | Report core memory pool usage statistics | `pool_stats` |
+| `unsched_api` | Unschedule a task previously created with `sched_api`, by task ID | `unsched_api <task_id>` |
+
+**Notes on `system` versus `spawn`:**
+
+`system` and `bg_system` pass the command to a shell (`/bin/sh -c`), so shell features such as pipes and redirection work. The `spawn` family invokes the target program directly without a shell, which avoids shell-injection and quoting issues but does not interpret shell metacharacters. Use `spawn_stream` when you need the program's standard output returned to the caller.
+
+**Notes on `log`:**
+
+`<level>` accepts any FreeSWITCH log level name (`console`, `alert`, `crit`, `err`, `warning`, `notice`, `info`, `debug`); an unrecognized level defaults to `debug`.
+
+---
+
+## NAT Mapping {#nat-mapping}
+
+The `nat_map` command manages UPnP/NAT-PMP port mappings on an upstream router when NAT traversal is initialized.
+
+| Command | Purpose | Syntax |
+|---------|---------|--------|
+| `nat_map` | Inspect or modify NAT port mappings | `nat_map [status\|republish\|reinit] \| [add\|del] <port> [tcp\|udp] [static]` |
+
+**Notes on `nat_map`:**
+
+`status` prints the current NAT status. `republish` re-announces existing mappings to the router. `reinit` re-detects the NAT device and re-publishes. `add` and `del` create or remove a single mapping for the given `<port>`; the protocol defaults to UDP when neither `tcp` nor `udp` is given, and `static` marks the mapping as sticky. The command returns an error if NAT traversal is not initialized.
 
 ---
 
@@ -281,6 +375,8 @@ These commands schedule API calls or call events at a future time.
 
 A leading `+` means relative seconds from now. A leading `@` means recurring: the command re-schedules itself every `<N>` seconds. A plain numeric value is an absolute Unix timestamp. Appending `&` runs the scheduled command in its own thread.
 
+To cancel a task created with `sched_api`, use `unsched_api <task_id>` (documented under [Process and Shell Execution](#process-and-shell-execution)); the task ID is the value returned when the task was scheduled. `sched_del` removes scheduled hangup, transfer, and broadcast tasks by ID or group.
+
 ---
 
 ## Background Execution {#background-execution}
@@ -298,6 +394,25 @@ bgapi uuid:my-job-id status
 ```
 
 `bgapi` is registered as an API command in `mod_commands` and is available at the `fs_cli` prompt as well as over the Event Socket. When used over the Event Socket as the ESL `bgapi` method, the transport layer handles the `Background-Job` event header directly; the behavior is otherwise identical.
+
+---
+
+## CLI Aliases and ACLs {#cli-aliases-and-acls}
+
+These commands define shorthand aliases for longer command strings and test IP addresses against named access control lists.
+
+| Command | Purpose | Syntax |
+|---------|---------|--------|
+| `alias` | Add, update, or delete a CLI/API command alias | `alias [add\|stickyadd] <alias> <command> \| del [<alias>\|*]` |
+| `acl` | Test an IP address against a named ACL (returns `true`/`false`) | `acl <ip> <list_name>` |
+
+**Notes on `alias`:**
+
+`add` creates an alias that maps `<alias>` to a full `<command>` string. `stickyadd` does the same but persists the alias across reloads. `del <alias>` removes a single alias; `del *` removes all aliases.
+
+**Notes on `acl`:**
+
+The ACL named by `<list_name>` is defined in `acl.conf.xml`. The command returns `true` when `<ip>` matches the list and `false` otherwise, making it useful for dialplan or script-driven access decisions. Reload ACL definitions with `reloadacl`.
 
 ---
 

--- a/docs/reference/index.mdx
+++ b/docs/reference/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Part 8: Reference"
 slug: /reference
-description: CLI and API reference, channel variables, and appendices.
+description: "CLI and API reference, channel variables, and appendices."
 ---
 
 import DocCardList from '@theme/DocCardList';

--- a/docs/users-endpoints/gateways.mdx
+++ b/docs/users-endpoints/gateways.mdx
@@ -9,7 +9,7 @@ sidebar_label: "8. Gateways and Trunk Registration"
 
 # Chapter 8: Gateways and Trunk Registration
 
-A FreeSWITCH gateway is a named outbound SIP trunk definition that lives inside a Sofia profile's `<gateways>` block. It tells the Sofia endpoint how to reach a remote SIP provider or peer, optionally registers a SIP account with that provider, and provides the named handle used in dialplan bridge strings to route outbound calls.
+A FreeSWITCH gateway is a named outbound SIP trunk definition that lives inside a [Sofia profile's](../users-endpoints/sip-profiles-sofia.mdx) `<gateways>` block. It tells the Sofia endpoint how to reach a remote SIP provider or peer, optionally registers a SIP account with that provider, and provides the named handle used in dialplan bridge strings to route outbound calls.
 
 ## Table of Contents
 
@@ -29,7 +29,7 @@ A FreeSWITCH gateway is a named outbound SIP trunk definition that lives inside 
 
 A gateway is a `<gateway>` element nested inside a Sofia profile's `<gateways>` block. Each gateway has a unique name that becomes the identifier used in dialplan bridge strings. At startup, FreeSWITCH reads each gateway definition, optionally sends a SIP REGISTER to the provider, and maintains the registration for the lifetime of the profile.
 
-Gateways belong to a Sofia profile. The `external` profile in the vanilla configuration is the conventional home for provider-facing gateways because it is configured with `context="public"` for inbound calls and does not enforce authentication on inbound requests.
+Gateways belong to a [Sofia profile](../users-endpoints/sip-profiles-sofia.mdx). The `external` profile in the vanilla configuration is the conventional home for provider-facing gateways because it is configured with `context="public"` for inbound calls (see [Chapter 13: Inbound Calls and the Public Context](../dialplan/inbound-public-context.mdx)) and does not enforce authentication on inbound requests.
 
 ---
 
@@ -234,7 +234,7 @@ When `register` is `false`, the gateway is brought up immediately at profile loa
 
 ## Routing Outbound Calls Through a Gateway
 
-Use the `bridge` application in the dialplan with the endpoint string `sofia/gateway/<name>/<number>`, where `<name>` is the gateway name and `<number>` is the destination number.
+Use the [`bridge` application](../dialplan/dptools-reference.mdx) in the dialplan with the endpoint string `sofia/gateway/<name>/<number>`, where `<name>` is the gateway name and `<number>` is the destination number.
 
 ```xml
 <action application="bridge" data="sofia/gateway/my-provider/12125550199"/>
@@ -252,4 +252,4 @@ A variable substitution is common when the gateway name is stored in a channel v
 
 ## Inbound Calls From a Trunk
 
-Inbound SIP INVITE requests arriving from a registered or IP-authenticated trunk enter the dialplan context configured on the parent Sofia profile (typically `public` for the `external` profile) unless the gateway definition overrides it with the `context` parameter. From that context, dialplan rules match on the destination number and route the call. The `public` context and inbound dialplan routing are covered in [Chapter 13: Inbound Calls and the Public Context](/dialplan/public-context).
+Inbound SIP INVITE requests arriving from a registered or IP-authenticated trunk enter the dialplan context configured on the parent Sofia profile (typically `public` for the `external` profile) unless the gateway definition overrides it with the `context` parameter. From that context, dialplan rules match on the destination number and route the call. The `public` context and inbound dialplan routing are covered in [Chapter 13: Inbound Calls and the Public Context](../dialplan/inbound-public-context.mdx).

--- a/docs/users-endpoints/gateways.mdx
+++ b/docs/users-endpoints/gateways.mdx
@@ -62,7 +62,7 @@ All parameters are `<param name="..." value="..."/>` children of the `<gateway>`
 
 ### Identity and Authentication
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `username` | SIP username for authentication and the user part of the outbound Request-URI. Required when `register` is `true`. When `register` is `false` and omitted, defaults to `FreeSWITCH`. | String | None |
 | `password` | SIP password for digest authentication. Required when `register` is `true`. When `register` is `false` and omitted, defaults to empty string. | String | None |
@@ -74,7 +74,7 @@ All parameters are `<param name="..." value="..."/>` children of the `<gateway>`
 
 ### Routing
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `proxy` | SIP server that receives REGISTER and INVITE requests. Constructs the outbound Request-URI host. Defaults to `realm` when omitted. | Hostname, IP, or `sip:` URI | Same as `realm` |
 | `register-proxy` | SIP server that receives only REGISTER requests. Use when the registration target differs from the call routing target. | Hostname, IP, or `sip:` URI | Same as `proxy` |
@@ -83,7 +83,7 @@ All parameters are `<param name="..." value="..."/>` children of the `<gateway>`
 
 ### Registration Behavior
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `register` | Whether to send SIP REGISTER to the provider. Set to `false` for IP-authenticated trunks. | `true`, `false` | `true` |
 | `register-transport` | Transport used for REGISTER requests. Must be supported by the parent profile. Specifying `tls` requires `enable-tls` on the profile. | `udp`, `tcp`, `tls` | `udp` |
@@ -95,7 +95,7 @@ All parameters are `<param name="..." value="..."/>` children of the `<gateway>`
 
 ### Contact Header
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `contact-host` | Override the host part of the SIP Contact header in REGISTER. The special value `sip-ip` forces use of the profile's internal SIP IP instead of the external IP. | Hostname, IP, or `sip-ip` | Profile's external SIP IP |
 | `contact-params` | Extra semicolon-delimited parameters appended to the Contact header URI in REGISTER requests. The transport and `gw` tag are appended automatically; do not duplicate them here. | Semicolon-delimited SIP URI params | Empty |
@@ -103,7 +103,7 @@ All parameters are `<param name="..." value="..."/>` children of the `<gateway>`
 
 ### Inbound Call Handling
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `extension` | Dialplan extension number that inbound calls arriving on this gateway target. Special values: `auto` and `auto_to_user` both map the destination to the SIP To header user part. When omitted, defaults to `username`. | String, `auto`, `auto_to_user` | Same as `username` |
 | `context` | Dialplan context inbound calls from this gateway enter. | String | Parent profile's `context` |
@@ -112,7 +112,7 @@ All parameters are `<param name="..." value="..."/>` children of the `<gateway>`
 
 ### OPTIONS Keepalive (Ping)
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `ping` | Send SIP OPTIONS to the gateway every N seconds. Values below `5` are rejected and pinging is disabled. A failure sequence of `ping-min` consecutive failures marks the gateway DOWN and unregisters it. | Integer (seconds) | Disabled |
 | `ping-max` | Consecutive successful OPTIONS responses required to transition the gateway to UP. | Integer | `1` |
@@ -123,7 +123,7 @@ All parameters are `<param name="..." value="..."/>` children of the `<gateway>`
 
 ### RFC 5626 (SIP Outbound)
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `rfc-5626` | Enable RFC 5626 SIP Outbound for this gateway. The parent profile must also have `enable-rfc-5626` set. Causes a `+sip.instance` and `reg-id` to be appended to the Contact header. | `true`, `false` | `false` |
 | `reg-id` | The `reg-id` value placed in the Contact header when RFC 5626 is active. | Integer string | None |

--- a/docs/users-endpoints/gateways.mdx
+++ b/docs/users-endpoints/gateways.mdx
@@ -252,4 +252,4 @@ A variable substitution is common when the gateway name is stored in a channel v
 
 ## Inbound Calls From a Trunk
 
-Inbound SIP INVITE requests arriving from a registered or IP-authenticated trunk enter the dialplan context configured on the parent Sofia profile (typically `public` for the `external` profile) unless the gateway definition overrides it with the `context` parameter. From that context, dialplan rules match on the destination number and route the call. The `public` context and inbound dialplan routing are covered in Chapter 5: Dialplan.
+Inbound SIP INVITE requests arriving from a registered or IP-authenticated trunk enter the dialplan context configured on the parent Sofia profile (typically `public` for the `external` profile) unless the gateway definition overrides it with the `context` parameter. From that context, dialplan rules match on the destination number and route the call. The `public` context and inbound dialplan routing are covered in [Chapter 13: Inbound Calls and the Public Context](/dialplan/public-context).

--- a/docs/users-endpoints/index.mdx
+++ b/docs/users-endpoints/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Part 3: Users and Endpoints"
 slug: /users-and-endpoints
-description: Define users and connect SIP, WebRTC, and gateway endpoints.
+description: "Define users and connect SIP, WebRTC, and gateway endpoints."
 ---
 
 import DocCardList from '@theme/DocCardList';

--- a/docs/users-endpoints/other-endpoints.mdx
+++ b/docs/users-endpoints/other-endpoints.mdx
@@ -75,7 +75,7 @@ loopback/app=<application>[:<argument>]
 
 ### Parameters {#loopback-parameters}
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `early-set-loopback-id` | Set the loopback channel variables `loopback_leg` and `is_loopback` on both legs before the B-leg is answered | `true` / `false` | `false` |
 | `fire-bowout-on-bridge` | Fire `loopback::direct` custom events when a media-path bowout bridge is executed | `true` / `false` | `false` |
@@ -158,7 +158,7 @@ Each file under `skinny_profiles/` defines one listener profile. The vanilla pro
 
 Changing `ip` or `port` sets a `PFLAG_SHOULD_RESPAWN` flag on the profile. `odbc-dsn` cannot be changed while the listener socket is open.
 
-| Parameter | Purpose | Values | Default (compiled-in) |
+| Parameter | Purpose | Accepted Values | Default (compiled-in) |
 |---|---|---|---|
 | `domain` | Domain name sent to phones in SCCP messages | Hostname or IP string | (none; required) |
 | `ip` | IP address the SCCP TCP listener binds to | IPv4 address | (none; required) |
@@ -227,7 +227,7 @@ The `<device-types>` block allows per-model firmware overrides. Each `<device-ty
 
 The table below lists the compiled-in defaults. The vanilla `rtmp.conf.xml` overrides three of them: `auth-calls` is `true`, `chunksize` is `512`, and `buffer-len` is `50`.
 
-| Parameter | Purpose | Values | Compiled Default |
+| Parameter | Purpose | Accepted Values | Compiled Default |
 |---|---|---|---|
 | `bind-address` | IP address and port the RTMP listener binds to; not reloadable | `ip:port` string | `0.0.0.0:1935` |
 | `context` | Dialplan context for inbound RTMP calls | Context name | `public` |
@@ -263,7 +263,7 @@ The table below lists the compiled-in defaults. The vanilla `rtmp.conf.xml` over
 
 ### Parameters {#alsa-parameters}
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `dialplan` | Dialplan module used for inbound calls from the sound card | Module name | `default` |
 | `cid-name` | Caller ID name presented on outbound calls from this device | String | (none) |

--- a/docs/users-endpoints/sip-profiles-sofia.mdx
+++ b/docs/users-endpoints/sip-profiles-sofia.mdx
@@ -13,49 +13,49 @@ sidebar_label: "7. SIP Profiles with Sofia"
 
 ## Table of Contents
 
-- [1. The Sofia Profile Model](#1-the-sofia-profile-model)
-- [2. Global Sofia Settings](#2-global-sofia-settings)
-- [3. Profile File Structure](#3-profile-file-structure)
-  - [3.1 The `gateways` Block](#31-the-gateways-block)
-  - [3.2 The `aliases` Block](#32-the-aliases-block)
-  - [3.3 The `domains` Block](#33-the-domains-block)
-  - [3.4 The `settings` Block](#34-the-settings-block)
-- [4. Bundled Profiles](#4-bundled-profiles)
-  - [4.1 The `internal` Profile](#41-the-internal-profile)
-  - [4.2 The `external` Profile](#42-the-external-profile)
-- [5. Settings Parameter Reference](#5-settings-parameter-reference)
-  - [5.1 Identity and Binding](#51-identity-and-binding)
-  - [5.2 Authentication and Registration](#52-authentication-and-registration)
-  - [5.3 Presence and Registration Domain](#53-presence-and-registration-domain)
-  - [5.4 Media](#54-media)
-  - [5.5 DTMF](#55-dtmf)
-  - [5.6 Call Control and Timers](#56-call-control-and-timers)
-  - [5.7 NAT Traversal](#57-nat-traversal)
-  - [5.8 TLS](#58-tls)
-  - [5.9 WebSocket Bindings](#59-websocket-bindings)
-  - [5.10 Advanced Settings](#510-advanced-settings)
-  - [5.11 Proxy and Relay](#511-proxy-and-relay)
-  - [5.12 Transfer and REFER](#512-transfer-and-refer)
-  - [5.13 Extended Authentication and Blind Auth](#513-extended-authentication-and-blind-auth)
-  - [5.14 Extended ACL](#514-extended-acl)
-  - [5.15 TCP, Keepalive, and NAT Transport](#515-tcp-keepalive-and-nat-transport)
-  - [5.16 Extended Media and RTP](#516-extended-media-and-rtp)
-  - [5.17 Presence, MWI, and Chat](#517-presence-mwi-and-chat)
-  - [5.18 Registration Ping](#518-registration-ping)
-  - [5.19 Database Transaction Hooks](#519-database-transaction-hooks)
-  - [5.20 Identity, RFC 7989, and RFC 8760](#520-identity-rfc-7989-and-rfc-8760)
-  - [5.21 Miscellaneous](#521-miscellaneous)
-- [6. Getting Started: Minimal Working Profile](#6-getting-started-minimal-working-profile)
-- [7. Presence, BLF, and MWI](#7-presence-blf-and-mwi)
-  - [7.1 Enabling Presence](#71-enabling-presence)
-  - [7.2 BLF (Busy Lamp Field)](#72-blf-busy-lamp-field)
-  - [7.3 MWI (Message Waiting Indication)](#73-mwi-message-waiting-indication)
-  - [7.4 presence\_map.conf.xml](#74-presence_mapconfxml)
-  - [7.5 Presence Parameter Reference](#75-presence-parameter-reference)
+- [The Sofia Profile Model](#the-sofia-profile-model)
+- [Global Sofia Settings](#global-sofia-settings)
+- [Profile File Structure](#profile-file-structure)
+  - [The `gateways` Block](#the-gateways-block)
+  - [The `aliases` Block](#the-aliases-block)
+  - [The `domains` Block](#the-domains-block)
+  - [The `settings` Block](#the-settings-block)
+- [Bundled Profiles](#bundled-profiles)
+  - [The `internal` Profile](#the-internal-profile)
+  - [The `external` Profile](#the-external-profile)
+- [Settings Parameter Reference](#settings-parameter-reference)
+  - [Identity and Binding](#identity-and-binding)
+  - [Authentication and Registration](#authentication-and-registration)
+  - [Presence and Registration Domain](#presence-and-registration-domain)
+  - [Media](#media)
+  - [DTMF](#dtmf)
+  - [Call Control and Timers](#call-control-and-timers)
+  - [NAT Traversal](#nat-traversal)
+  - [TLS](#tls)
+  - [WebSocket Bindings](#websocket-bindings)
+  - [Advanced Settings](#advanced-settings)
+  - [Proxy and Relay](#proxy-and-relay)
+  - [Transfer and REFER](#transfer-and-refer)
+  - [Extended Authentication and Blind Auth](#extended-authentication-and-blind-auth)
+  - [Extended ACL](#extended-acl)
+  - [TCP, Keepalive, and NAT Transport](#tcp-keepalive-and-nat-transport)
+  - [Extended Media and RTP](#extended-media-and-rtp)
+  - [Presence, MWI, and Chat](#presence-mwi-and-chat)
+  - [Registration Ping](#registration-ping)
+  - [Database Transaction Hooks](#database-transaction-hooks)
+  - [Identity, RFC 7989, and RFC 8760](#identity-rfc-7989-and-rfc-8760)
+  - [Miscellaneous](#miscellaneous)
+- [Getting Started: Minimal Working Profile](#getting-started-minimal-working-profile)
+- [Presence, BLF, and MWI](#presence-blf-and-mwi)
+  - [Enabling Presence](#enabling-presence)
+  - [BLF (Busy Lamp Field)](#blf-busy-lamp-field)
+  - [MWI (Message Waiting Indication)](#mwi-message-waiting-indication)
+  - [presence\_map.conf.xml](#presence_mapconfxml)
+  - [Presence Parameter Reference](#presence-parameter-reference)
 
 ---
 
-## 1. The Sofia Profile Model
+## The Sofia Profile Model {#the-sofia-profile-model}
 
 Each Sofia SIP profile services exactly one IP address and port combination. Running multiple profiles is how FreeSWITCH presents separate SIP user agents on the same host, for example, one for internal registered phones and another for outbound carrier trunks. Profiles are independent: each has its own transport socket, [ACL rules](../integration/access-control-lists.mdx), [codec preferences](../media/codecs-and-negotiation.mdx), authentication requirements, and dialplan context.
 
@@ -71,7 +71,7 @@ To add a profile, place a new XML file in `conf/sip_profiles/` and execute `sofi
 
 ---
 
-## 2. Global Sofia Settings
+## Global Sofia Settings {#global-sofia-settings}
 
 `sofia.conf.xml` also contains a `global_settings` block that applies across all profiles.
 
@@ -85,7 +85,7 @@ To add a profile, place a new XML file in `conf/sip_profiles/` and execute `sofi
 </global_settings>
 ```
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `log-level` | Sofia-SIP stack verbosity | `0`-`9` | `0` |
 | `debug-presence` | Presence subsystem debug verbosity | `0`-`9` | `0` |
@@ -95,7 +95,7 @@ To add a profile, place a new XML file in `conf/sip_profiles/` and execute `sofi
 
 ---
 
-## 3. Profile File Structure
+## Profile File Structure {#profile-file-structure}
 
 A profile XML file follows this skeleton:
 
@@ -120,7 +120,7 @@ A profile XML file follows this skeleton:
 </profile>
 ```
 
-### 3.1 The `gateways` Block
+### The `gateways` Block {#the-gateways-block}
 
 Outbound SIP registrations to upstream carriers or SIP trunks are defined inside `<gateways>`. The external profile uses an include to load individual gateway files:
 
@@ -132,7 +132,7 @@ Outbound SIP registrations to upstream carriers or SIP trunks are defined inside
 
 Each gateway XML file defines one outbound registration. Gateways are covered in [Chapter 8: Gateways and Trunk Registration](../users-endpoints/gateways.mdx).
 
-### 3.2 The `aliases` Block
+### The `aliases` Block {#the-aliases-block}
 
 An alias is an alternative name by which a profile can be referenced in dialplan strings and API calls. Multiple aliases are permitted per profile.
 
@@ -145,7 +145,7 @@ An alias is an alternative name by which a profile can be referenced in dialplan
 
 Aliases allow dialplan bridge strings such as `sofia/default/1000@domain.com` to resolve to the `internal` profile even when the profile is named `internal`.
 
-### 3.3 The `domains` Block
+### The `domains` Block {#the-domains-block}
 
 The `domains` block controls two independent behaviors: whether the profile parses the directory for domain-level gateway definitions, and whether each listed domain is aliased to this profile for routing purposes.
 
@@ -155,7 +155,7 @@ The `domains` block controls two independent behaviors: whether the profile pars
 </domains>
 ```
 
-| Attribute | Purpose | Values |
+| Attribute | Purpose | Accepted Values |
 |---|---|---|
 | `name` | The domain to act on, or the special value `all` to match every configured domain | FQDN or `all` |
 | `alias` | Alias this domain name to the profile so SIP URIs addressed to the domain resolve here | `true`, `false` |
@@ -165,17 +165,17 @@ Setting `alias="true"` and `name="all"` causes every domain in the directory to 
 
 Setting `parse="true"` instructs the profile to read the XML directory for the named domain and load any `<gateway>` stanzas found there. The `external` profile uses `parse="true"` and `alias="false"` by default, loading directory-defined gateways without routing all domain traffic through it.
 
-### 3.4 The `settings` Block
+### The `settings` Block {#the-settings-block}
 
 All per-profile operational parameters are declared as `<param name="..." value="..."/>` elements inside `<settings>`. The complete reference is in Section 5.
 
 ---
 
-## 4. Bundled Profiles
+## Bundled Profiles {#bundled-profiles}
 
 The vanilla configuration ships two profiles: `internal` and `external`. They cover the two dominant use cases and serve as templates for custom profiles.
 
-### 4.1 The `internal` Profile
+### The `internal` Profile {#the-internal-profile}
 
 **File:** `conf/sip_profiles/internal.xml`
 
@@ -240,7 +240,7 @@ Key characteristics of the vanilla `internal` profile:
 </profile>
 ```
 
-### 4.2 The `external` Profile
+### The `external` Profile {#the-external-profile}
 
 **File:** `conf/sip_profiles/external.xml`
 
@@ -291,13 +291,13 @@ Key characteristics of the vanilla `external` profile:
 
 ---
 
-## 5. Settings Parameter Reference
+## Settings Parameter Reference {#settings-parameter-reference}
 
-### 5.1 Identity and Binding
+### Identity and Binding {#identity-and-binding}
 
 These parameters define what address and port the profile binds to, and how inbound calls are dispatched.
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `sip-ip` | Local IP address for the SIP transport socket. Use only IP addresses, not hostnames. Accepts `auto` (use the system-guessed IP), `interface:NAME` (resolve from a named network interface), or an explicit dotted-decimal address. | IP address, `auto`, `interface:[auto\|ipv4\|ipv6]/IFNAME` | System-guessed local IPv4 |
 | `sip-port` | UDP/TCP port the SIP transport listens on. Accepts `auto` to let the OS assign a port. | Port number or `auto` | `5060` |
@@ -311,9 +311,9 @@ These parameters define what address and port the profile binds to, and how inbo
 | `outbound-proxy` | Force all outbound SIP requests through this proxy URI. `sip:` scheme is prepended if absent. | SIP URI, e.g. `sip:proxy.example.com` | (none) |
 | `max-calls` | Maximum simultaneous calls allowed on this profile. `0` means unlimited. | Integer | `0` |
 
-### 5.2 Authentication and Registration
+### Authentication and Registration {#authentication-and-registration}
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `auth-calls` | Require digest authentication on inbound INVITE requests. | `true`, `false` | `false` |
 | `auth-all-packets` | When authentication is enabled, challenge every SIP request method, not only INVITE. | `true`, `false` | `false` |
@@ -330,9 +330,9 @@ These parameters define what address and port the profile binds to, and how inbo
 | `inbound-reg-force-matching-username` | Reject registrations where the `username` field of the `Authorization` header does not match the user portion of the `From` URI. | `true`, `false` | `false` |
 | `multiple-registrations` | Allow a single user to register from multiple devices simultaneously. `call-id` tracks registrations by Call-ID; `contact` tracks by Contact URI. `true` is treated as `contact`. | `false`, `call-id`, `contact`, `true` | `false` |
 
-### 5.3 Presence and Registration Domain
+### Presence and Registration Domain {#presence-and-registration-domain}
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `manage-presence` | Enable the presence engine on this profile. `true` enables full presence. `passive` enables presence in read-only/relay mode (used to share presence from the `internal` profile). `pnp` enables Plug and Play provisioning presence. `false` disables presence. | `true`, `false`, `passive`, `pnp` | `false` |
 | `presence-hosts` | Comma-separated list of hostnames or IPs that this profile serves for presence. Used to match presence subscriptions to the correct profile. | Comma-separated host list | (none) |
@@ -342,9 +342,9 @@ These parameters define what address and port the profile binds to, and how inbo
 | `record-path` | Default directory where call recordings initiated from this profile are stored. | Absolute path | Value of `$${recordings_dir}` |
 | `record-template` | Filename template for auto-recordings. Supports FreeSWITCH channel variable expansion and `${strftime(...)}`. | String with variable references | (none) |
 
-### 5.4 Media
+### Media {#media}
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `inbound-codec-prefs` | Ordered list of codecs offered to inbound callers in the SDP answer. | Comma-separated codec names, e.g. `OPUS,G722,PCMU,PCMA` | (none; uses global codec list) |
 | `outbound-codec-prefs` | Ordered list of codecs offered in SDP offers for outbound calls. | Comma-separated codec names | (none; uses global codec list) |
@@ -370,9 +370,9 @@ These parameters define what address and port the profile binds to, and how inbo
 | `rtcp-video-interval-msec` | Interval in milliseconds at which RTCP packets are sent for video streams. | Integer milliseconds or `passthru` | (none; RTCP disabled) |
 | `auto-jitterbuffer-msec` | Enable an automatic jitter buffer of the specified size (in milliseconds) on every call on this profile. Values below 20 ms are ignored. Can also be set per-channel with the `jitterbuffer_msec` channel variable. | Integer milliseconds | (none; jitter buffer disabled) |
 
-### 5.5 DTMF
+### DTMF {#dtmf}
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `dtmf-type` | DTMF method used for outbound legs. `rfc2833` sends DTMF as RFC 2833 telephone-event packets. `info` sends DTMF as SIP INFO messages. `none` disables automatic DTMF handling. | `rfc2833`, `info`, `none` | `rfc2833` |
 | `rfc2833-pt` | RTP payload type number for RFC 2833 telephone-event. Must match the remote endpoint's expectation. | Integer payload type | `101` |
@@ -380,9 +380,9 @@ These parameters define what address and port the profile binds to, and how inbo
 | `liberal-dtmf` | Accept DTMF using either RFC 2833 or SIP INFO without requiring the signaled method, improving compatibility with endpoints that send both. | `true`, `false` | `false` |
 | `rtp-digit-delay` | Milliseconds of delay to inject between consecutive RFC 2833 DTMF digits on send. Can help slow DTMF processors. Also overridable per-channel with the `rtp_digit_delay` variable. | Integer milliseconds | `40` |
 
-### 5.6 Call Control and Timers
+### Call Control and Timers {#call-control-and-timers}
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `enable-timer` | Enable SIP session timers (RFC 4028). When `false`, session refresh is disabled. | `true`, `false` | `true` |
 | `session-timeout` | Session timer interval in seconds placed in the `Session-Expires` SIP header. `0` disables session timers. | Integer seconds | `0` |
@@ -398,9 +398,9 @@ These parameters define what address and port the profile binds to, and how inbo
 | `max-proceeding` | Maximum number of simultaneous outbound dialogs in the proceeding state. `0` means unlimited. | Integer | `0` |
 | `max-recv-requests-per-second` | Rate limit for inbound SIP requests per second per profile. `0` disables the limit. | Integer | `1000` |
 
-### 5.7 NAT Traversal
+### NAT Traversal {#nat-traversal}
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `ext-rtp-ip` | Public IP address advertised in SDP for RTP. Used when the FreeSWITCH host is behind NAT. Accepts a literal IP, `auto` (system-guessed external IP), `auto-nat` (IP learned via NAT-PMP or UPnP), `stun:host` (STUN query), or `host:hostname` (DNS lookup). | IP address, `auto`, `auto-nat`, `stun:host`, `host:hostname` | (none; uses `rtp-ip`) |
 | `ext-sip-ip` | Public IP address advertised in SIP Contact and Via headers for the SIP transport. Accepts the same forms as `ext-rtp-ip`. | IP address, `auto`, `auto-nat`, `stun:host`, `host:hostname` | (none; uses `sip-ip`) |
@@ -410,11 +410,11 @@ These parameters define what address and port the profile binds to, and how inbo
 | `NDLB-received-in-nat-reg-contact` | Append `;received="ip:port"` to the Contact in REGISTER responses to assist NATed phones that do not detect their own public address. | `true`, `false` | `false` |
 | `NDLB-force-rport` | Force `rport` handling for NAT. `true` enables forced rport on both server and client; `safe` enables it only where it will not break compliant endpoints; `client-only` or `server-only` restrict to one direction; `disabled` turns it off entirely. | `true`, `false`, `safe`, `client-only`, `server-only`, `disabled` | Server and client both at level 1 (standard rport) |
 
-### 5.8 TLS
+### TLS {#tls}
 
 TLS is disabled by default. Enabling it requires setting `tls` to `true` and providing valid certificate files in `tls-cert-dir`. The default TLS port for the internal profile is `5061`; for the external profile it is `5081`.
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `tls` | Enable TLS transport on this profile. | `true`, `false` | `false` |
 | `tls-only` | When `true`, the profile does not bind the plain SIP port (`sip-port`) and accepts connections only on the TLS port. | `true`, `false` | `false` |
@@ -431,16 +431,16 @@ TLS is disabled by default. Enabling it requires setting `tls` to `true` and pro
 | `tls-timeout` | Timeout in seconds for inactive TLS connections before they are closed. | Integer seconds | `300` |
 | `tls-orq-connect-timeout` | Timeout in milliseconds for outgoing TLS connection attempts. When the timeout expires, FreeSWITCH retries and may use an alternate DNS-resolved address. `0` disables the timeout. | Integer milliseconds | `0` |
 
-### 5.9 WebSocket Bindings
+### WebSocket Bindings {#websocket-bindings}
 
 These parameters add WebSocket and secure WebSocket listeners to the profile, enabling SIP over WebSocket for WebRTC clients. They are independent of the TLS setting.
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `ws-binding` | IP address and port for the WebSocket (WS) listener. Format is `[ip]:port`. Omitting the IP binds all interfaces. | `[ip]:port`, e.g. `:5066` | (none) |
 | `wss-binding` | IP address and port for the secure WebSocket (WSS) listener. Requires a `wss.pem` certificate in `$${certs_dir}`, which is auto-generated if absent. When `tls-cert-dir` is set, FreeSWITCH also looks for `wss.key` and `wss.crt` in that directory. | `[ip]:port`, e.g. `:7443` | (none) |
 
-### 5.10 Advanced Settings
+### Advanced Settings {#advanced-settings}
 
 The following parameters are accepted by the parser but are less commonly set by operators. They are listed here for completeness. Verify current behavior against `sofia.c` before use.
 
@@ -507,7 +507,7 @@ The following parameters are accepted by the parser but are less commonly set by
 | `user-agent-filter` | A regex or string; only process requests whose `User-Agent` header matches. | (none) |
 | `max-registrations-per-extension` | Limit the number of simultaneous registrations per extension number. `0` means unlimited. | `0` |
 
-### 5.11 Proxy and Relay
+### Proxy and Relay {#proxy-and-relay}
 
 These parameters make the profile pass selected SIP requests through to the dialplan (or bridged leg) instead of handling them internally. Each can also be toggled per-call with the matching `sip_proxy_*` channel variable.
 
@@ -522,7 +522,7 @@ These parameters make the profile pass selected SIP requests through to the dial
 | `sip-subscribe-respond-200-ok` | Answer inbound SIP SUBSCRIBE requests with `200 OK` instead of `202 Accepted`. Vanilla `internal.xml` ships this commented out. | `true`, `false` | `false` |
 | `pnp-provision-url` | Provisioning URL handed to Plug-and-Play (PnP) endpoints. Used together with `manage-presence` = `pnp`. | URL string | (none) |
 
-### 5.12 Transfer and REFER
+### Transfer and REFER {#transfer-and-refer}
 
 | Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
@@ -531,7 +531,7 @@ These parameters make the profile pass selected SIP requests through to the dial
 | `channel-xml-fetch-on-nightmare-transfer` | During a nightmare transfer, fetch the channel XML from the directory/dialplan to rebuild caller data on the transferred leg. | `true`, `false` | `false` |
 | `fire-transfer-events` | Fire a FreeSWITCH event for each SIP transfer (REFER) processed on this profile. | `true`, `false` | `false` |
 
-### 5.13 Extended Authentication and Blind Auth
+### Extended Authentication and Blind Auth {#extended-authentication-and-blind-auth}
 
 | Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
@@ -544,7 +544,7 @@ These parameters make the profile pass selected SIP requests through to the dial
 | `disable-auth-subscriptions` | Inverse of `auth-subscriptions`. `true` disables digest auth for SUBSCRIBE requests; `false` requires it. Overrides `auth-subscriptions` when both are present. | `true`, `false` | `false` (auth on) |
 | `rfc8760-auth-algorithms` | Comma-separated, priority-ordered list of RFC 8760 digest algorithms to offer/accept (in addition to MD5). Up to 6 algorithms; unknown tokens are ignored and the list is sorted into the compiled priority order. | e.g. `SHA-256,SHA-512-256` | (none; MD5 only) |
 
-### 5.14 Extended ACL
+### Extended ACL {#extended-acl}
 
 | Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
@@ -553,7 +553,7 @@ These parameters make the profile pass selected SIP requests through to the dial
 | `apply-proxy-acl-x-token` | Name of an `X-` header whose value supplies the token-based source identity for the proxy ACL check. | Header name | (none) |
 | `use-port-for-acl-check` | Include the source (or token-supplied) port, not just the IP, when evaluating ACLs. | `true`, `false` | `false` |
 
-### 5.15 TCP, Keepalive, and NAT Transport
+### TCP, Keepalive, and NAT Transport {#tcp-keepalive-and-nat-transport}
 
 | Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
@@ -566,7 +566,7 @@ These parameters make the profile pass selected SIP requests through to the dial
 | `tls-always-nat` | Treat all endpoints reached over TLS as NATed, regardless of ACL detection. | `true`, `false` | `false` |
 | `tcp-unreg-on-socket-close` | Unregister a contact when its TCP/TLS connection socket closes (useful with `reuse-connections`). | `true`, `false` | `false` |
 
-### 5.16 Extended Media and RTP
+### Extended Media and RTP {#extended-media-and-rtp}
 
 | Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
@@ -578,7 +578,7 @@ These parameters make the profile pass selected SIP requests through to the dial
 | `enable-soa` | Use the Sofia SOA (SDP offer/answer) engine. Set `false` for raw SDP passthrough where FreeSWITCH should not parse/rewrite SDP via SOA. | `true`, `false` | `true` |
 | `NDLB-support-asterisk-missing-srtp-auth` | Disable SRTP authentication to interoperate with Asterisk builds that omit the SRTP auth tag. | `true`, `false` | `false` |
 
-### 5.17 Presence, MWI, and Chat
+### Presence, MWI, and Chat {#presence-mwi-and-chat}
 
 | Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
@@ -590,7 +590,7 @@ These parameters make the profile pass selected SIP requests through to the dial
 | `enable-chat` | Enable SIP chat (MESSAGE) handling on this profile. When `false`, chat is disabled. | `true`, `false` | `true` |
 | `in-dialog-chat` | Allow SIP MESSAGE within an established dialog to be delivered as in-call chat. | `true`, `false` | `false` |
 
-### 5.18 Registration Ping
+### Registration Ping {#registration-ping}
 
 These parameters tune the background thread that probes registered users (the user-ping loop, distinct from `nat-options-ping`).
 
@@ -601,7 +601,7 @@ These parameters tune the background thread that probes registered users (the us
 | `ping-thread-frequency` | How often (seconds) the ping thread wakes to process due pings. Negative values reset to the compiled default. | Integer seconds | `1` |
 | `ping-mean-interval` | Mean interval (seconds) between pings for a given registered user. Negative values reset to the compiled default. | Integer seconds | `30` |
 
-### 5.19 Database Transaction Hooks
+### Database Transaction Hooks {#database-transaction-hooks}
 
 SQL statements executed by the profile's registration/dialog database thread. Use with care; intended for tuning external databases (for example PRAGMA or session settings).
 
@@ -612,7 +612,7 @@ SQL statements executed by the profile's registration/dialog database thread. Us
 | `db-inner-pre-trans-execute` | SQL executed before each inner database transaction. | SQL string | (none) |
 | `db-inner-post-trans-execute` | SQL executed after each inner database transaction. | SQL string | (none) |
 
-### 5.20 Identity, RFC 7989, and RFC 8760
+### Identity, RFC 7989, and RFC 8760 {#identity-rfc-7989-and-rfc-8760}
 
 | Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
@@ -626,7 +626,7 @@ SQL statements executed by the profile's registration/dialog database thread. Us
 | `extended-info-parsing` | Parse and expose additional fields from inbound SIP INFO requests. | `true`, `false` | `false` |
 | `parse-invite-tel-params` | Parse `tel:` URI parameters from inbound INVITE Request-URIs and expose them to the channel. | `true`, `false` | `false` |
 
-### 5.21 Miscellaneous
+### Miscellaneous {#miscellaneous}
 
 | Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
@@ -639,7 +639,7 @@ SQL statements executed by the profile's registration/dialog database thread. Us
 
 ---
 
-## 6. Getting Started: Minimal Working Profile
+## Getting Started: Minimal Working Profile {#getting-started-minimal-working-profile}
 
 The following is a minimal profile sufficient to accept and authenticate SIP calls on a single NATed host. Expand it by adding parameters from the reference tables above as your deployment requires.
 
@@ -707,11 +707,11 @@ The profile should appear with its bound SIP URI and transport.
 
 ---
 
-## 7. Presence, BLF, and MWI
+## Presence, BLF, and MWI {#presence-blf-and-mwi}
 
 Presence, Busy Lamp Field (BLF), and Message Waiting Indication (MWI) all rely on the SIP SUBSCRIBE/NOTIFY mechanism. A phone sends a SUBSCRIBE for a specific event package; FreeSWITCH responds with a NOTIFY whenever the relevant state changes. The profile parameters in this section control whether FreeSWITCH accepts those subscriptions and how it handles them.
 
-### 7.1 Enabling Presence
+### Enabling Presence {#enabling-presence}
 
 Presence is controlled by the `manage-presence` parameter on each profile. When set to `true`, the profile registers a full presence engine: it accepts SUBSCRIBE requests for dialog (BLF) and message-summary (MWI) event packages, stores subscriptions in the `sip_subscriptions` database table, and sends NOTIFY messages when state changes.
 
@@ -733,7 +733,7 @@ If a phone subscribes to `sip:1001@pbx.example.com` and `pbx.example.com` is lis
 
 The `presence-privacy` parameter suppresses caller identity in presence NOTIFYs. When `true`, the status line in NOTIFY bodies for `early`, `confirmed`, and `hold` states omits the remote party name or number, showing only generic text such as `Ring`, `On The Phone`, or `Hold`. This limits information visible to BLF watchers.
 
-### 7.2 BLF (Busy Lamp Field)
+### BLF (Busy Lamp Field) {#blf-busy-lamp-field}
 
 BLF is implemented using the `dialog` SIP event package (RFC 4235). A phone with a BLF key sends a SUBSCRIBE request targeting the extension it wants to monitor:
 
@@ -757,7 +757,7 @@ The `manage-shared-appearance` parameter enables Shared Line Appearance per the 
 <param name="manage-shared-appearance" value="true"/>
 ```
 
-### 7.3 MWI (Message Waiting Indication)
+### MWI (Message Waiting Indication) {#mwi-message-waiting-indication}
 
 MWI uses the `message-summary` SIP event package (RFC 3842). A phone subscribes to the event package for its own address:
 
@@ -797,7 +797,7 @@ If a user's voicemail mailbox is different from their SIP registration address, 
 
 The `mwi-account` value is a `user@host` string. If the host portion is absent, FreeSWITCH falls back to the registration host.
 
-### 7.4 presence\_map.conf.xml
+### presence\_map.conf.xml {#presence_mapconfxml}
 
 `presence_map.conf.xml` maps extension regex patterns to presence protocol identifiers. It is consulted when the profile parameter `presence-proto-lookup` is `true` and a SUBSCRIBE arrives for an extension whose protocol cannot be determined from the subscription itself. FreeSWITCH calls `switch_ivr_check_presence_mapping()`, which opens the config, iterates domain/extension entries, and returns the first `proto` whose `regex` matches the subscribed extension name.
 
@@ -826,11 +826,11 @@ The file lives at `conf/autoload_configs/presence_map.conf.xml`. Structure:
 
 Use `name="*"` on the `domain` element to match all domains. Each `exten` element is evaluated in document order and the first match wins. If no entry matches, FreeSWITCH uses standard presence handling.
 
-### 7.5 Presence Parameter Reference
+### Presence Parameter Reference {#presence-parameter-reference}
 
 The following parameters appear in the profile `settings` block. Parameters already covered in Section 5.3 are repeated here for completeness as part of the presence feature group.
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |---|---|---|---|
 | `manage-presence` | Enable or disable the presence engine on this profile. `true` enables full SUBSCRIBE/NOTIFY handling. `passive` relays presence from a primary profile. `pnp` enables plug-and-play provisioning presence. `false` disables presence. | `true`, `false`, `passive`, `pnp` | `false` |
 | `presence-hosts` | Comma-separated list of hostnames or IP addresses that this profile services for presence subscriptions. Used to match SUBSCRIBE Request-URI hosts and to query `sip_subscriptions`. | Comma-separated host list | (none) |

--- a/docs/users-endpoints/sip-profiles-sofia.mdx
+++ b/docs/users-endpoints/sip-profiles-sofia.mdx
@@ -34,6 +34,17 @@ sidebar_label: "7. SIP Profiles with Sofia"
   - [5.8 TLS](#58-tls)
   - [5.9 WebSocket Bindings](#59-websocket-bindings)
   - [5.10 Advanced Settings](#510-advanced-settings)
+  - [5.11 Proxy and Relay](#511-proxy-and-relay)
+  - [5.12 Transfer and REFER](#512-transfer-and-refer)
+  - [5.13 Extended Authentication and Blind Auth](#513-extended-authentication-and-blind-auth)
+  - [5.14 Extended ACL](#514-extended-acl)
+  - [5.15 TCP, Keepalive, and NAT Transport](#515-tcp-keepalive-and-nat-transport)
+  - [5.16 Extended Media and RTP](#516-extended-media-and-rtp)
+  - [5.17 Presence, MWI, and Chat](#517-presence-mwi-and-chat)
+  - [5.18 Registration Ping](#518-registration-ping)
+  - [5.19 Database Transaction Hooks](#519-database-transaction-hooks)
+  - [5.20 Identity, RFC 7989, and RFC 8760](#520-identity-rfc-7989-and-rfc-8760)
+  - [5.21 Miscellaneous](#521-miscellaneous)
 - [6. Getting Started: Minimal Working Profile](#6-getting-started-minimal-working-profile)
 - [7. Presence, BLF, and MWI](#7-presence-blf-and-mwi)
   - [7.1 Enabling Presence](#71-enabling-presence)
@@ -495,6 +506,136 @@ The following parameters are accepted by the parser but are less commonly set by
 | `p-asserted-id-parse` | Controls how the `P-Asserted-Identity` header is parsed for inbound calls. `default` uses the display name and URI. `user-only` extracts only the user portion. `user-domain` extracts user and domain. `verbatim` passes the raw header value. | `default` |
 | `user-agent-filter` | A regex or string; only process requests whose `User-Agent` header matches. | (none) |
 | `max-registrations-per-extension` | Limit the number of simultaneous registrations per extension number. `0` means unlimited. | `0` |
+
+### 5.11 Proxy and Relay
+
+These parameters make the profile pass selected SIP requests through to the dialplan (or bridged leg) instead of handling them internally. Each can also be toggled per-call with the matching `sip_proxy_*` channel variable.
+
+| Parameter | Purpose | Accepted Values | Default |
+|---|---|---|---|
+| `proxy-info` | Relay inbound SIP INFO requests across a bridge instead of handling them locally. Can be overridden per-call with the `sip_proxy_info` channel variable. | `true`, `false` | `false` |
+| `proxy-info-content-types` | Restrict `proxy-info` to INFO messages whose `Content-Type` matches one of the listed types. Empty or unset proxies all INFO content types. | Comma/space-separated content-type list | (none; all types proxied) |
+| `proxy-message` | Relay inbound SIP MESSAGE requests across a bridge instead of handling them as chat locally. Can be overridden per-call with the `sip_proxy_message` channel variable. | `true`, `false` | `false` |
+| `proxy-notify-events` | Relay in-dialog NOTIFY requests for the listed event packages to the bridged leg. `all` proxies every event type; otherwise a substring match against the NOTIFY `Event` type is used. | `all`, or event-type list | (none) |
+| `proxy-hold` | Pass hold/unhold (re-INVITE with `sendonly`/`inactive`) through transparently in proxy/bypass-media scenarios rather than generating hold locally. | `true`, `false` | `false` |
+| `sip-messages-respond-200-ok` | Answer inbound SIP MESSAGE requests with `200 OK` instead of `202 Accepted`. Vanilla `internal.xml` ships this commented out. | `true`, `false` | `false` |
+| `sip-subscribe-respond-200-ok` | Answer inbound SIP SUBSCRIBE requests with `200 OK` instead of `202 Accepted`. Vanilla `internal.xml` ships this commented out. | `true`, `false` | `false` |
+| `pnp-provision-url` | Provisioning URL handed to Plug-and-Play (PnP) endpoints. Used together with `manage-presence` = `pnp`. | URL string | (none) |
+
+### 5.12 Transfer and REFER
+
+| Parameter | Purpose | Accepted Values | Default |
+|---|---|---|---|
+| `confirm-blind-transfer` | Wait for the transfer target to answer before completing (and acknowledging) a blind REFER, so the transferee is not dropped if the target fails. | `true`, `false` | `false` |
+| `make-every-transfer-a-nightmare` | Force the "nightmare transfer" code path (full re-routing through the dialplan) for all transfers, not only cross-profile ones. Diagnostic/compatibility option. | `true`, `false` | `false` |
+| `channel-xml-fetch-on-nightmare-transfer` | During a nightmare transfer, fetch the channel XML from the directory/dialplan to rebuild caller data on the transferred leg. | `true`, `false` | `false` |
+| `fire-transfer-events` | Fire a FreeSWITCH event for each SIP transfer (REFER) processed on this profile. | `true`, `false` | `false` |
+
+### 5.13 Extended Authentication and Blind Auth
+
+| Parameter | Purpose | Accepted Values | Default |
+|---|---|---|---|
+| `auth-calls-acl-only` | When `auth-calls` is enabled, treat a successful inbound ACL match as sufficient authorization and skip the digest challenge. Requires `auth-calls` = `true`. | `true`, `false` | `false` |
+| `auth-require-user` | Require the SIP `From` user (or `Authorization` username) to be present and resolvable before authenticating a request. | `true`, `false` | `false` |
+| `accept-blind-auth` | Accept any digest response without verifying the password. Testing only. (Documented for context; see Section 5.2.) | `true`, `false` | `false` |
+| `enforce-blind-auth-result` | When `accept-blind-auth` is on, still honor the underlying directory lookup result: reject the request if blind auth lookup fails rather than blindly accepting. | `true`, `false` | `false` |
+| `blind-auth-reply-403` | When `enforce-blind-auth-result` rejects a blind-auth request, reply `403 Forbidden` instead of re-challenging. | `true`, `false` | `false` |
+| `disable-auth-messages` | Inverse of `auth-messages`. `true` disables digest auth for inbound MESSAGE requests; `false` requires it. Overrides `auth-messages` when both are present. | `true`, `false` | `false` (auth on) |
+| `disable-auth-subscriptions` | Inverse of `auth-subscriptions`. `true` disables digest auth for SUBSCRIBE requests; `false` requires it. Overrides `auth-subscriptions` when both are present. | `true`, `false` | `false` (auth on) |
+| `rfc8760-auth-algorithms` | Comma-separated, priority-ordered list of RFC 8760 digest algorithms to offer/accept (in addition to MD5). Up to 6 algorithms; unknown tokens are ignored and the list is sorted into the compiled priority order. | e.g. `SHA-256,SHA-512-256` | (none; MD5 only) |
+
+### 5.14 Extended ACL
+
+| Parameter | Purpose | Accepted Values | Default |
+|---|---|---|---|
+| `apply-candidate-acl` | ACL applied to ICE/media candidate addresses (WebRTC). Multiple instances are supported up to the candidate-ACL maximum. Use `none` to clear. | ACL name or `none` | (none) |
+| `apply-inbound-acl-x-token` | Name of an `X-` header whose value supplies a token-based source identity for the inbound ACL check, allowing ACL evaluation against a trusted upstream-supplied address. | Header name | (none) |
+| `apply-proxy-acl-x-token` | Name of an `X-` header whose value supplies the token-based source identity for the proxy ACL check. | Header name | (none) |
+| `use-port-for-acl-check` | Include the source (or token-supplied) port, not just the IP, when evaluating ACLs. | `true`, `false` | `false` |
+
+### 5.15 TCP, Keepalive, and NAT Transport
+
+| Parameter | Purpose | Accepted Values | Default |
+|---|---|---|---|
+| `tcp-keepalive` | Enable and set the TCP keepalive interval (milliseconds) on SIP TCP connections, passed to the transport as `TPTAG_KEEPALIVE`. | Integer milliseconds | (off unless set) |
+| `socket-tcp-keepalive` | Enable and set the OS socket-level TCP keepalive (`SO_KEEPALIVE`) interval in milliseconds (`TPTAG_SOCKET_KEEPALIVE`). | Integer milliseconds | (off unless set) |
+| `tcp-pingpong` | Enable Sofia ping-pong keepalive on TCP and set its interval (milliseconds). | Integer milliseconds | (off unless set) |
+| `tcp-ping2pong` | Enable the stricter ping2pong keepalive variant on TCP and set its interval (milliseconds). | Integer milliseconds | (off unless set) |
+| `keepalive-method` | Method used for SIP-level keepalive pings to endpoints. `info` sends SIP INFO; any other value uses SIP MESSAGE. | `info`, `message` | `message` |
+| `tcp-always-nat` | Treat all endpoints reached over TCP as NATed, regardless of ACL detection. | `true`, `false` | `false` |
+| `tls-always-nat` | Treat all endpoints reached over TLS as NATed, regardless of ACL detection. | `true`, `false` | `false` |
+| `tcp-unreg-on-socket-close` | Unregister a contact when its TCP/TLS connection socket closes (useful with `reuse-connections`). | `true`, `false` | `false` |
+
+### 5.16 Extended Media and RTP
+
+| Parameter | Purpose | Accepted Values | Default |
+|---|---|---|---|
+| `cng-pt` | RTP payload type used for Comfort Noise Generation. Ignored when `suppress-cng` is set (which forces it to `0`). | Integer payload type | `13` |
+| `manual-rtp-bugs` | Comma-separated list of RTP bug workarounds applied manually to audio (same token set as `auto-rtp-bugs`). Use `clear` to reset. | RTP-bug token list or `clear` | (none) |
+| `manual-video-rtp-bugs` | Comma-separated list of RTP bug workarounds applied manually to video. | RTP-bug token list or `clear` | (none) |
+| `rtp-notimer-during-bridge` | Disable the RTP soft timer while a call is bridged, letting the bridged peer pace media. | `true`, `false` | `false` |
+| `ignore-183nosdp` | Ignore `183 Session Progress` responses that arrive without SDP rather than treating them as early media. Also settable per-call via `sip_ignore_183nosdp`. | `true`, `false` | `false` |
+| `enable-soa` | Use the Sofia SOA (SDP offer/answer) engine. Set `false` for raw SDP passthrough where FreeSWITCH should not parse/rewrite SDP via SOA. | `true`, `false` | `true` |
+| `NDLB-support-asterisk-missing-srtp-auth` | Disable SRTP authentication to interoperate with Asterisk builds that omit the SRTP auth tag. | `true`, `false` | `false` |
+
+### 5.17 Presence, MWI, and Chat
+
+| Parameter | Purpose | Accepted Values | Default |
+|---|---|---|---|
+| `presence-disable-early` | Suppress `early` (ringing) dialog state in presence/BLF NOTIFYs, reporting only confirmed and terminated states. Also settable per-call. | `true`, `false` | `false` |
+| `mwi-use-reg-callid` | Send MWI NOTIFYs using the Call-ID stored from the endpoint's REGISTER, improving delivery to phones that key MWI on the registration dialog. | `true`, `false` | `false` |
+| `forward-unsolicited-mwi-notify` | Forward unsolicited (gateway-originated) MWI NOTIFY messages on to matching subscribers. | `true`, `false` | `false` |
+| `send-message-query-on-register` | On REGISTER, query stored messages (SIP MESSAGE) for the user. `true`/`all` runs on every REGISTER; `first-only` runs only on the first REGISTER. | `true`, `all`, `first-only`, `false` | `first-only` |
+| `fire-message-events` | Fire a FreeSWITCH event for each inbound SIP MESSAGE processed on this profile. | `true`, `false` | `false` |
+| `enable-chat` | Enable SIP chat (MESSAGE) handling on this profile. When `false`, chat is disabled. | `true`, `false` | `true` |
+| `in-dialog-chat` | Allow SIP MESSAGE within an established dialog to be delivered as in-call chat. | `true`, `false` | `false` |
+
+### 5.18 Registration Ping
+
+These parameters tune the background thread that probes registered users (the user-ping loop, distinct from `nat-options-ping`).
+
+| Parameter | Purpose | Accepted Values | Default |
+|---|---|---|---|
+| `sip-user-ping-min` | Minimum consecutive successful probes before a user is considered reachable/up. | Integer | `1` |
+| `sip-user-ping-max` | Maximum consecutive failed probes before a user is considered unreachable/down. | Integer | `3` |
+| `ping-thread-frequency` | How often (seconds) the ping thread wakes to process due pings. Negative values reset to the compiled default. | Integer seconds | `1` |
+| `ping-mean-interval` | Mean interval (seconds) between pings for a given registered user. Negative values reset to the compiled default. | Integer seconds | `30` |
+
+### 5.19 Database Transaction Hooks
+
+SQL statements executed by the profile's registration/dialog database thread. Use with care; intended for tuning external databases (for example PRAGMA or session settings).
+
+| Parameter | Purpose | Accepted Values | Default |
+|---|---|---|---|
+| `db-pre-trans-execute` | SQL executed before each outer database transaction. | SQL string | (none) |
+| `db-post-trans-execute` | SQL executed after each outer database transaction. | SQL string | (none) |
+| `db-inner-pre-trans-execute` | SQL executed before each inner database transaction. | SQL string | (none) |
+| `db-inner-post-trans-execute` | SQL executed after each inner database transaction. | SQL string | (none) |
+
+### 5.20 Identity, RFC 7989, and RFC 8760
+
+| Parameter | Purpose | Accepted Values | Default |
+|---|---|---|---|
+| `username` | Username placed in the SDP origin (`o=`) line generated by this profile. | String | `FreeSWITCH` |
+| `ext-sip-port` | Public SIP port advertised in Contact/Via when behind NAT, when it differs from the bound `sip-port`. Set automatically by `ext-sip-ip` STUN resolution; can be overridden explicitly. Values of `0` or less are ignored. | Port number | (none; uses `sip-port`) |
+| `rfc-7989` | Enable RFC 7989 SIP Session-ID generation and propagation. | `true`, `false` | `false` |
+| `rfc-7989-filter` | Header-name filter controlling which messages carry the Session-ID, used with `rfc-7989`. | Filter string | (none) |
+| `rfc-7989-force-old` | Force the older (pre-final) RFC 7989 Session-ID format for interoperability with early implementations. | `true`, `false` | `false` |
+| `cid-in-1xx` | Include caller/callee identity (Remote-Party-ID / P-Asserted-Identity) in `1xx` provisional responses. Vanilla `internal.xml` ships this commented out. | `true`, `false` | `true` |
+| `full-id-in-dialplan` | Expose the full SIP `From` identity (URI including parameters) to the dialplan rather than just the user portion. | `true`, `false` | `false` |
+| `extended-info-parsing` | Parse and expose additional fields from inbound SIP INFO requests. | `true`, `false` | `false` |
+| `parse-invite-tel-params` | Parse `tel:` URI parameters from inbound INVITE Request-URIs and expose them to the channel. | `true`, `false` | `false` |
+
+### 5.21 Miscellaneous
+
+| Parameter | Purpose | Accepted Values | Default |
+|---|---|---|---|
+| `track-calls` | Enable call tracking (recovery state persisted to the database for this profile). Once enabled it is not cleared by a `false` value during the same load. | `true` | `false` |
+| `update-refresher` | Include the `refresher` parameter in `Session-Expires` on UPDATE requests. Also settable per-call via `sip_update_refresher`. | `true`, `false` | `false` |
+| `auto-invite-100` | Automatically send `100 Trying` for inbound INVITEs. Vanilla `internal.xml` ships this commented out. | `true`, `false` | `true` |
+| `3pcc-reinvite-bridged-on-ack` | In 3PCC, send the bridged re-INVITE on receipt of ACK rather than earlier, improving compatibility with some 3PCC flows. | `true`, `false` | `false` |
+| `inbound-reg-in-new-thread` | Process each inbound REGISTER in its own thread. Vanilla `internal.xml` ships this commented out. | `true`, `false` | `false` |
+| `fire-bye-response-events` | Fire a FreeSWITCH event when a response to an outbound BYE is received. | `true`, `false` | `false` |
 
 ---
 

--- a/docs/users-endpoints/sip-profiles-sofia.mdx
+++ b/docs/users-endpoints/sip-profiles-sofia.mdx
@@ -447,7 +447,7 @@ The following parameters are accepted by the parser but are less commonly set by
 | `enable-compact-headers` | Send SIP messages using compact header forms. | `false` |
 | `enable-3pcc` | Enable third-party call control. `true` accepts immediately; `proxy` waits for answer. | `false` |
 | `enable-rfc-5626` | Include `reg-id` and `sip.instance` parameters in REGISTER requests (RFC 5626 outbound). | `false` |
-| `rtp-autoflush-during-bridge` | Flush RTP buffers during bridge when the socket already has data, reducing latency on lossy links. | `true` |
+| `rtp-autoflush-during-bridge` | Flushes RTP buffers during bridge when the socket already has data, reducing latency on lossy links. Not configurable: `mod_sofia` does not parse this as a profile param; the behavior is a hardcoded profile default that is always on. | `true` (hardcoded) |
 | `manage-shared-appearance` | Enable Bridged Line Appearance (BLA/SCA) for shared line management per the BroadSoft spec. | `false` |
 | `parse-all-invite-headers` | Parse and expose all SIP headers from inbound INVITE requests as channel variables. | `false` |
 | `pass-callee-id` | Pass callee identity information to the far end as `X-` headers. | `true` |

--- a/docs/users-endpoints/sip-profiles-sofia.mdx
+++ b/docs/users-endpoints/sip-profiles-sofia.mdx
@@ -57,7 +57,7 @@ sidebar_label: "7. SIP Profiles with Sofia"
 
 ## 1. The Sofia Profile Model
 
-Each Sofia SIP profile services exactly one IP address and port combination. Running multiple profiles is how FreeSWITCH presents separate SIP user agents on the same host, for example, one for internal registered phones and another for outbound carrier trunks. Profiles are independent: each has its own transport socket, ACL rules, codec preferences, authentication requirements, and dialplan context.
+Each Sofia SIP profile services exactly one IP address and port combination. Running multiple profiles is how FreeSWITCH presents separate SIP user agents on the same host, for example, one for internal registered phones and another for outbound carrier trunks. Profiles are independent: each has its own transport socket, [ACL rules](../integration/access-control-lists.mdx), [codec preferences](../media/codecs-and-negotiation.mdx), authentication requirements, and dialplan context.
 
 All profile XML files live under `conf/sip_profiles/`. The module-level configuration file `conf/autoload_configs/sofia.conf.xml` uses an `X-PRE-PROCESS` include directive to load every `*.xml` file from that directory:
 
@@ -130,7 +130,7 @@ Outbound SIP registrations to upstream carriers or SIP trunks are defined inside
 </gateways>
 ```
 
-Each gateway XML file defines one outbound registration. Gateways are covered in Chapter 8: Gateways.
+Each gateway XML file defines one outbound registration. Gateways are covered in [Chapter 8: Gateways and Trunk Registration](../users-endpoints/gateways.mdx).
 
 ### 3.2 The `aliases` Block
 

--- a/docs/users-endpoints/user-directory.mdx
+++ b/docs/users-endpoints/user-directory.mdx
@@ -44,7 +44,7 @@ The directory section of the FreeSWITCH configuration tree lives under `conf/dir
 
 This directive causes every `.xml` file in `conf/directory/default/` to be merged into the enclosing `<users>` block at configuration parse time. Each included file must be a valid XML fragment wrapped in `<include>` tags and containing one or more `<user>` elements.
 
-Files are merged, not overridden. Adding a new file to `conf/directory/default/` is sufficient to register a new user; no changes to `default.xml` are required. The merge order follows filesystem glob expansion, which is typically alphabetical.
+Files are merged, not overridden. Adding a new file to `conf/directory/default/` is sufficient to register a new user; no changes to `default.xml` are required. The merge order follows glob expansion, which FreeSWITCH sorts alphabetically by filename.
 
 ---
 
@@ -191,21 +191,21 @@ All `vm-*` params are read from the user's `<params>` block by mod_voicemail. Th
 | `vm-enabled` | When `false`, voicemail is disabled for this user. Calls routed to voicemail return an invalid-extension prompt. | `true`, `false` | `true` |
 | `vm-mailto` | Email address to which new voicemail messages are sent as audio attachments or notifications. | Email address string | None |
 | `vm-notify-mailto` | Email address that receives a short notification (no audio attachment) when a new voicemail arrives. | Email address string | None |
-| `vm-mailfrom` | Sender address used in the `From` header of voicemail email notifications. | Email address string | Profile default |
+| `vm-mailfrom` | Sender address used in the `From` header of voicemail email notifications. | Email address string | Falls back to the profile `email-from` param (vanilla: `${voicemail_account}@${voicemail_domain}`) |
 | `vm-cc` | Voicemail box (in `user@domain` format) to which a copy of every new message is forwarded. | `user@domain` string | None |
 | `vm-email-all-messages` | When `true`, emails are sent for every new voicemail regardless of whether the profile has email enabled globally. | `true`, `false` | `false` |
 | `vm-notify-email-all-messages` | When `true`, notification-only emails (no attachment) are sent for every new voicemail. | `true`, `false` | `false` |
-| `vm-attach-file` | When `true`, the voicemail audio file is attached to the notification email. | `true`, `false` | Profile default |
+| `vm-attach-file` | When `true`, the voicemail audio file is attached to the notification email. There is no profile-level equivalent; if this param is absent, no file is attached. | `true`, `false` | `false` |
 | `vm-keep-local-after-email` | When `true`, the voicemail message is kept in the mailbox after it has been emailed. When `false`, the message is deleted from the mailbox once emailed. | `true`, `false` | `true` |
 | `vm-skip-instructions` | When `true`, the post-beep recording instructions are not played to the caller leaving a message. | `true`, `false` | `false` |
 | `vm-disk-quota` | Maximum total size in bytes of stored voicemail messages for this user. New messages are rejected when the quota is reached. | Integer (bytes) | Unlimited |
-| `vm-storage-dir` | Per-user directory path where voicemail recordings are stored, overriding the profile default. | Filesystem path | Profile default |
-| `vm-domain-storage-dir` | Directory path for domain-scoped voicemail storage. Deprecated `storage-dir` is an alias for this param. | Filesystem path | Profile default |
+| `vm-storage-dir` | Per-user directory path where voicemail recordings are stored, overriding the profile default. | Filesystem path | Falls back to the profile `storage-dir` param (unset in vanilla, so `$${storage_dir}/voicemail/<profile>/<domain>/<user>`) |
+| `vm-domain-storage-dir` | Directory path for domain-scoped voicemail storage. Deprecated `storage-dir` is an alias for this param. | Filesystem path | Falls back to the profile `storage-dir` param (unset in vanilla) |
 | `vm-alternate-greet-id` | User `id` whose greeting is played instead of this user's own greeting. Useful for shared or virtual mailboxes. | User `id` string | None |
-| `vm-message-ext` | File extension for recorded voicemail messages for this user, overriding the profile default. | Extension string (e.g., `mp3`, `wav`) | Profile default |
+| `vm-message-ext` | File extension for recorded voicemail messages for this user, overriding the profile default. | Extension string (e.g., `mp3`, `wav`) | Falls back to the profile `file-extension` param (`wav`) |
 | `vm-operator-extension` | Extension dialed when the caller presses `0` during the voicemail greeting. | Extension string | None |
-| `vm-convert-cmd` | Shell command used to convert the recorded audio file before storage or email. | Command string | Profile default |
-| `vm-convert-ext` | File extension produced by `vm-convert-cmd`. | Extension string | Profile default |
+| `vm-convert-cmd` | Shell command used to convert the recorded audio file before storage or email. | Command string | Falls back to the profile `convert-cmd` param (unset in vanilla, so no conversion) |
+| `vm-convert-ext` | File extension produced by `vm-convert-cmd`. | Extension string | Falls back to the profile `convert-ext` param (unset in vanilla) |
 
 ### Common User Variables
 

--- a/docs/users-endpoints/user-directory.mdx
+++ b/docs/users-endpoints/user-directory.mdx
@@ -119,7 +119,7 @@ Each user is represented by a `<user>` element with a mandatory `id` attribute. 
 |---|---|---|
 | `id` | Unique user identifier within the domain. Corresponds to the SIP username. | Required |
 | `number-alias` | Alternate number string that resolves to this user record. Allows a phone number to map to an alphanumeric `id`. | Optional |
-| `cidr` | Restricts registration to requests arriving from the specified CIDR range. Enables IP-based authentication without a password challenge. | Optional |
+| `cidr` | Adds a `<user-id>@<domain>` token to any ACL whose node lists this domain (a `network-list` ACL), pairing the user with the given CIDR range. It does not by itself bypass digest auth; a SIP profile must reference that ACL via `apply-inbound-acl`/`apply-register-acl` for the IP-based allow to take effect. | Optional |
 
 Example using `cidr` and `number-alias`:
 
@@ -315,7 +315,7 @@ If `auth-acl` is set, the source IP of the request must pass the named ACL; fail
 
 Setting `sip-forbid-register` to `true` unconditionally rejects REGISTER for that user with a 403 response, regardless of credentials.
 
-The `cidr` attribute on the `<user>` element (see User Attributes above) bypasses digest authentication entirely for requests arriving from the specified IP range. A user with both `cidr` and `password` set will authenticate by CIDR for matching source IPs and fall back to digest for others.
+The `cidr` attribute on the `<user>` element (see User Attributes above) does not act in the digest-auth path on its own. When an ACL is built, FreeSWITCH walks the directory and, for each `<user>` carrying a `cidr`, adds a `<user-id>@<domain>` token bound to that range into any `network-list` ACL whose node names the domain. A SIP profile then enables IP-based authentication by referencing that ACL through `apply-inbound-acl` or `apply-register-acl`; without such a reference the `cidr` attribute has no effect and the request is still subject to the normal digest challenge.
 
 Which domain FreeSWITCH uses for the lookup depends on the `auth-calls` and related settings in the SIP profile. SIP profile configuration is covered in the chapter on SIP profiles.
 
@@ -346,4 +346,4 @@ This means arbitrary data can be stored on a user record and consumed by custom 
 <variable name="max_calls" value="5"/>
 ```
 
-These would appear as `$${department}` and `$${max_calls}` on any call leg for that user. There is no validation; any string is accepted.
+These would appear as the channel variables `${department}` and `${max_calls}` on any call leg for that user. (Directory `<variable>`s are channel variables, referenced with a single `$`; the `$${...}` form is reserved for preprocessor-global variables set in `vars.xml`.) There is no validation; any string is accepted.

--- a/docs/users-endpoints/webrtc-sip-wss.mdx
+++ b/docs/users-endpoints/webrtc-sip-wss.mdx
@@ -33,9 +33,9 @@ FreeSWITCH supports two distinct mechanisms for browser-based real-time communic
 
 SIP over WSS uses standard SIP messaging encapsulated inside a WebSocket connection. Any SIP client library that supports the WebSocket transport (such as JsSIP or SIP.js) can register and call against a Sofia profile without any FreeSWITCH-specific client code. The trade-off is that SIP-over-WebSocket carries the full complexity of SIP negotiation into the browser.
 
-Verto (documented in the Verto chapter) is a JSON-RPC protocol designed and implemented by the FreeSWITCH project. It is simpler for client developers but requires the `mod_verto` FreeSWITCH module and a Verto-aware JavaScript client.
+Verto (documented in [Chapter 9: WebRTC with Verto](../users-endpoints/webrtc-verto.mdx)) is a JSON-RPC protocol designed and implemented by the FreeSWITCH project. It is simpler for client developers but requires the `mod_verto` FreeSWITCH module and a Verto-aware JavaScript client.
 
-If your browser client uses a standard SIP library, configure `ws-binding` or `wss-binding` on a Sofia profile as described in this chapter. If your browser client uses `verto.js`, refer to the Verto chapter instead.
+If your browser client uses a standard SIP library, configure `ws-binding` or `wss-binding` on a Sofia profile as described in this chapter. If your browser client uses `verto.js`, refer to [Chapter 9: WebRTC with Verto](../users-endpoints/webrtc-verto.mdx) instead.
 
 ---
 
@@ -270,7 +270,7 @@ TURN relays are configured on the browser client, not on FreeSWITCH. The browser
 
 ### 5.4 NAT Traversal: Server-Side Parameters
 
-The consolidated server-side NAT setup, including `ext-sip-ip`, `ext-rtp-ip`, and `auto-nat`, is documented in detail in the Media Handling chapter's NAT Traversal section. The configuration in this chapter refers to the same `ext-rtp-ip` parameter. For a full treatment of how these parameters interact with NAT-PMP, UPnP, and the Sofia profile's SIP signaling address, refer to that section rather than duplicating it here.
+The consolidated server-side NAT setup, including `ext-sip-ip`, `ext-rtp-ip`, and `auto-nat`, is documented in detail in the [Media Handling chapter's NAT Traversal section](../media/media-handling.mdx#179-nat-traversal). The configuration in this chapter refers to the same `ext-rtp-ip` parameter. For a full treatment of how these parameters interact with NAT-PMP, UPnP, and the Sofia profile's SIP signaling address, refer to that section rather than duplicating it here.
 
 ---
 

--- a/docs/users-endpoints/webrtc-sip-wss.mdx
+++ b/docs/users-endpoints/webrtc-sip-wss.mdx
@@ -13,21 +13,21 @@ A Sofia profile can accept SIP signaling carried over WebSocket (WS) and Secure 
 
 ## Table of Contents
 
-- [1. SIP over WebSocket vs. Verto](#1-sip-over-websocket-vs-verto)
-- [2. Enabling ws-binding and wss-binding](#2-enabling-ws-binding-and-wss-binding)
-- [3. TLS Certificate Material](#3-tls-certificate-material)
-- [4. TLS Parameters](#4-tls-parameters)
-- [5. Media: SRTP, DTLS, and ICE](#5-media-srtp-dtls-and-ice)
-  - [5.1 DTLS-SRTP](#51-dtls-srtp)
-  - [5.2 ICE](#52-ice)
-  - [5.3 STUN and TURN](#53-stun-and-turn)
-  - [5.4 NAT Traversal: Server-Side Parameters](#54-nat-traversal-server-side-parameters)
-- [6. Browser Transport Requirement](#6-browser-transport-requirement)
-- [7. Parameter Reference](#7-parameter-reference)
+- [SIP over WebSocket vs. Verto](#sip-over-websocket-vs-verto)
+- [Enabling ws-binding and wss-binding](#enabling-ws-binding-and-wss-binding)
+- [TLS Certificate Material](#tls-certificate-material)
+- [TLS Parameters](#tls-parameters)
+- [Media: SRTP, DTLS, and ICE](#media-srtp-dtls-and-ice)
+  - [DTLS-SRTP](#dtls-srtp)
+  - [ICE](#ice)
+  - [STUN and TURN](#stun-and-turn)
+  - [NAT Traversal: Server-Side Parameters](#nat-traversal-server-side-parameters)
+- [Browser Transport Requirement](#browser-transport-requirement)
+- [Parameter Reference](#parameter-reference)
 
 ---
 
-## 1. SIP over WebSocket vs. Verto
+## SIP over WebSocket vs. Verto {#sip-over-websocket-vs-verto}
 
 FreeSWITCH supports two distinct mechanisms for browser-based real-time communication: SIP transported over WebSocket (RFC 7118) via `mod_sofia`, and the proprietary Verto protocol via `mod_verto`. Both approaches serve browser clients; the difference lies in signaling.
 
@@ -39,7 +39,7 @@ If your browser client uses a standard SIP library, configure `ws-binding` or `w
 
 ---
 
-## 2. Enabling ws-binding and wss-binding
+## Enabling ws-binding and wss-binding {#enabling-ws-binding-and-wss-binding}
 
 The `ws-binding` and `wss-binding` parameters are set inside the `<settings>` block of a Sofia profile. Each parameter accepts a value in the form `[ip]:port`. When the IP portion is omitted (e.g., `:5066`), the profile binds on all interfaces using the IP already configured for the profile.
 
@@ -65,7 +65,7 @@ To bind to a specific interface rather than all interfaces:
 
 ---
 
-## 3. TLS Certificate Material
+## TLS Certificate Material {#tls-certificate-material}
 
 `wss-binding` requires a TLS certificate. FreeSWITCH looks for certificate files in the directory specified by `tls-cert-dir` (defaults to the global `certs_dir`, typically `/etc/freeswitch/tls`).
 
@@ -103,7 +103,7 @@ The SIP TLS transport (`tls` parameter) uses `agent.pem` (key + cert) and `cafil
 
 ---
 
-## 4. TLS Parameters
+## TLS Parameters {#tls-parameters}
 
 The following parameters govern TLS behavior. They apply to the SIP TLS transport and, for `tls-cert-dir`, also determine where WSS certificate files are loaded from.
 
@@ -128,13 +128,13 @@ The `tls-cert-dir` value in the example above shows the conventional path; the c
 
 ---
 
-## 5. Media: SRTP, DTLS, and ICE
+## Media: SRTP, DTLS, and ICE {#media-srtp-dtls-and-ice}
 
 Browser SIP clients require encrypted media and ICE-based NAT traversal. This section covers how DTLS-SRTP key exchange works, how FreeSWITCH participates as an ICE peer, and how to configure the server-side candidate addresses. SRTP via SDES (inline SDP key exchange) is also supported but is not used by WebRTC browsers; browsers always use DTLS-SRTP.
 
 ---
 
-### 5.1 DTLS-SRTP
+### DTLS-SRTP {#dtls-srtp}
 
 WebRTC mandates DTLS-SRTP for media encryption. No profile parameter enables or disables it; FreeSWITCH activates DTLS-SRTP automatically when a browser offer contains an `a=fingerprint` attribute in the SDP.
 
@@ -188,7 +188,7 @@ For WebRTC browser calls using DTLS-SRTP, `rtp_secure_media` does not need to be
 
 ---
 
-### 5.2 ICE
+### ICE {#ice}
 
 FreeSWITCH participates in ICE (Interactive Connectivity Establishment) as a full ICE agent by default. It generates ICE credentials (`a=ice-ufrag` and `a=ice-pwd`) using random strings at session setup time and includes them in SDP. The ufrag is 16 characters; the password is 24 characters.
 
@@ -236,7 +236,7 @@ By default FreeSWITCH operates as a full ICE agent. Setting the channel variable
 
 ---
 
-### 5.3 STUN and TURN
+### STUN and TURN {#stun-and-turn}
 
 **FreeSWITCH and STUN**
 
@@ -268,13 +268,13 @@ TURN relays are configured on the browser client, not on FreeSWITCH. The browser
 
 ---
 
-### 5.4 NAT Traversal: Server-Side Parameters
+### NAT Traversal: Server-Side Parameters {#nat-traversal-server-side-parameters}
 
-The consolidated server-side NAT setup, including `ext-sip-ip`, `ext-rtp-ip`, and `auto-nat`, is documented in detail in the [Media Handling chapter's NAT Traversal section](../media/media-handling.mdx#179-nat-traversal). The configuration in this chapter refers to the same `ext-rtp-ip` parameter. For a full treatment of how these parameters interact with NAT-PMP, UPnP, and the Sofia profile's SIP signaling address, refer to that section rather than duplicating it here.
+The consolidated server-side NAT setup, including `ext-sip-ip`, `ext-rtp-ip`, and `auto-nat`, is documented in detail in the [Media Handling chapter's NAT Traversal section](../media/media-handling.mdx#nat-traversal). The configuration in this chapter refers to the same `ext-rtp-ip` parameter. For a full treatment of how these parameters interact with NAT-PMP, UPnP, and the Sofia profile's SIP signaling address, refer to that section rather than duplicating it here.
 
 ---
 
-## 6. Browser Transport Requirement
+## Browser Transport Requirement {#browser-transport-requirement}
 
 Browsers served over HTTPS refuse to open unencrypted WebSocket connections (`ws://`) due to mixed-content policy. In practice this means:
 
@@ -285,7 +285,7 @@ Always configure `wss-binding` and provide a CA-trusted certificate when deployi
 
 ---
 
-## 7. Parameter Reference
+## Parameter Reference {#parameter-reference}
 
 | Parameter | Purpose | Accepted Values | Default |
 |-----------|---------|----------------|---------|

--- a/docs/users-endpoints/webrtc-verto.mdx
+++ b/docs/users-endpoints/webrtc-verto.mdx
@@ -297,13 +297,13 @@ Both profiles can be active simultaneously. A client that connects to the IPv6 l
 
 ## 11. Browser Media: SRTP, DTLS, and ICE
 
-`mod_verto` uses the same core media engine (`mod_rtc` plus `switch_core_media`) as SIP-over-WSS. The browser media path is identical: DTLS-SRTP for encryption, ICE for NAT traversal. The profile parameters that control this path are `rtp-ip`, `ext-rtp-ip`, `local-network`, and `apply-candidate-acl`.
+`mod_verto` uses the same core media engine (`mod_rtc` plus `switch_core_media`) as [SIP-over-WSS](../users-endpoints/webrtc-sip-wss.mdx). The browser media path is identical: DTLS-SRTP for encryption, ICE for NAT traversal. The profile parameters that control this path are `rtp-ip`, `ext-rtp-ip`, `local-network`, and `apply-candidate-acl`.
 
 ### DTLS-SRTP
 
 FreeSWITCH activates DTLS-SRTP automatically when a Verto client's SDP offer contains `a=fingerprint`. No Verto profile parameter enables or disables DTLS-SRTP. FreeSWITCH reads the remote fingerprint, generates a local fingerprint from `$${certs_dir}/dtls-srtp.pem` (creating a self-signed certificate if that file does not exist), and includes `a=fingerprint` and `a=setup` in its SDP answer.
 
-The DTLS certificate used for Verto media (`dtls-srtp.pem`) is the same file used for SIP-over-WSS media. It is distinct from the WSS signaling certificate (`wss.pem`). See section 5.1 of the WebRTC over SIP (WSS) chapter for the full description of `a=setup` role negotiation and fingerprint hash behavior.
+The DTLS certificate used for Verto media (`dtls-srtp.pem`) is the same file used for SIP-over-WSS media. It is distinct from the WSS signaling certificate (`wss.pem`). See [Chapter 10: WebRTC over SIP (WSS)](../users-endpoints/webrtc-sip-wss.mdx#51-dtls-srtp) for the full description of `a=setup` role negotiation and fingerprint hash behavior.
 
 ### ICE: Candidates and Filtering
 
@@ -338,4 +338,4 @@ The `stun:` prefix on `ext-rtp-ip` causes FreeSWITCH to query a STUN server at p
 
 FreeSWITCH does not use TURN relays. TURN server credentials are configured on the browser client. When the browser advertises a relay candidate in its SDP, FreeSWITCH treats it as any other remote candidate address, subject to `apply-candidate-acl`. The relay is transparent to FreeSWITCH.
 
-For the full treatment of server-side NAT traversal parameters (`ext-rtp-ip`, `ext-sip-ip`, `auto-nat`), refer to the Media Handling chapter's NAT Traversal section.
+For the full treatment of server-side NAT traversal parameters (`ext-rtp-ip`, `ext-sip-ip`, `auto-nat`), refer to the [Media Handling chapter's NAT Traversal section](../media/media-handling.mdx#179-nat-traversal).

--- a/docs/users-endpoints/webrtc-verto.mdx
+++ b/docs/users-endpoints/webrtc-verto.mdx
@@ -13,21 +13,21 @@ Verto (VERto Telephone Overlay) is a JSON-RPC signaling protocol transported ove
 
 ## Table of Contents
 
-- [1. Overview](#1-overview)
-- [2. Module Loading](#2-module-loading)
-- [3. Profile Structure](#3-profile-structure)
-- [4. Global Settings](#4-global-settings)
-- [5. Profile Parameter Reference](#5-profile-parameter-reference)
-- [6. Secure WebSocket (WSS)](#6-secure-websocket-wss)
-- [7. User Directory Integration](#7-user-directory-integration)
-- [8. The Role of mod_rtc](#8-the-role-of-mod_rtc)
-- [9. Codec Selection for Browser Media](#9-codec-selection-for-browser-media)
-- [10. IPv4 and IPv6 Profiles](#10-ipv4-and-ipv6-profiles)
-- [11. Browser Media: SRTP, DTLS, and ICE](#11-browser-media-srtp-dtls-and-ice)
+- [Overview](#overview)
+- [Module Loading](#module-loading)
+- [Profile Structure](#profile-structure)
+- [Global Settings](#global-settings)
+- [Profile Parameter Reference](#profile-parameter-reference)
+- [Secure WebSocket (WSS)](#secure-websocket-wss)
+- [User Directory Integration](#user-directory-integration)
+- [The Role of mod_rtc](#the-role-of-mod_rtc)
+- [Codec Selection for Browser Media](#codec-selection-for-browser-media)
+- [IPv4 and IPv6 Profiles](#ipv4-and-ipv6-profiles)
+- [Browser Media: SRTP, DTLS, and ICE](#browser-media-srtp-dtls-and-ice)
 
 ---
 
-## 1. Overview
+## Overview {#overview}
 
 `mod_verto` implements the server side of the Verto protocol. A browser client connects over a WebSocket (plain WS or encrypted WSS), authenticates using credentials stored in the FreeSWITCH user directory, and then exchanges JSON-RPC messages to initiate or receive calls. The actual media (audio, video) flows over SRTP using ICE candidate negotiation, coordinated by `mod_rtc`.
 
@@ -39,7 +39,7 @@ Key characteristics:
 
 ---
 
-## 2. Module Loading
+## Module Loading {#module-loading}
 
 Add both `mod_verto` and `mod_rtc` to `autoload_configs/modules.conf.xml`:
 
@@ -52,7 +52,7 @@ Add both `mod_verto` and `mod_rtc` to `autoload_configs/modules.conf.xml`:
 
 ---
 
-## 3. Profile Structure
+## Profile Structure {#profile-structure}
 
 `verto.conf.xml` contains a top-level `<settings>` block for module-wide parameters and a `<profiles>` block holding one or more named `<profile>` elements.
 
@@ -97,11 +97,11 @@ A `bind-local` entry without `secure="true"` binds a plain WebSocket listener. T
 
 ---
 
-## 4. Global Settings
+## Global Settings {#global-settings}
 
 These parameters appear inside `<settings>` and apply to the entire module, not to individual profiles.
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |-----------|---------|--------|---------|
 | `debug` | Module-wide debug verbosity. Applied to all profiles unless overridden at the profile level. | Integer `0`-`10` | `0` |
 | `detach-timeout-sec` | Seconds to hold a channel after a client disconnects before hanging it up. Must be a positive integer; non-positive values are ignored. | Positive integer | `120` |
@@ -112,19 +112,19 @@ These parameters appear inside `<settings>` and apply to the entire module, not 
 
 ---
 
-## 5. Profile Parameter Reference
+## Profile Parameter Reference {#profile-parameter-reference}
 
 All parameters below appear inside a `<profile>` element.
 
 ### Binding
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |-----------|---------|--------|---------|
 | `bind-local` | IP address and port to listen on. Repeatable; maximum 25 entries per profile. Add the attribute `secure="true"` to make that binding a WSS listener. IPv6 addresses must be enclosed in brackets, e.g., `[$${local_ip_v6}]:8082`. At least one `bind-local` entry is required; the profile is discarded at startup if none is valid. | `ip:port` string | None (required) |
 
 ### TLS / WSS
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |-----------|---------|--------|---------|
 | `secure-combined` | Path to a PEM file containing both the certificate and the private key concatenated. Sets both cert and key from a single file. | File path | None |
 | `secure-cert` | Path to the TLS certificate PEM file. Used when cert and key are in separate files. | File path | None |
@@ -133,7 +133,7 @@ All parameters below appear inside a `<profile>` element.
 
 ### Authentication
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |-----------|---------|--------|---------|
 | `userauth` | Require clients to authenticate against the FreeSWITCH user directory. Set to `true` to enable authentication; the login username is split on `@` to derive the user ID and domain (subject to `chop-domain`). Set to `@domain` (e.g., `@example.com`) to force the lookup domain to that value and treat the entire login string as the user ID. Authentication is bypassed when this parameter is absent or empty, unless `root-password` is configured. | `true` / `@domain` string | None (auth disabled if absent) |
 | `blind-reg` | Allow any client to register even without a matching directory entry. Enable only in controlled environments. | `true` / `false` | `false` |
@@ -143,7 +143,7 @@ All parameters below appear inside a `<profile>` element.
 
 ### Domain and Dialplan
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |-----------|---------|--------|---------|
 | `force-register-domain` | Domain to use for all registrations regardless of the domain the client presents. | Domain string | None |
 | `context` | FreeSWITCH dialplan context that inbound Verto calls enter. | Context name string | `default` |
@@ -151,7 +151,7 @@ All parameters below appear inside a `<profile>` element.
 
 ### Media and ICE
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |-----------|---------|--------|---------|
 | `rtp-ip` | Local IP address used for RTP media. Repeatable; up to 25 IPv4 addresses and 25 IPv6 addresses may be listed. Values containing `:` are treated as IPv6 addresses and stored in a separate pool. | IP address string | None |
 | `ext-rtp-ip` | External (NAT) IP address advertised in SDP for RTP. Accepts a literal IP, a FreeSWITCH variable such as `$${external_rtp_ip}`, or a STUN URI (e.g., `stun:stun.example.com`). The value is resolved at load time via `switch_stun_ip_lookup`. | IP address or `stun:host` | None |
@@ -163,7 +163,7 @@ All parameters below appear inside a `<profile>` element.
 
 ### Codecs and Jitter Buffer
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |-----------|---------|--------|---------|
 | `outbound-codec-string` | Comma-separated list of codecs offered to the remote (browser) side for outbound calls. | Codec name list | `opus,vp8` |
 | `inbound-codec-string` | Comma-separated list of codecs accepted from the remote side for inbound calls. Defaults to the `outbound-codec-string` value if not set. | Codec name list | Same as `outbound-codec-string` |
@@ -171,7 +171,7 @@ All parameters below appear inside a `<profile>` element.
 
 ### Timer and Miscellaneous
 
-| Parameter | Purpose | Values | Default |
+| Parameter | Purpose | Accepted Values | Default |
 |-----------|---------|--------|---------|
 | `timer-name` | FreeSWITCH timer used for media pacing on this profile. | `soft` or other registered timer name | `soft` |
 | `debug` | Per-profile debug verbosity. Checked alongside the global `debug` value; the effective debug level is whichever is non-zero. | Integer `0`-`10` | `0` |
@@ -179,7 +179,7 @@ All parameters below appear inside a `<profile>` element.
 
 ---
 
-## 6. Secure WebSocket (WSS)
+## Secure WebSocket (WSS) {#secure-websocket-wss}
 
 Browsers require WSS for WebRTC; plain WebSocket connections from an HTTPS page are blocked by browser security policy. A Verto profile serves WSS when at least one `bind-local` entry carries `secure="true"` and the TLS material is configured.
 
@@ -206,7 +206,7 @@ Port convention: port `8081` for plain WS, port `8082` for WSS. These are defaul
 
 ---
 
-## 7. User Directory Integration
+## User Directory Integration {#user-directory-integration}
 
 When `userauth` is set to `true` (or to `@domain`), `mod_verto` authenticates connecting clients against the standard FreeSWITCH user directory (the same `directory` XML tree used by `mod_sofia`). No separate Verto-specific user database is needed.
 
@@ -245,7 +245,7 @@ The `root-password` parameter defines a superuser credential. A client authentic
 
 ---
 
-## 8. The Role of mod_rtc
+## The Role of mod_rtc {#the-role-of-mod_rtc}
 
 `mod_rtc` is the WebRTC media engine that `mod_verto` relies on for ICE negotiation, DTLS-SRTP key exchange, and RTP/RTCP handling. It does not expose its own configuration file; all media-related behavior is driven by the parameters set on the Verto profile (`rtp-ip`, `ext-rtp-ip`, `apply-candidate-acl`, codec strings, etc.).
 
@@ -253,7 +253,7 @@ Loading `mod_rtc` before `mod_verto` is required. If `mod_rtc` is absent, `mod_v
 
 ---
 
-## 9. Codec Selection for Browser Media
+## Codec Selection for Browser Media {#codec-selection-for-browser-media}
 
 Browser WebRTC implementations mandate support for specific codecs. The `outbound-codec-string` and `inbound-codec-string` profile parameters control which codecs FreeSWITCH offers and accepts in SDP negotiation with Verto clients.
 
@@ -278,7 +278,7 @@ The codec list is evaluated in order; the first codec that both sides support is
 
 ---
 
-## 10. IPv4 and IPv6 Profiles
+## IPv4 and IPv6 Profiles {#ipv4-and-ipv6-profiles}
 
 The vanilla configuration ships with two profiles: `default-v4` (IPv4) and `default-v6` (IPv6). They are structurally identical except for the IP address variables and the ICE candidate ACLs.
 
@@ -295,7 +295,7 @@ Both profiles can be active simultaneously. A client that connects to the IPv6 l
 
 ---
 
-## 11. Browser Media: SRTP, DTLS, and ICE
+## Browser Media: SRTP, DTLS, and ICE {#browser-media-srtp-dtls-and-ice}
 
 `mod_verto` uses the same core media engine (`mod_rtc` plus `switch_core_media`) as [SIP-over-WSS](../users-endpoints/webrtc-sip-wss.mdx). The browser media path is identical: DTLS-SRTP for encryption, ICE for NAT traversal. The profile parameters that control this path are `rtp-ip`, `ext-rtp-ip`, `local-network`, and `apply-candidate-acl`.
 
@@ -303,7 +303,7 @@ Both profiles can be active simultaneously. A client that connects to the IPv6 l
 
 FreeSWITCH activates DTLS-SRTP automatically when a Verto client's SDP offer contains `a=fingerprint`. No Verto profile parameter enables or disables DTLS-SRTP. FreeSWITCH reads the remote fingerprint, generates a local fingerprint from `$${certs_dir}/dtls-srtp.pem` (creating a self-signed certificate if that file does not exist), and includes `a=fingerprint` and `a=setup` in its SDP answer.
 
-The DTLS certificate used for Verto media (`dtls-srtp.pem`) is the same file used for SIP-over-WSS media. It is distinct from the WSS signaling certificate (`wss.pem`). See [Chapter 10: WebRTC over SIP (WSS)](../users-endpoints/webrtc-sip-wss.mdx#51-dtls-srtp) for the full description of `a=setup` role negotiation and fingerprint hash behavior.
+The DTLS certificate used for Verto media (`dtls-srtp.pem`) is the same file used for SIP-over-WSS media. It is distinct from the WSS signaling certificate (`wss.pem`). See [Chapter 10: WebRTC over SIP (WSS)](../users-endpoints/webrtc-sip-wss.mdx#dtls-srtp) for the full description of `a=setup` role negotiation and fingerprint hash behavior.
 
 ### ICE: Candidates and Filtering
 
@@ -338,4 +338,4 @@ The `stun:` prefix on `ext-rtp-ip` causes FreeSWITCH to query a STUN server at p
 
 FreeSWITCH does not use TURN relays. TURN server credentials are configured on the browser client. When the browser advertises a relay candidate in its SDP, FreeSWITCH treats it as any other remote candidate address, subject to `apply-candidate-acl`. The relay is transparent to FreeSWITCH.
 
-For the full treatment of server-side NAT traversal parameters (`ext-rtp-ip`, `ext-sip-ip`, `auto-nat`), refer to the [Media Handling chapter's NAT Traversal section](../media/media-handling.mdx#179-nat-traversal).
+For the full treatment of server-side NAT traversal parameters (`ext-rtp-ip`, `ext-sip-ip`, `auto-nat`), refer to the [Media Handling chapter's NAT Traversal section](../media/media-handling.mdx#nat-traversal).


### PR DESCRIPTION
## Summary

Full remediation for the manual-wide source-of-truth audit, in one PR. **94 files, ~+2340 / −970.** Every value re-verified against the FreeSWITCH source; `npm run build` passes with `onBrokenLinks`/`onBrokenAnchors = throw`.

### 1. Correctness
`pocketsphinx` broken examples (`set`→`param`); `httapi` `execute-apps` default `true`→`false`; wrong defaults on `mod_http_cache`/`mod_format_cdr`/`mod_json_cdr`/`mod_amqp`/`mod_memcache`; two wrong chapter cross-refs; removed phantom conference `waste` flag; `rtp-autoflush-during-bridge` marked non-configurable; `$${department}`→`${department}` sigil; added `zh_CN`.

### 2. Completeness (full exhaustive, code-verified)
Sofia **68 settings**; conference **~84-cmd API** + 10 params; callcenter **~30-cmd API** + 6 settings + fifo API; dptools **12 apps**; mod_commands **~25 cmds** + fsctl sub-syntax; scripting per-engine config (incl. `mod_java`); av/vpx codec config; AEAD-GCM SRTP suites; spandsp T.38 vars + hooks; local_stream/shout; two SIP channel vars; Part-9 second-pass items.

### 3. Organization / IA
- **De-duplication** to single sources of truth (say, SRTP, codec table); fixed stale appendix CDR refs; Ch27↔Part-9 CDR links.
- **Voice/precision** cleanup (real `vm-*` defaults, de-hedged module-loading, de-marketed signalwire); frontmatter normalization.
- **Cross-link layer**: ~37 in-prose links + 23 Part-9 back-links (manual had ~5 before).
- **TOCs** added to 57 Part-9 module pages.
- **Heading numbering unified**: the two numbered styles (`## 20.1 X`, `## 1. X`) converted to the un-numbered descriptive style (354 headings / 19 chapters) with explicit `{#anchors}`; TOCs and cross-page anchors updated.
- **Tables standardized**: 46 header rows normalized to canonical columns (`Accepted Values`; `Event Subclass | Fired When | Extra Headers`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
