### PR TITLE
Learner content (Recipes/Troubleshooting/Programming) + complete Part 9 index + Ch 33-48 numbering

### DIFF
--- a/CONTENT-ROADMAP.md
+++ b/CONTENT-ROADMAP.md
@@ -1,0 +1,67 @@
+# Learning-Content Roadmap
+
+The current manual (Parts 1–9) is a **verified configuration reference**. Its
+`README.md` deliberately excludes troubleshooting, diagnostics, deployment,
+scaling, hardening, and operations. That keeps the reference tight, but it leaves
+real gaps for someone trying to *learn* FreeSWITCH rather than look up a value.
+
+This roadmap captures the highest-value additions for the FreeSWITCH audience and
+the blueprint for each. Three new sections are planned. Where a section crosses
+the manual's stated scope, it is flagged so the boundary is a conscious choice.
+
+---
+
+## Part 10 — Recipes / Worked Examples  (in scope)
+
+**Why:** the manual documents every *piece* but never *composes* them. Recipes turn
+the reference into something people can learn from. They use only features already
+documented elsewhere and cross-link back to the relevant chapters.
+
+Every recipe is verified against `conf/vanilla/` and the documented dialplan apps.
+
+| Chapter | Recipe | Builds on |
+|---|---|---|
+| 10.1 | Inbound DID → IVR → Voicemail | public context (Ch 13), IVR menus (Ch 21), voicemail (Ch 19) |
+| 10.2 | Ring group / hunt group (simultaneous + sequential) | `bridge` (Ch 14), directory (Ch 6) |
+| 10.3 | Business-hours / time-of-day routing | time conditions (Ch 15), IVR/voicemail |
+| 10.4 | Connecting two FreeSWITCH servers (box-to-box trunk) | gateways (Ch 8), dialplan (Ch 12) |
+| 10.5 | A conference bridge with a PIN | conferencing (Ch 20), dialplan |
+| 10.6 | Click-to-call / originate from the CLI | `originate` (Ch 31), bridge |
+
+## Part 11 — Troubleshooting & Diagnostics  (scope expansion)
+
+**Why:** the single most-searched newcomer need ("no audio", "won't register").
+Diagnostics, not internals — it documents the *tools and reads*, not the C code.
+
+| Chapter | Covers |
+|---|---|
+| 11.1 | The diagnostic toolbox: `fs_cli`, log levels, `sofia status`, `sofia global siptrace`, `sngrep`/pcap |
+| 11.2 | Registration problems (auth, NAT, `sofia status profile … reg`) |
+| 11.3 | Audio problems: no audio / one-way audio (NAT, RTP, codec mismatch, proxy vs bypass media) |
+| 11.4 | Call-setup failures: reading hangup causes, `continue_on_fail`, gateway state |
+| 11.5 | Reading a SIP trace and a CDR to localize a fault |
+
+## Part 12 — Programming with the Event Socket & Scripting  (scope expansion)
+
+**Why:** the manual *configures* `mod_event_socket` and the language modules but
+never shows how to *program* them — the gap for every integrator.
+
+| Chapter | Covers |
+|---|---|
+| 12.1 | The event model: events, subclasses, headers, the channel lifecycle |
+| 12.2 | Events catalog (companion to the channel-variables catalog): the key events and their headers |
+| 12.3 | ESL inbound socket: connect, subscribe, `api`/`bgapi`, consume events |
+| 12.4 | ESL outbound socket: the `socket` app, the async/sync models |
+| 12.5 | Scripting APIs: the `session` object, `freeswitch.API()`, event consumers (Lua and JS) |
+
+---
+
+## Approach
+
+- One section per PR, built section by section, each `npm run build`-validated and
+  cross-linked into the existing chapters.
+- Recipes and scripting examples are verified against the real `conf/vanilla/`
+  config and the registered applications/commands — same source-of-truth bar as
+  the reference.
+- Parts 11 and 12 are conscious scope expansions; if the manual should stay a pure
+  reference, they can instead live as a separate companion guide.

--- a/README.md
+++ b/README.md
@@ -54,19 +54,27 @@ and it does not teach programming.
 - Integration surfaces configured by the operator: Event Socket, XML Curl,
   CDR, scripting wiring, and SignalWire connectivity.
 - A channel variables reference.
+- Worked end-to-end examples (recipes) that compose the documented configuration,
+  dialplan, and applications into complete call flows.
+- Operator troubleshooting and diagnostics: the console, `sofia status`, SIP
+  tracing, logs, and CDRs, and the common registration, audio, and call-setup
+  failures — diagnosed with FreeSWITCH's own tools, not by reading the codebase.
+- The programmable surfaces: the Event Socket protocol (inbound and outbound) and
+  the embedded scripting APIs (the runtime objects a script or ESL client uses).
 
 ### Out of scope (never include)
 
 - The FreeSWITCH codebase itself: internal implementation, code structure,
-  functions, data flow, or source-level behavior.
-- Troubleshooting, debugging, or diagnostics of any kind.
+  functions, data flow, or source-level behavior. (Operator-level troubleshooting
+  using the supported tools is in scope; source-level debugging is not.)
 - Deployment, provisioning, scaling, hardening, or operations guidance.
 - High availability, performance tuning, and enterprise deployment topics.
 
-Some legacy topics sit on a boundary. ACLs, authentication, and TLS/WSS are
-documented strictly as configuration surface (what the parameters are and what
-values they accept), never as security hardening guidance. Where a topic crosses
-into operations, the manual documents the configuration and stops.
+Some topics sit on a boundary. ACLs, authentication, and TLS/WSS are documented
+strictly as configuration surface (what the parameters are and what values they
+accept), never as security hardening guidance. Troubleshooting documents the
+diagnostic tools and the reads, not internals. Where a topic crosses into
+deployment or operations, the manual documents the configuration and stops.
 
 ## 3. Source of Truth Method
 

--- a/docs/programming/_category_.json
+++ b/docs/programming/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Part 12: Programming (ESL & Scripting)", "position": 12 }

--- a/docs/programming/esl-inbound.mdx
+++ b/docs/programming/esl-inbound.mdx
@@ -1,0 +1,295 @@
+---
+sidebar_position: 3
+id: esl-inbound
+slug: /programming/esl-inbound
+title: "The Inbound Event Socket"
+description: "Connect to FreeSWITCH's event_socket listener from your own program: the wire protocol, the ESL client library, and a worked event-consuming loop."
+sidebar_label: "ESL: Inbound"
+---
+
+# The Inbound Event Socket
+
+In **inbound** mode your program is the client: it opens a TCP connection *to*
+FreeSWITCH's `mod_event_socket` listener, authenticates, and then issues
+commands and consumes events for as long as it likes. This is the mode you use
+to build dashboards, click-to-call backends, dialers, billing collectors, and
+any out-of-band controller that talks to a running FreeSWITCH.
+
+Contrast this with **outbound** mode, covered in the sibling chapter
+[The Outbound Event Socket](/programming/esl-outbound), where the roles are
+reversed: the dialplan's `socket` application makes FreeSWITCH connect *out* to
+*your* listening server, handing you one call to control. Same wire protocol,
+opposite direction. Inbound is server-wide and persistent; outbound is per-call.
+
+The listener itself, its configuration parameters, and ACL restrictions are
+documented in the integration chapter
+[The Event Socket](/integration/event-socket). The events you will subscribe to
+are described in [The Event Model](./event-model.mdx) and the
+[events catalog](./events-catalog.mdx). This chapter is the programmer's
+companion: how to *write client code* against the socket.
+
+## The Connection Model {#the-connection-model}
+
+By default `mod_event_socket` listens on port `8021` with the password
+`ClueCon`. The shipped `event_socket.conf.xml` binds `listen-ip` to `::`
+(all interfaces, IPv6/IPv4), but the conventional and safe target for a local
+controller is `127.0.0.1:8021`.
+
+```
+listen-port = 8021
+password    = ClueCon
+```
+
+Source: `conf/vanilla/autoload_configs/event_socket.conf.xml`. The password is
+checked verbatim against the `auth` command in `mod_event_socket.c`
+(`parse_command`, `if (!strcmp(prefs.password, pass))`). Change it before
+exposing the socket to anything other than localhost.
+
+When a connection is accepted, FreeSWITCH speaks first. It sends an
+authentication challenge:
+
+```
+Content-Type: auth/request
+
+```
+
+(`switch_snprintf(buf, ..., "Content-Type: auth/request\n\n")` in
+`mod_event_socket.c`.) Your program must respond with `auth` before any other
+command is accepted.
+
+## The Wire Protocol {#the-wire-protocol}
+
+Every message on the socket is a block of `Name: Value` headers terminated by a
+blank line, optionally followed by a body whose length is given by a
+`Content-Length` header. This is the same framing FreeSWITCH events use, so the
+protocol is symmetric: commands you send and events you receive look alike.
+
+### Commands {#commands}
+
+The commands below are the ones `parse_command` recognizes in
+`mod_event_socket.c`. Send each as a single line terminated by a blank line. The
+argument to each comparison in the source is shown so you can trust the spelling.
+
+| Command | Purpose |
+| --- | --- |
+| `auth <password>` | Authenticate. Required first. Replies `+OK accepted` or `-ERR invalid`. |
+| `api <cmd> <args>` | Run an API command and **block** until it returns; the result comes back as `Content-Type: api/response`. |
+| `bgapi <cmd> <args>` | Run an API command in the **background**; returns a `Job-UUID` immediately, the result arrives later as a `BACKGROUND_JOB` event. |
+| `event <format> <types>` | Subscribe to events. Format is `plain`, `json`, or `xml`. Use `event plain ALL` for everything. |
+| `nixevent <types>` | Unsubscribe from specific event types while keeping the rest. |
+| `noevents` | Unsubscribe from all events. |
+| `filter <header> <value>` | Restrict delivered events to those whose header matches; `filter delete ...` removes a filter. |
+| `sendevent <event-name>` | Inject an event into FreeSWITCH's event system. |
+| `sendmsg <uuid>` | Send a message/command to a specific channel (used to control calls). |
+| `exit` | Close the connection cleanly (replies `+OK bye`). |
+
+These names are verified against the `strncasecmp(cmd, "...")` checks in
+`mod_event_socket.c`: `auth ` (line ~1739), `api ` (~2277), `bgapi ` (~2322),
+`event` (~2454), `nixevent` (~2536), `noevents` (~2590), `filter ` (~1950),
+`sendevent` (~2230), `sendmsg` (~2169), and `exit` (~1732). Additional commands
+exist for log streaming (`log`, `nolog`) and the linger/divert mechanics used by
+outbound mode.
+
+### Command and Reply {#command-and-reply}
+
+Most commands get a synchronous **Command/Reply**. FreeSWITCH answers with:
+
+```
+Content-Type: command/reply
+Reply-Text: +OK accepted
+
+```
+
+(`"Content-Type: command/reply\nReply-Text: %s\n\n"` in `mod_event_socket.c`.)
+A reply that starts with `+OK` succeeded; one that starts with `-ERR` failed and
+carries a reason, for example `-ERR invalid` or `-ERR command not found`.
+
+`api` is the exception: its result is not a `command/reply` but a separate
+framed block:
+
+```
+Content-Type: api/response
+Content-Length: 5
+
++OK 1
+```
+
+(`"Content-Type: api/response\nContent-Length: %ld\n\n"` in `api_exec`,
+`mod_event_socket.c`.) You must read exactly `Content-Length` bytes of body.
+
+### Blocking vs Background {#blocking-vs-background}
+
+`api uptime` blocks the socket until the command completes and returns the
+output inline. `bgapi originate ...` returns immediately:
+
+```
+Content-Type: command/reply
+Reply-Text: +OK Job-UUID: 1b9be1e2-...
+Job-UUID: 1b9be1e2-...
+
+```
+
+(`"~Reply-Text: +OK Job-UUID: %s\nJob-UUID: %s\n\n"` in the `bgapi` branch of
+`mod_event_socket.c`.) The actual result is delivered later, only if you are
+subscribed to events, as a `BACKGROUND_JOB` event carrying the matching
+`Job-UUID` header and the command output in its body. The event is built in
+`api_exec`:
+
+```c
+switch_event_create(&event, SWITCH_EVENT_BACKGROUND_JOB);
+switch_event_add_header_string(event, ..., "Job-UUID", acs->uuid_str);
+switch_event_add_header_string(event, ..., "Job-Command", acs->api_cmd);
+switch_event_add_body(event, "%s", reply);
+```
+
+Use `bgapi` for anything slow (notably `originate`) so a single long call does
+not stall your control connection.
+
+## The ESL Client Library {#the-esl-client-library}
+
+You rarely hand-roll this framing. FreeSWITCH ships **ESL** (Event Socket
+Library) under `libs/esl/`, a small C library wrapped by SWIG into Lua, Python,
+Perl, PHP, Ruby, Java, and .NET bindings. All bindings expose the same two
+objects, `ESLconnection` and `ESLevent`, declared in
+`libs/esl/src/include/esl_oop.h`.
+
+### ESLconnection {#eslconnection}
+
+For inbound use you construct an `ESLconnection` with a host, port, and
+password. The constructor connects and performs the `auth` handshake for you.
+The methods you will use most, all from `esl_oop.h`:
+
+| Method | What it does |
+| --- | --- |
+| `ESLconnection(host, port, password)` | Connect and authenticate (inbound). |
+| `connected()` | Returns nonzero while the socket is up. |
+| `api(cmd, arg)` | Send `api`, block, return an `ESLevent` whose body holds the result. |
+| `bgapi(cmd, arg, job_uuid)` | Send `bgapi`, return immediately; result arrives as a `BACKGROUND_JOB` event. |
+| `events(etype, value)` | Subscribe. `etype` is `plain`, `json`, or `xml`; `value` is the event list. |
+| `filter(header, value)` | Add a server-side event filter. |
+| `recvEvent()` | Block until the next event arrives; return it as an `ESLevent`. |
+| `recvEventTimed(ms)` | Like `recvEvent` but give up after `ms` milliseconds. |
+| `sendEvent(event)` | Send an `ESLevent` you built (the `sendevent` command). |
+| `sendMSG(event, uuid)` | Send a message to a channel (the `sendmsg` command). |
+| `disconnect()` | Close the connection. |
+
+Under the hood these build the wire commands shown above. For example
+`api(cmd, arg)` emits `api <cmd> <arg>` and `bgapi` emits
+`bgapi <cmd> <arg>` with a `Job-UUID:` header (see `esl.c`, `esl_oop.cpp`).
+`events` emits `event <type> <value>` and `filter` emits
+`filter <header> <value>`.
+
+### ESLevent {#eslevent}
+
+Every event and every API result comes back as an `ESLevent`. Its accessors,
+from `esl_oop.h`:
+
+| Method | What it returns |
+| --- | --- |
+| `getHeader(name)` | The value of a header, or null if absent. |
+| `getBody()` | The event body (the API output, or a message payload). |
+| `getType()` | The event name, e.g. `CHANNEL_ANSWER`. |
+| `serialize(format)` | The whole event as text (or `json`/`xml`). |
+| `addHeader(name, value)` | Set a header (when building an event to send). |
+| `addBody(value)` | Set the body (when building an event to send). |
+
+## A Worked Example {#a-worked-example}
+
+The example below uses the Lua binding (`libs/esl/lua`). The constructor,
+`con:api(...)`, and `e:getBody()` are exactly the pattern in the shipped
+`libs/esl/lua/single_command.lua`. The Python, Perl, and other bindings are
+identical method-for-method; only the dot-versus-colon syntax differs.
+
+```lua
+-- inbound ESL: connect, run an API command, then watch channel events
+require("ESL")
+
+-- ESLconnection(host, port, password) connects AND authenticates
+local con = ESL.ESLconnection("127.0.0.1", "8021", "ClueCon")
+
+if con:connected() == 0 then
+    print("could not connect to FreeSWITCH")
+    return
+end
+
+-- a blocking api call: result is the ESLevent body
+local info = con:api("status")
+print(info:getBody())
+
+-- kick off a call in the background; we get a Job-UUID back immediately
+con:bgapi("originate", "user/1000 &echo")
+
+-- subscribe to all events in plain format so we receive BACKGROUND_JOB
+-- and the CHANNEL_* lifecycle
+con:events("plain", "ALL")
+
+-- consume events forever
+while con:connected() == 1 do
+    -- recvEvent() blocks for the next event; recvEventTimed(ms) is the
+    -- timed variant
+    local e = con:recvEvent()
+    if e then
+        local name = e:getHeader("Event-Name")
+        if name == "CHANNEL_CREATE"
+            or name == "CHANNEL_ANSWER"
+            or name == "CHANNEL_HANGUP" then
+            print(string.format("%s  uuid=%s  number=%s",
+                name,
+                e:getHeader("Unique-ID"),
+                e:getHeader("Caller-Destination-Number")))
+        elseif name == "BACKGROUND_JOB" then
+            -- the deferred result of our bgapi originate
+            print("job " .. tostring(e:getHeader("Job-UUID"))
+                .. " -> " .. tostring(e:getBody()))
+        end
+    end
+end
+```
+
+The same program in Python is line-for-line equivalent (and matches the shipped
+`libs/esl/python3/events.py`):
+
+```python
+from ESL import ESLconnection
+
+con = ESLconnection("127.0.0.1", "8021", "ClueCon")
+if con.connected():
+    print(con.api("status").getBody())
+    con.events("plain", "ALL")
+    while con.connected():
+        e = con.recvEvent()
+        if e:
+            print(e.getType(), e.getHeader("Unique-ID"))
+```
+
+## Common Uses {#common-uses}
+
+**Monitoring channel lifecycle.** Subscribe with
+`con:events("plain", "CHANNEL_CREATE CHANNEL_ANSWER CHANNEL_HANGUP_COMPLETE")`
+and loop on `recvEvent()`. Each event's headers (`Unique-ID`,
+`Caller-Caller-ID-Number`, `Caller-Destination-Number`, `Hangup-Cause`) give you
+a complete picture of who is talking to whom. To reduce noise, subscribe only to
+the event types you need rather than `ALL`, or add a `filter` to narrow by
+header.
+
+**Placing and controlling calls.** Use `api`/`bgapi` to run any API command. The
+two you will reach for most:
+
+- `con:bgapi("originate", "user/1000 &park")` to start a call without blocking.
+- `con:api("uuid_kill", uuid)` or `con:api("uuid_transfer", uuid .. " 9999")`
+  to act on a live channel by its `Unique-ID`.
+
+Because `bgapi` returns a `Job-UUID` and the real answer arrives later as a
+`BACKGROUND_JOB` event, a robust dialer keeps an events loop running, records
+the `Job-UUID` it got back, and matches it against the `Job-UUID` header on each
+`BACKGROUND_JOB` to learn the outcome of each `originate`.
+
+**Injecting events.** Build an `ESLevent`, populate it with `addHeader`, and send
+it with `con:sendEvent(...)` (the `sendevent` command) to fire custom events or
+trigger behavior in other modules.
+
+For the listener-side configuration, ACLs, the `event_socket.conf.xml`
+parameters, and the raw protocol walkthrough, see
+[The Event Socket](/integration/event-socket). For the per-call,
+FreeSWITCH-connects-to-you variant, see
+[The Outbound Event Socket](/programming/esl-outbound).

--- a/docs/programming/esl-outbound.mdx
+++ b/docs/programming/esl-outbound.mdx
@@ -1,0 +1,343 @@
+---
+sidebar_position: 4
+id: esl-outbound
+slug: /programming/esl-outbound
+title: "The Outbound Event Socket"
+description: "How FreeSWITCH connects out to your server with the socket dialplan application, the connect/linger/myevents handshake, the sync and async execution models, and a worked outbound handler built on the ESL library."
+sidebar_label: "ESL: Outbound"
+---
+
+# The Outbound Event Socket
+
+The inbound Event Socket (see [ESL: Inbound](/programming/esl-inbound)) has your
+program open a TCP connection *to* FreeSWITCH, authenticate, and then drive the
+whole system. The **outbound** Event Socket inverts that relationship. Here
+FreeSWITCH is the client: when the dialplan executes the `socket` application on
+a call, FreeSWITCH opens a TCP connection *out* to a server you are running, and
+your code on the far end controls that one call.
+
+This is the natural model for "one connection per call" call control. Each call
+that reaches a `socket` action gets its own socket to your handler, already bound
+to that channel — there is no password, no `api uuid_...` indirection, and no
+need to hunt for the channel by UUID. Your handler answers the call, plays
+prompts, collects digits, bridges, and hangs up, then the socket closes when the
+call ends.
+
+## Invoking it from the dialplan
+
+The outbound socket is started by the `socket` dialplan application, registered
+by `mod_event_socket`:
+
+```c
+SWITCH_ADD_APP(app_interface, "socket", "Connect to a socket", "Connect to a socket",
+               socket_function, "<ip>[:<port>]", SAF_SUPPORT_NOMEDIA);
+```
+
+(`mod_event_socket.c`, line 1198.) You call it from the dialplan like any other
+application:
+
+```xml
+<action application="socket" data="127.0.0.1:8084 async full"/>
+```
+
+The first token of `data` is the destination; the remaining tokens are flags.
+`socket_function` splits `data` on spaces, then treats the first argument as the
+host (`mod_event_socket.c`, lines 430–431). The host token itself has structure:
+
+- **`host:port`** — the port is split off at the last `:`. If no port is given,
+  it defaults to **8084** (`port = 8084;` at line 417; port parsing at lines
+  451–454).
+- **`host:port/path`** — an optional trailing `/path` is stripped and stored in
+  the channel variable `socket_path`; the host is stored in `socket_host`
+  (lines 456–461).
+- **`hostA:port|hostB:port`** — the host token is also split on `|` into a list
+  of up to 50 candidates. FreeSWITCH tries each in order and connects to the
+  first one that answers (lines 439–484). This gives you simple failover across
+  several handler servers.
+
+### The `async` and `full` flags
+
+After the host, every remaining space-separated token is checked, case
+insensitively, against exactly two flag names (`mod_event_socket.c`, lines
+514–520):
+
+```c
+for (x = 1; x < argc; x++) {
+    if (argv[x] && !strcasecmp(argv[x], "full")) {
+        switch_set_flag(listener, LFLAG_FULL);
+    } else if (argv[x] && !strcasecmp(argv[x], "async")) {
+        switch_set_flag(listener, LFLAG_ASYNC);
+    }
+}
+```
+
+Order does not matter, and anything that is not `full` or `async` is ignored.
+
+**`async`** changes how the `socket` application behaves *inside FreeSWITCH while
+your handler runs*. By default (synchronous), the channel is blocked in the
+`socket` application and each command you send runs to completion before the
+next one is read. With `async` set, FreeSWITCH launches a separate listener
+thread and parks the call, so the channel keeps processing events and your
+queued application commands while your handler is still issuing more of them
+(lines 522–549). In other words, `async` lets you fire `sendmsg`/`execute`
+commands without each one blocking the read loop. The mode you chose is reported
+back to you in the connect reply as the `Socket-Mode` header: `async` or
+`static` (line 2026).
+
+**`full`** grants the outbound connection access to the *global* command set —
+`sendevent`, `api`, `bgapi`, log subscription, and so on — in addition to the
+per-channel commands. Without `full`, the connection is restricted to its own
+channel. This restriction is enforced directly in the command parser
+(`mod_event_socket.c`, lines 2225–2227):
+
+```c
+if (switch_test_flag(listener, LFLAG_OUTBOUND) && !switch_test_flag(listener, LFLAG_FULL)) {
+    goto done;
+}
+```
+
+Commands handled *before* this check — `connect`, `getvar`, `myevents`,
+`sendmsg`, `linger`, `nolinger`, and the event subscription commands — always
+work on an outbound socket. Everything after it requires `full`. The connect
+reply reports this as the `Control` header: `full` or `single-channel` (line
+2027).
+
+:::tip
+Use `async full` when your handler needs to issue overlapping commands and reach
+the broader API; use plain `socket` (synchronous, single-channel) for a simple
+"answer, play a prompt, hang up" flow where blocking on each step is exactly what
+you want.
+:::
+
+## The handshake
+
+When FreeSWITCH connects out, your side speaks the same line-based Event Socket
+protocol as inbound, with one difference at the start: there is **no
+authentication**. The outbound connection is already authenticated and already
+bound to the channel (`switch_set_flag(listener, LFLAG_AUTHED)` and
+`LFLAG_OUTBOUND` at lines 512–513).
+
+Your first command is `connect`. In response, FreeSWITCH builds a
+`CHANNEL_DATA` event populated with the channel's caller profile and all its
+variables, and serializes it back to you (`mod_event_socket.c`, lines
+2012–2036):
+
+```c
+if (!strncasecmp(cmd, "connect", 7)) {
+    switch_set_flag_locked(listener, LFLAG_CONNECTED);
+    switch_event_create(&call_event, SWITCH_EVENT_CHANNEL_DATA);
+    /* ... fills in caller profile + channel variables ... */
+    switch_event_add_header_string(call_event, SWITCH_STACK_BOTTOM, "Content-Type", "command/reply");
+    switch_event_add_header_string(call_event, SWITCH_STACK_BOTTOM, "Reply-Text", "+OK\n");
+    switch_event_add_header_string(call_event, SWITCH_STACK_BOTTOM, "Socket-Mode", /* async | static */);
+    switch_event_add_header_string(call_event, SWITCH_STACK_BOTTOM, "Control",     /* full | single-channel */);
+    /* serialized and sent back over the socket */
+}
+```
+
+That reply block is your snapshot of the call: the `Channel-*` headers, the
+caller ID, the dialed number, every channel variable, plus the `Socket-Mode` and
+`Control` headers describing the flags you chose. Header names are normalized,
+for example `Channel-Unique-ID` and `Caller-Unique-ID` (the channel UUID you will
+pass to later commands).
+
+After connecting, the per-channel commands available to an outbound socket
+include:
+
+| Command | Effect |
+| --- | --- |
+| `connect` | Bind to the call and receive the `CHANNEL_DATA` reply. |
+| `linger` / `linger <seconds>` | Keep the socket open after the call hangs up so you can drain remaining events. `linger` with no argument lingers indefinitely; `linger 5` lingers 5 seconds. Default when no number is given is "forever" until disconnect (lines 2420–2435). |
+| `nolinger` | Turn linger back off (lines 2439–2444). |
+| `myevents` | Subscribe to only this channel's events (see below). |
+| `sendmsg` | Send a message to the bound call — most importantly, execute an application (lines 2169–2223). |
+| `getvar <name>` | Fetch a single channel variable (lines 2037–2051). |
+
+### Subscribing with `myevents`
+
+A plain `connect` gives you the call data but no ongoing event stream. To follow
+the call as it progresses, issue `myevents`. On an outbound socket it subscribes
+*this* connection to the events for *its own* channel — answer, execute,
+execute-complete, DTMF, hangup, and the rest of the channel event family
+(`mod_event_socket.c`, lines 2052–2124). From then on, every event for your call
+is delivered to you as a message you read off the socket. You can request a
+serialization format by appending `plain` (the default), `xml`, or `json`.
+
+### Sync vs async execution
+
+You drive the call by executing dialplan applications on it. At the protocol
+level this is a `sendmsg` with `call-command: execute` and `execute-app-name` /
+`execute-app-arg` headers. The ESL library builds exactly that for you
+(`libs/esl/src/esl.c`, `esl_execute`, lines 530–559):
+
+```c
+snprintf(send_buf, sizeof(send_buf), "%s\ncall-command: execute\n%s%s%s%s\n",
+         cmd_buf, app_buf, arg_buf,
+         handle->event_lock    ? "event-lock: true\n" : "",
+         handle->async_execute ? "async: true\n"      : "");
+```
+
+Two execution models follow from this:
+
+- **Synchronous** — by default the channel runs your application to completion
+  before reading the next command. If you subscribed with `myevents`, you will
+  receive a `CHANNEL_EXECUTE` event when the application starts and a
+  `CHANNEL_EXECUTE_COMPLETE` event when it finishes. Waiting for
+  `CHANNEL_EXECUTE_COMPLETE` is how you know a `playback` actually finished, what
+  digits a `play_and_get_digits` collected, and so on.
+- **Asynchronous** — when the connection or the individual `sendmsg` is marked
+  `async`, the command is queued as a private event and control returns
+  immediately (`mod_event_socket.c`, lines 2169–2207; the per-message `async`
+  header is honored at lines 2172–2177). This lets you queue several
+  applications back to back, or interrupt a running one, without blocking on each.
+
+The `event-lock: true` header (set by the library's `setEventLock`) forces
+applications you queue to run strictly in the order you sent them even in async
+mode — useful when you want async delivery but ordered execution.
+
+## A worked example: the ESL library in outbound mode
+
+The Event Socket Library (ESL) ships with FreeSWITCH under `libs/esl` and wraps
+the protocol in an object API (`ESLconnection` and `ESLevent`) available from
+C++, Lua, Perl, Python, Ruby, and more. For outbound mode it provides a
+constructor that takes an already-accepted socket file descriptor
+(`libs/esl/src/esl_oop.h`, line 81; implementation in `esl_oop.cpp`, lines 45–49):
+
+```cpp
+ESLconnection::ESLconnection(int socket)
+{
+    connection_construct_common();
+    esl_attach_handle(&handle, (esl_socket_t)socket, NULL);
+}
+```
+
+`esl_attach_handle` performs the handshake for you: it sends `connect\n\n` and
+stores the `CHANNEL_DATA` reply as the connection's *info event*
+(`libs/esl/src/esl.c`, lines 454–492):
+
+```c
+esl_send_recv(handle, "connect\n\n");
+if (handle->last_sr_event) {
+    handle->info_event = handle->last_sr_event;
+    /* ... */
+}
+```
+
+So by the time the constructor returns, the call data is already available
+through `getInfo()`. The pattern is: run your own TCP accept loop, and for each
+incoming connection hand the file descriptor to a new `ESLconnection`. The ESL
+methods you use to control the call are (`esl_oop.h`, lines 73–101):
+
+- `getInfo()` — the `CHANNEL_DATA` event for this call.
+- `event:getHeader(name)` — read a header (such as `unique-id`) from any event.
+- `execute(app, arg, uuid)` — run a dialplan application synchronously; returns
+  the reply event (`esl_oop.cpp`, lines 179–188).
+- `executeAsync(app, arg, uuid)` — the async variant (lines 191–207).
+- `recvEvent()` / `recvEventTimed(ms)` — read the next channel event, used after
+  `myevents` (lines 232–259).
+- `setEventLock(val)` / `setAsyncExecute(val)` — toggle the headers described
+  above (lines 163–177).
+
+The repository's own outbound example demonstrates the whole flow
+(`libs/esl/perl/server.pl`). It is the most compact correct outbound handler in
+the tree:
+
+```perl
+require ESL;
+use IO::Socket::INET;
+
+my $sock = IO::Socket::INET->new(LocalHost => "127.0.0.1", LocalPort => 8084,
+                                 Proto => 'tcp', Listen => 1, Reuse => 1);
+die "Could not create socket: $!\n" unless $sock;
+
+for (;;) {
+    my $new_sock = $sock->accept();      # FreeSWITCH connected out to us
+    my $pid = fork();
+    if ($pid) { close($new_sock); next; } # parent keeps listening
+
+    my $fd  = fileno($new_sock);
+    my $con = ESL::ESLconnection->new($fd);   # sends "connect", binds to the call
+    my $info = $con->getInfo();               # the CHANNEL_DATA reply
+    my $uuid = $info->getHeader("unique-id");
+
+    $con->execute("answer", "", $uuid);
+    $con->execute("playback", "/usr/share/freeswitch/sounds/.../ivr-welcome.wav", $uuid);
+    $con->execute("hangup", "", $uuid);
+
+    close($new_sock);
+    exit;
+}
+```
+
+Here is the same idea in Lua, adding `myevents` so we can collect digits and read
+the result of `play_and_get_digits` from its `CHANNEL_EXECUTE_COMPLETE` event.
+The Lua binding exposes the identical method names from `esl_oop.h`, and
+constructs the object as `ESL.ESLconnection(fd)`:
+
+```lua
+require("ESL")
+
+-- 'fd' is the file descriptor of a socket your accept loop just accepted.
+local con  = ESL.ESLconnection(fd)        -- handshake: sends "connect"
+local info = con:getInfo()                -- CHANNEL_DATA reply
+local uuid = info:getHeader("unique-id")
+
+con:execute("answer", "", uuid)
+con:execute("playback", "ivr/ivr-welcome.wav", uuid)
+
+-- Subscribe to this call's events, then collect 4 digits.
+con:setEventLock("true")
+con:myevents()
+con:execute("play_and_get_digits",
+            "4 4 3 5000 # ivr/ivr-enter_pin.wav ivr/ivr-that_was_an_invalid_entry.wav mypin \\d+",
+            uuid)
+
+-- Wait for the application to finish and read what was collected.
+local pin
+while con:connected() == 1 do
+    local e = con:recvEvent()
+    if e then
+        local name = e:getHeader("Event-Name")
+        if name == "CHANNEL_EXECUTE_COMPLETE" then
+            if e:getHeader("Application") == "play_and_get_digits" then
+                -- the collected digits are now in the channel variable 'mypin';
+                -- the value comes back in the command reply's Reply-Text.
+                pin = con:sendRecv("getvar mypin"):getHeader("Reply-Text")
+                break
+            end
+        elseif name == "CHANNEL_HANGUP" then
+            break
+        end
+    end
+end
+
+con:execute("hangup", "", uuid)
+```
+
+The `myevents` subscription is what makes the `recvEvent()` loop meaningful: it
+turns the connection into a stream of this channel's events, so the handler can
+react to `CHANNEL_EXECUTE_COMPLETE`, `DTMF`, and `CHANNEL_HANGUP` rather than
+blindly firing applications. Collected digits are written into the channel
+variable named by the `play_and_get_digits` argument (here `mypin`), which you
+read back with `getvar` or from a later channel snapshot.
+
+:::note
+`con:myevents()` here is shorthand for `con:sendRecv("myevents")` — send the raw
+`myevents` command and read its `+OK` reply. The ESL object API exposes
+`events()` for the general event subscription; for outbound per-channel events
+the `myevents` command is what you want, and `sendRecv` sends it verbatim.
+:::
+
+## When to use outbound vs inbound
+
+| Use **outbound** when… | Use **inbound** when… |
+| --- | --- |
+| You are controlling individual calls (IVR, voicebot, screening) and want one connection bound to each call. | You are monitoring, logging, or originating across the whole system. |
+| You want FreeSWITCH to reach out to your app servers, with `\|`-separated failover. | Your app is a long-lived client that connects once and stays connected. |
+| You do not want to manage authentication or look calls up by UUID. | You need the global API (`api`/`bgapi`), system-wide event streams, or to originate new calls. |
+| Each call's logic is short-lived and self-contained. | One process must see and act on many channels at once. |
+
+The two modes are not exclusive. A common architecture uses an inbound
+connection for system-wide monitoring and origination, and the `socket`
+application to hand specific calls off to a dedicated outbound handler for
+detailed call control.

--- a/docs/programming/event-model.mdx
+++ b/docs/programming/event-model.mdx
@@ -1,0 +1,240 @@
+---
+sidebar_position: 1
+id: event-model
+slug: /programming/event-model
+title: "The Event Model"
+description: "How FreeSWITCH represents everything significant as a typed event with named headers and an optional body, the SWITCH_EVENT_* family, the headers every event carries, and the channel lifecycle as a stream of events."
+sidebar_label: "The Event Model"
+---
+
+FreeSWITCH is event-driven at its core. Almost everything significant that
+happens inside the system — a channel is created, a call is answered, a digit is
+pressed, a module is loaded, an API command runs — is published as an *event*.
+Your code does not poll FreeSWITCH for state; it subscribes to the events it
+cares about and reacts to them. Understanding the event model is the foundation
+for everything in this part of the manual: the Event Socket, the scripting
+APIs, and the event handler modules all consume the same events described here.
+
+## What an event is
+
+An event is a typed message. It has three parts:
+
+- A **type** (the event ID, one of the `SWITCH_EVENT_*` values).
+- A set of **headers** — name/value string pairs — that carry the event's data.
+- An optional **body** — a free-form block of text that does not fit neatly into
+  a header (for example, the textual result of an API call or a chat message).
+
+The header is the unit you work with most. Both the name and the value are
+strings, so an event is essentially a small, self-describing dictionary plus a
+type tag and an optional payload. This uniform shape is what lets a single Event
+Socket connection consume `CHANNEL_ANSWER`, `DTMF`, and `BACKGROUND_JOB` events
+through the same parsing code.
+
+Internally the body is stored on the event structure and read back with the core
+API; `switch_event_add_body()` sets it and the body field is what gets returned
+to a consumer (see `freeswitch/src/switch_event.c`, lines 862-870 and 1258-1267).
+
+## Event types
+
+The set of event types is a fixed enum, `switch_event_types_t`, declared in
+`freeswitch/src/include/switch_types.h` (lines 2083-2178). Each enum value has a
+matching string name in the `EVENT_NAMES[]` table in
+`freeswitch/src/switch_event.c` (lines 137-232); that string is what you see in
+the `Event-Name` header and what you subscribe to by name. The two lists are
+kept in lock-step and in the same order.
+
+The enum value is `SWITCH_EVENT_CHANNEL_ANSWER`; the wire name is
+`CHANNEL_ANSWER`. The names below are taken verbatim from `EVENT_NAMES[]`.
+
+### The channel lifecycle events
+
+These describe the life of a call leg (a *channel*) and are the events you will
+consume most often:
+
+| Event name | Meaning |
+| --- | --- |
+| `CHANNEL_CREATE` | A channel has been created. |
+| `CHANNEL_STATE` | A channel has changed state. |
+| `CHANNEL_CALLSTATE` | A channel has changed call state. |
+| `CHANNEL_ANSWER` | A channel has been answered. |
+| `CHANNEL_HANGUP` | A channel has begun hanging up. |
+| `CHANNEL_HANGUP_COMPLETE` | A channel has completed the hangup. |
+| `CHANNEL_DESTROY` | A channel has been destroyed and its session freed. |
+| `CHANNEL_BRIDGE` | A channel has bridged to another channel. |
+| `CHANNEL_UNBRIDGE` | A channel has unbridged from another channel. |
+| `CHANNEL_EXECUTE` | A channel has begun executing an application. |
+| `CHANNEL_EXECUTE_COMPLETE` | A channel has finished executing an application. |
+| `CHANNEL_PROGRESS` | A channel has started ringing. |
+| `CHANNEL_PROGRESS_MEDIA` | A channel has started early media. |
+| `CHANNEL_ORIGINATE` | A channel has been originated. |
+| `CHANNEL_PARK` / `CHANNEL_UNPARK` | A channel has been parked / unparked. |
+| `CHANNEL_HOLD` / `CHANNEL_UNHOLD` | A channel has been put on / taken off hold. |
+
+### Other commonly used events
+
+| Event name | Meaning |
+| --- | --- |
+| `DTMF` | A DTMF digit was detected on a channel. |
+| `CUSTOM` | A custom event, qualified by a subclass string (see below). |
+| `HEARTBEAT` | The system is alive; fired periodically by the core. |
+| `BACKGROUND_JOB` | An asynchronous (`bgapi`) job has finished; carries its result. |
+| `API` | An API command was executed. |
+| `RECORD_START` / `RECORD_STOP` | Recording of a channel started / stopped. |
+| `PLAYBACK_START` / `PLAYBACK_STOP` | Playback on a channel started / stopped. |
+| `STARTUP` / `SHUTDOWN` | The system started / shut down. |
+| `MODULE_LOAD` / `MODULE_UNLOAD` | A module was loaded / unloaded. |
+| `RELOADXML` | The XML registry was reloaded. |
+| `LOG` | A log line was emitted. |
+| `PRESENCE_IN` / `PRESENCE_OUT` / `PRESENCE_PROBE` | Presence (BLF) signalling. |
+
+There are roughly ninety event types in all; the table above is the working set.
+The full enumeration lives in the two source files cited above, and a per-event
+reference of the events you are most likely to consume is in the
+[events catalog](./events-catalog.mdx).
+
+### CUSTOM events and subclasses
+
+`CUSTOM` is special. Rather than adding a new enum value every time a module
+needs to publish something, modules fire a `CUSTOM` event qualified by a
+**subclass** — a namespaced string, conventionally `module::name`. The subclass
+is carried in the `Event-Subclass` header
+(`freeswitch/src/switch_event.c`, line 784), and subscribers match on both the
+`CUSTOM` type *and* the subclass string. Examples from the bundled modules:
+
+- `sofia::register` — a SIP endpoint registered
+  (`freeswitch/src/mod/endpoints/mod_sofia/mod_sofia.h`, line 84).
+- `conference::maintenance` — a conference state change such as a member
+  joining or leaving
+  (`freeswitch/src/mod/applications/mod_conference/mod_conference.h`, line 63).
+
+When you subscribe to events you can ask for `CUSTOM` with a specific subclass,
+which is far more precise than receiving every custom event in the system.
+
+## Standard headers
+
+Every event, regardless of type, is stamped with a common set of headers when it
+is fired. These are added by the core in `switch_event_prepare_for_fire()`
+(`freeswitch/src/switch_event.c`, lines 1986-2002):
+
+| Header | Contents |
+| --- | --- |
+| `Event-Name` | The event's wire name, e.g. `CHANNEL_ANSWER`. |
+| `Core-UUID` | The UUID of this FreeSWITCH core instance. |
+| `FreeSWITCH-Hostname` | The OS hostname of the server. |
+| `FreeSWITCH-Switchname` | The configured switch name (may differ from the hostname). |
+| `FreeSWITCH-IPv4` / `FreeSWITCH-IPv6` | The guessed local IP addresses. |
+| `Event-Date-Local` | Local wall-clock time the event was fired. |
+| `Event-Date-GMT` | The same instant as an RFC 822 (GMT) timestamp. |
+| `Event-Date-Timestamp` | Microseconds since the Unix epoch. |
+| `Event-Calling-File` | Source file that fired the event. |
+| `Event-Calling-Function` | Source function that fired the event. |
+| `Event-Calling-Line-Number` | Source line that fired the event. |
+| `Event-Sequence` | A monotonically increasing per-core sequence number. |
+
+`CUSTOM` events additionally carry `Event-Subclass` as described above.
+
+### Channel event headers
+
+When an event is associated with a channel, the core adds a further block of
+channel headers via `switch_channel_event_set_basic_data()`
+(`freeswitch/src/switch_channel.c`, lines 2672-2718):
+
+| Header | Contents |
+| --- | --- |
+| `Unique-ID` | The channel's UUID — the key you use to address it. |
+| `Channel-Name` | The channel name, e.g. `sofia/internal/1001@example.com`. |
+| `Channel-State` | The internal state machine state, e.g. `CS_EXECUTE`. |
+| `Channel-State-Number` | The numeric form of that state. |
+| `Channel-Call-State` | The call state, e.g. `RINGING`, `ACTIVE`, `HANGUP`. |
+| `Call-Direction` | `inbound` or `outbound`. |
+| `Answer-State` | `ringing`, `early`, `answered`, or `hangup`. |
+| `Channel-Call-UUID` | The UUID grouping the legs of a single call. |
+| `Hangup-Cause` | The hangup cause string, present once the channel is tearing down. |
+
+The caller's identity is added from the channel's caller profile with a `Caller-`
+prefix by `switch_caller_profile_event_set_data()`
+(`freeswitch/src/switch_caller.c`, lines 322-385) — for example
+`Caller-Caller-ID-Name`, `Caller-Caller-ID-Number`, `Caller-Destination-Number`,
+`Caller-ANI`, `Caller-Network-Addr`, and `Caller-Unique-ID`. When the channel is
+bridged, the far leg's profile is added under an `Other-Leg-` prefix.
+
+### DTMF, BACKGROUND_JOB, and API headers
+
+A few of the common non-lifecycle events carry their own distinctive headers:
+
+- `DTMF` carries `DTMF-Digit` (the pressed character) and `DTMF-Duration` (in
+  samples) — `freeswitch/src/switch_channel.c`, lines 681-682.
+- `BACKGROUND_JOB` carries `Job-UUID`, `Job-Command`, and `Job-Command-Arg`, and
+  the command's textual output is delivered in the event **body**
+  (`freeswitch/src/mod/event_handlers/mod_event_socket/mod_event_socket.c`,
+  lines 1570-1574).
+- `API` carries `API-Command` and `API-Command-Argument`
+  (`freeswitch/src/switch_loadable_module.c`, lines 2959-2962).
+
+## The channel lifecycle as a stream of events
+
+A single inbound call answered, bridged, and hung up produces a predictable
+sequence of events on its channel. Following one `Unique-ID` through that
+sequence is the canonical way to track a call. A typical answered-and-bridged
+call looks like this:
+
+```text
+CHANNEL_CREATE            a new channel exists (Unique-ID assigned)
+  CHANNEL_STATE  ...      one per internal state transition (CS_NEW, CS_INIT, ...)
+  CHANNEL_CALLSTATE ...   call-state transitions (DOWN -> RINGING -> ...)
+CHANNEL_PROGRESS          remote end is ringing
+CHANNEL_PROGRESS_MEDIA    early media (optional)
+CHANNEL_ANSWER            the call is answered
+  CHANNEL_EXECUTE         dialplan application starts (e.g. bridge)
+  CHANNEL_BRIDGE          this leg is bridged to another channel
+  ... DTMF, media events ...
+  CHANNEL_UNBRIDGE        the bridge ends
+  CHANNEL_EXECUTE_COMPLETE application finished
+CHANNEL_HANGUP            hangup has begun; Hangup-Cause is now set
+CHANNEL_HANGUP_COMPLETE   teardown finished, channel statistics finalized
+CHANNEL_DESTROY           the session is freed; no further events for this UUID
+```
+
+Two distinctions are worth internalizing:
+
+- `CHANNEL_HANGUP` fires when teardown *starts*; `CHANNEL_HANGUP_COMPLETE` fires
+  when it *finishes*. Use `CHANNEL_HANGUP_COMPLETE` for accounting, because by
+  then the durations and the final `Hangup-Cause` are settled.
+- `CHANNEL_DESTROY` is the very last event for a given `Unique-ID`. After it,
+  that UUID is gone. It is the right place to release any per-call state your
+  application is holding.
+
+State changes are reported by `CHANNEL_STATE` (the internal state machine,
+`Channel-State`) and `CHANNEL_CALLSTATE` (the higher-level call state,
+`Channel-Call-State`). For most applications the call-state view and the
+named lifecycle events above are enough; the raw state events are there when you
+need finer-grained tracking.
+
+## How variables ride on events
+
+Channel variables are surfaced on channel events as headers with a `variable_`
+prefix: a variable named `foo` appears as the header `variable_foo`. The core
+copies every channel variable onto qualifying events in
+`switch_channel_event_set_extended_data()`
+(`freeswitch/src/switch_channel.c`, lines 2825-2837, with the
+`switch_snprintf(buf, sizeof(buf), "variable_%s", vvar)` building the header
+name on line 2834).
+
+This is how data you set on a call — `sip_h_X-*` SIP headers, accounting tags,
+routing decisions, dialed digits stored in a variable — travels with the event
+to your consumer without any extra wiring. Not every event carries the full
+variable set; the extended data is attached for the major lifecycle events
+(create, answer, hangup, destroy, execute, and others) and whenever verbose
+events are enabled for the channel
+(`freeswitch/src/switch_channel.c`, lines 2768-2800).
+
+For the meaning of individual variables you will see in `variable_*` headers,
+see the [channel variables reference](../reference/channel-variables.mdx).
+
+## Where to go next
+
+- The [events catalog](./events-catalog.mdx) documents the individual events you
+  are most likely to consume, header by header.
+- [Consuming events with the inbound Event Socket](./esl-inbound.mdx) shows how
+  to connect to FreeSWITCH, subscribe to these events, and act on them from your
+  own code.

--- a/docs/programming/events-catalog.mdx
+++ b/docs/programming/events-catalog.mdx
@@ -1,0 +1,185 @@
+---
+sidebar_position: 2
+id: events-catalog
+slug: /programming/events-catalog
+title: "Events Catalog"
+description: "Reference catalog of FreeSWITCH events: when each fires, its notable headers, and whether it is a first-class event or a CUSTOM subclass."
+sidebar_label: "Events Catalog"
+---
+
+# Events Catalog
+
+FreeSWITCH publishes a continuous stream of *events* that describe everything
+happening inside the switch: channels being created and torn down, applications
+executing, media starting and stopping, registrations arriving, and the system
+itself starting up and shutting down. Any consumer — the Event Socket, a
+scripting language, or a loaded module — can subscribe to these events and react
+to them. This catalog is the companion to the
+[Channel Variables Catalog](/reference/channel-variables): where that chapter
+documents the per-channel values you *read*, this chapter documents the events
+you *consume*.
+
+Every event has a name and a set of headers (name/value string pairs). The
+events listed here fall into two kinds:
+
+- **First-class events** have a dedicated entry in the `switch_event_types_t`
+  enum in `switch_types.h` and a matching string in the `EVENT_NAMES[]` table in
+  `switch_event.c`. You subscribe to them by name, for example `CHANNEL_ANSWER`.
+- **CUSTOM subclasses** are `SWITCH_EVENT_CUSTOM` events tagged with an
+  `Event-Subclass` header, used when a module needs an event that the core does
+  not define. You subscribe to them with `CUSTOM <subclass>`, for example
+  `CUSTOM sofia::register`. The subclass strings below are defined in
+  `mod_sofia.h` and reserved at module load.
+
+Channel-scoped events carry a near-universal set of channel headers added by
+`switch_channel_event_set_data()` in `switch_channel.c` — most importantly
+`Unique-ID` (the channel UUID), plus `Channel-State`, `Channel-Call-State`,
+`Answer-State`, `Caller-Caller-ID-Number`, `Caller-Destination-Number`, and the
+full set of `Caller-*` and `variable_*` headers. The tables below call out the
+headers that are *specific* to each event rather than repeating this common set.
+
+The event identifiers are confirmed against
+`src/include/switch_types.h` (the `SWITCH_EVENT_*` enum, lines 2084–2177) and
+`src/switch_event.c` (the `EVENT_NAMES[]` table, lines 137+).
+
+## Channel lifecycle
+
+These first-class events trace a call leg from creation through teardown. They
+all carry the common channel headers (`Unique-ID` and the `Caller-*` set);
+the table lists the headers most useful for each specific event.
+
+| Event | Fired when | Notable headers |
+| --- | --- | --- |
+| `CHANNEL_CREATE` | A new channel object is created, before it is answered. | `Unique-ID`, `Channel-State`, `Call-Direction` |
+| `CHANNEL_OUTGOING` | An outbound channel has been created (the B-leg of an origination). | `Unique-ID`, `Caller-Destination-Number` |
+| `CHANNEL_ORIGINATE` | A channel has been originated by the originate API/app. | `Unique-ID`, `Caller-Destination-Number` |
+| `CHANNEL_PROGRESS` | The channel has started ringing (180 Ringing, no media). | `Unique-ID`, `Channel-State` |
+| `CHANNEL_PROGRESS_MEDIA` | The channel has early media (183 Session Progress). | `Unique-ID`, `Channel-State` |
+| `CHANNEL_ANSWER` | The channel has been answered. | `Unique-ID`, `Answer-State` |
+| `CHANNEL_EXECUTE` | A dialplan application begins executing on the channel. | `Application`, `Application-Data`, `Application-UUID` |
+| `CHANNEL_EXECUTE_COMPLETE` | A dialplan application finishes executing. | `Application`, `Application-Data`, `Application-Response` |
+| `CHANNEL_BRIDGE` | The channel is bridged to another channel. | `Bridge-A-Unique-ID`, `Bridge-B-Unique-ID`, `Other-Leg-Unique-ID` |
+| `CHANNEL_UNBRIDGE` | The channel is unbridged from its peer. | `Bridge-A-Unique-ID`, `Bridge-B-Unique-ID` |
+| `CHANNEL_PARK` | The channel has been parked. | `Unique-ID`, `Channel-State` |
+| `CHANNEL_UNPARK` | The channel has been unparked. | `Unique-ID`, `Channel-State` |
+| `CHANNEL_HOLD` | The channel has been put on hold. | `Unique-ID` |
+| `CHANNEL_UNHOLD` | The channel has been taken off hold. | `Unique-ID` |
+| `CHANNEL_STATE` | The channel's internal state changes (CS_NEW, CS_ROUTING, CS_EXECUTE, etc.). | `Channel-State`, `Channel-State-Number`, `Channel-Call-State` |
+| `CHANNEL_CALLSTATE` | The channel's call state changes (DOWN, RINGING, ACTIVE, HELD, etc.). | `Channel-Call-State`, `Original-Channel-Call-State`, `Channel-Call-UUID` |
+| `CHANNEL_HANGUP` | The channel begins hanging up. | `Hangup-Cause`, `Unique-ID` |
+| `CHANNEL_HANGUP_COMPLETE` | The hangup has fully completed; all media and timing data is final. | `Hangup-Cause`, `Unique-ID` |
+| `CHANNEL_DESTROY` | The channel object is being destroyed and freed. | `Unique-ID`, `Hangup-Cause` |
+
+The `Channel-State` header on `CHANNEL_STATE` reflects the low-level state
+machine, while `Channel-Call-State` on `CHANNEL_CALLSTATE` reflects the
+higher-level call state that most applications care about. For most call-tracking
+purposes, `CHANNEL_ANSWER`, `CHANNEL_BRIDGE`, and `CHANNEL_HANGUP_COMPLETE` are
+the events to watch; `CHANNEL_HANGUP_COMPLETE` is preferred over `CHANNEL_HANGUP`
+for CDR-style processing because all timers and counters are finalized.
+
+## DTMF
+
+| Event | Fired when | Notable headers |
+| --- | --- | --- |
+| `DTMF` | A DTMF digit is received or sent on a channel. | `DTMF-Digit`, `DTMF-Duration`, `DTMF-Source` |
+
+`DTMF-Source` indicates how the digit arrived (for example `RTP`, `INBAND`, or
+`APP`). The event carries the common channel headers, so `Unique-ID` identifies
+the leg the digit belongs to.
+
+## Media and recording
+
+These first-class events mark the start and stop of recording and playback, and
+report detected audio conditions. They carry the common channel headers.
+
+| Event | Fired when | Notable headers |
+| --- | --- | --- |
+| `RECORD_START` | A recording begins on the channel. | `Record-File-Path`, `Unique-ID` |
+| `RECORD_STOP` | A recording stops. | `Record-File-Path`, `Record-Completion-Cause`, `Unique-ID` |
+| `PLAYBACK_START` | File playback begins on the channel. | `Playback-File-Path`, `Unique-ID` |
+| `PLAYBACK_STOP` | File playback stops (completed or interrupted). | `Playback-File-Path`, `Playback-Status`, `Unique-ID` |
+| `DETECTED_TONE` | A tone the channel was watching for is detected. | `Detected-Tone`, `Unique-ID` |
+| `TALK` | Voice activity (talking) is detected on the channel. | `Unique-ID` |
+| `NOTALK` | Voice activity stops (silence) on the channel. | `Unique-ID` |
+
+`Playback-Status` is `done` when playback completed normally and `break` when it
+was interrupted (for example by a caller pressing a digit). `RECORD_STOP` carries
+a `Record-Completion-Cause` when the recording ended for a specific reason. `TALK`
+and `NOTALK` are emitted by the RTP layer's voice-activity detector and require
+VAD to be enabled on the channel.
+
+## System and jobs
+
+These first-class events describe the switch itself rather than any one channel.
+
+| Event | Fired when | Notable headers |
+| --- | --- | --- |
+| `STARTUP` | The system has finished starting and is ready. | `Event-Info` (`System Ready`), `Up-Time` |
+| `SHUTDOWN` | The system is shutting down. | `Event-Info` |
+| `HEARTBEAT` | Emitted periodically (every ~20 seconds) while the system runs. | `Event-Info`, `Up-Time`, `FreeSWITCH-Version`, `Session-Count`, `Session-Per-Sec`, `Idle-CPU` |
+| `BACKGROUND_JOB` | A `bgapi` background job completes; the body holds the API result. | `Job-UUID`, `Job-Command`, `Job-Command-Arg` |
+| `API` | An API command has been executed. | `API-Command`, `API-Command-Argument` |
+| `MODULE_LOAD` | A module (or one of its interfaces) is loaded. | `type`, `name`, `key`, `filename` |
+| `MODULE_UNLOAD` | A module is unloaded. | `type`, `name`, `key` |
+| `RELOADXML` | The XML registry has been reloaded. | — |
+| `TRAP` | An internal trap fires for a system-level condition (hostname change, network address change, network outage). | `condition`, plus condition-specific headers |
+
+`BACKGROUND_JOB` is the key event for the inbound Event Socket `bgapi` workflow:
+you submit a command, receive the `Job-UUID` immediately, and later receive a
+`BACKGROUND_JOB` event whose `Job-UUID` matches and whose body contains the
+command's output. `MODULE_LOAD` fires once per interface a module registers, so a
+single module can produce several `MODULE_LOAD` events with different `type`
+values (`endpoint`, `codec`, `dialplan`, `application`, and so on).
+
+## Registration and presence
+
+Registration and presence are split between **CUSTOM subclasses** published by
+`mod_sofia` and **first-class** presence/messaging events defined in the core.
+Subscribe to the `mod_sofia` events with `CUSTOM <subclass>`; the subclass
+strings are defined in `src/mod/endpoints/mod_sofia/mod_sofia.h` and fired from
+`sofia_reg.c`.
+
+### mod_sofia CUSTOM subclasses
+
+| Event (subclass) | Fired when | Notable headers |
+| --- | --- | --- |
+| `sofia::register` | A SIP endpoint successfully registers. | `profile-name`, `from-user`, `from-host`, `contact`, `call-id`, `expires`, `network-ip`, `user-agent` |
+| `sofia::unregister` | An endpoint unregisters (sends a REGISTER with Expires: 0). | `profile-name`, `from-user`, `from-host`, `contact`, `call-id` |
+| `sofia::expire` | A registration is reaped because it expired. | `profile-name`, `user`, `host`, `contact`, `call-id`, `expires`, `network-ip` |
+| `sofia::gateway_state` | A gateway's registration/ping state changes. | `Gateway`, `State`, `Ping-Status`, `Register-Network-IP` |
+
+`sofia::register` additionally merges any variables collected during
+registration, and sets `update-reg` to `true` when the event represents a
+re-registration of an already-known contact rather than a brand-new one. For
+`sofia::gateway_state`, `State` is the gateway's lifecycle state (for example
+`REGED`, `UNREGED`, `FAIL_WAIT`) and `Ping-Status` reflects OPTIONS keepalive
+health.
+
+### First-class presence and messaging events
+
+| Event | Fired when | Notable headers |
+| --- | --- | --- |
+| `PRESENCE_IN` | An incoming presence/status update is published for a user. | `proto`, `login`, `from`, `status`, `rpid`, `event_type` |
+| `PRESENCE_OUT` | An outgoing presence update. | `proto`, `from`, `status` |
+| `MESSAGE` | A basic chat/instant message passes through the switch. | `proto`, `from`, `to` |
+
+`PRESENCE_IN` and `PRESENCE_OUT` are the transport-neutral presence events that
+`mod_sofia` both produces (from registrations and SUBSCRIBE/NOTIFY traffic) and
+consumes (to drive BLF/dialog NOTIFY). The `proto` header identifies the
+originating protocol or chat plugin; for SIP it is typically `sip`. `MESSAGE` is
+the generic instant-message event used by the chat plumbing across protocols.
+
+## Quick reference: first-class vs CUSTOM
+
+| Name | Kind | Source |
+| --- | --- | --- |
+| All `CHANNEL_*` above | First-class | `switch_types.h` enum / `EVENT_NAMES[]` |
+| `DTMF` | First-class | `switch_types.h` enum / `EVENT_NAMES[]` |
+| `RECORD_*`, `PLAYBACK_*`, `DETECTED_TONE`, `TALK`, `NOTALK` | First-class | `switch_types.h` enum / `EVENT_NAMES[]` |
+| `STARTUP`, `SHUTDOWN`, `HEARTBEAT`, `BACKGROUND_JOB`, `API`, `MODULE_LOAD`, `MODULE_UNLOAD`, `RELOADXML`, `TRAP` | First-class | `switch_types.h` enum / `EVENT_NAMES[]` |
+| `PRESENCE_IN`, `PRESENCE_OUT`, `MESSAGE` | First-class | `switch_types.h` enum / `EVENT_NAMES[]` |
+| `sofia::register`, `sofia::unregister`, `sofia::expire`, `sofia::gateway_state` | CUSTOM subclass | `mod_sofia.h` / `sofia_reg.c` |
+
+To see the live headers for any event on your own system, subscribe to it from
+`fs_cli` with `/event plain <NAME>` (or `/event plain CUSTOM <subclass>`) and
+trigger the condition; the full header set is printed as it fires.

--- a/docs/programming/index.mdx
+++ b/docs/programming/index.mdx
@@ -1,0 +1,17 @@
+---
+title: "Part 12: Programming with the Event Socket and Scripting"
+slug: /programming
+description: "Drive FreeSWITCH from code: the event model, an events catalog, the inbound and outbound Event Socket, and the embedded scripting APIs."
+---
+
+import DocCardList from '@theme/DocCardList';
+
+The integration chapters showed how to *configure* the Event Socket and the
+scripting modules. This part shows how to *program* with them. It covers
+FreeSWITCH's event model and a catalog of the events you will consume, the two
+Event Socket modes — inbound (your code connects to FreeSWITCH) and outbound
+(FreeSWITCH connects to your code) — and the embedded scripting APIs for driving
+a call from Lua or JavaScript. It is a developer's companion to the reference,
+focused on the programmable surface rather than the configuration.
+
+<DocCardList />

--- a/docs/programming/scripting-apis.mdx
+++ b/docs/programming/scripting-apis.mdx
@@ -1,0 +1,378 @@
+---
+sidebar_position: 5
+id: scripting-apis
+slug: /programming/scripting-apis
+title: "Embedded Scripting APIs"
+description: "The shared scripting surface for mod_lua and mod_v8: the Session object, freeswitch.API, freeswitch.Event, consoleLog, and stream output, with parallel Lua and JavaScript examples."
+sidebar_label: "Scripting APIs"
+---
+
+# Embedded Scripting APIs
+
+[Chapter 28: Scripting Integration](/integration/scripting) covered how to *wire up* the language modules — the dialplan application, the API command, the XML handler, and the event hooks. This chapter documents the *programmable surface* those modules expose: the objects and functions a script calls once it is running.
+
+`mod_lua` and `mod_v8` (JavaScript) share almost the same object model because both wrap the same C++ classes in `src/switch_cpp.cpp` — the `CoreSession`, `API`, `Event`, and `Stream` classes declared in `src/include/switch_cpp.h`. `mod_lua` exposes them through a SWIG binding (`src/mod/languages/mod_lua/freeswitch.i`); `mod_v8` reimplements an equivalent surface in C++ under `src/mod/languages/mod_v8/`. The two languages are close enough to read interchangeably, but the spellings differ in a few places. Those differences are flagged explicitly below.
+
+Every method and function named in this chapter was verified against the FreeSWITCH source. Where Lua and JavaScript disagree, both names are given.
+
+---
+
+## How a Script Gets a Session {#how-a-script-gets-a-session}
+
+A *session* is the script's handle to a call leg. There are three ways a script comes to hold one.
+
+### The global `session` {#the-global-session}
+
+When a script is launched by the `lua` or `javascript` dialplan application on an active call leg, the module injects a ready-to-use session object into the script under the global name `session`.
+
+In Lua this is done by `mod_lua_conjure_session(L, session, "session", 1)` (`mod_lua.cpp`); in JavaScript `mod_v8` registers the same object under the name `session` (`mod_v8.cpp`, `RegisterInstance(isolate, "session", true)`). In both languages the global is simply called `session`.
+
+```lua title="Lua — from the lua dialplan app"
+-- 'session' already exists; it is the inbound call leg
+session:answer()
+```
+
+```javascript title="JavaScript — from the javascript dialplan app"
+// 'session' already exists; it is the inbound call leg
+session.answer();
+```
+
+When a script is run *outside* a call leg (the `luarun`/`jsrun` API command, a startup script, or an XML handler), there is no call, so `session` is not a usable call object. In `mod_v8` the global is set to the boolean `false` in that case so a script can test for it (`mod_v8.cpp`).
+
+### Wrapping an existing call by UUID {#wrapping-an-existing-call-by-uuid}
+
+A script can attach to any live channel by its UUID.
+
+In Lua, construct a `freeswitch.Session` with the UUID string:
+
+```lua
+local sess = freeswitch.Session("<uuid>")
+if sess:ready() then
+  sess:execute("playback", "ivr/ivr-welcome.wav")
+end
+```
+
+In JavaScript, construct a `Session` with the UUID. If the argument contains no `/`, `mod_v8` treats it as a UUID and locates the existing channel (`fssession.cpp`, `FSSession::Construct`):
+
+```javascript
+var sess = new Session("<uuid>");
+if (sess.ready()) {
+  sess.execute("playback", "ivr/ivr-welcome.wav");
+}
+```
+
+### Originating a new call {#originating-a-new-call}
+
+Passing a dial string (something containing `/`) originates a *new* outbound leg instead of wrapping an existing one. An optional second argument is the originating (A-leg) session, used to inherit caller-profile data.
+
+```lua
+-- new outbound leg, originated from the current call leg
+local b = freeswitch.Session("sofia/gateway/mygw/+15551234567", session)
+if b:ready() then
+  session:bridge(b)
+end
+```
+
+```javascript
+// new outbound leg, originated from the current call leg
+var b = new Session("sofia/gateway/mygw/+15551234567", session);
+if (b.ready()) {
+  bridge(session, b);   // see "Bridging" below
+}
+```
+
+:::note Lua vs. JavaScript
+`mod_v8` also exposes a deprecated `session.originate(a_leg, dialstring)` method, but it logs a deprecation warning and the constructor form `new Session("<dial string>", a_leg)` is preferred (`fssession.cpp`).
+:::
+
+---
+
+## The Session Object {#the-session-object}
+
+Session methods map onto the `CoreSession` C++ class in `src/include/switch_cpp.h`. `mod_lua` binds that class almost verbatim through SWIG, so the Lua method names match the C++ declarations exactly. `mod_v8` registers an equivalent — but not identical — set of methods in its `session_proc` table (`fssession.cpp`).
+
+The table below lists the commonly used methods. The **Lua** column is the SWIG name; the **JavaScript** column is the `mod_v8` name. A dash means the method is not exposed in that language under the shared surface.
+
+| Purpose | Lua | JavaScript | Verified in |
+|---|---|---|---|
+| Answer the call | `session:answer()` | `session.answer()` | `switch_cpp.h` / `fssession.cpp` |
+| Pre-answer (early media) | `session:preAnswer()` | `session.preAnswer()` | `switch_cpp.h` / `fssession.cpp` |
+| Hang up | `session:hangup(cause)` | `session.hangup(cause)` | `switch_cpp.h` / `fssession.cpp` |
+| Play a file | `session:streamFile(file)` | `session.streamFile(file)` | `switch_cpp.h` / `fssession.cpp` |
+| Record to a file | `session:recordFile(name, limit, thresh, hits)` | `session.recordFile(name, cb, arg, limit, thresh, hits)` | `switch_cpp.h` / `fssession.cpp` |
+| Play prompt and collect DTMF | `session:playAndGetDigits(...)` | *(not exposed)* | `switch_cpp.h` |
+| Collect a fixed count of digits | `session:getDigits(max, terminators, timeout)` | `session.getDigits(max, terminators, timeout)` | `switch_cpp.h` / `fssession.cpp` |
+| Play prompt and read digits | `session:read(min, max, file, timeout, terminators)` | *(not exposed)* | `switch_cpp.h` |
+| Execute a dialplan app | `session:execute(app, data)` | `session.execute(app, data)` | `switch_cpp.h` / `fssession.cpp` |
+| Get a channel variable | `session:getVariable(name)` | `session.getVariable(name)` | `switch_cpp.h` / `fssession.cpp` |
+| Set a channel variable | `session:setVariable(name, val)` | `session.setVariable(name, val)` | `switch_cpp.h` / `fssession.cpp` |
+| Say a structured value (number, date, …) | `session:say(text, module, type, method, gender)` | *(use `sayPhrase` / `speak`)* | `switch_cpp.h` |
+| Play a phrase macro | `session:sayPhrase(name, data, lang)` | `session.sayPhrase(name, data, lang)` | `switch_cpp.h` / `fssession.cpp` |
+| Sleep (ms), serviced for DTMF | `session:sleep(ms)` | `session.sleep(ms)` | `switch_cpp.h` / `fssession.cpp` |
+| Is the channel still up? | `session:ready()` | `session.ready()` | `switch_cpp.h` / `fssession.cpp` |
+| Has the call been answered? | `session:answered()` | `session.answered()` | `switch_cpp.h` / `fssession.cpp` |
+| Bridge to another session | `session:bridge(other)` | `session.bridge(other)` | `switch_cpp.h` / `fssession.cpp` |
+| Set a hangup hook | `session:setHangupHook(func)` | `session.setHangupHook(func)` | `freeswitch.i` / `fssession.cpp` |
+| Set a DTMF/input callback | `session:setInputCallback(func, args)` | `session.collectInput(func, arg, timeout)` | `freeswitch.i` / `fssession.cpp` |
+
+A few of these warrant detail.
+
+### `streamFile` {#streamfile}
+
+`streamFile(file)` plays a file into the channel. In Lua a second integer argument is the starting sample offset (`switch_cpp.h`):
+
+```lua
+session:streamFile("ivr/ivr-welcome.wav")
+```
+
+In JavaScript the extra arguments are an optional input-callback function, a callback argument, and a sample offset (`fssession.cpp`, `StreamFile`):
+
+```javascript
+session.streamFile("ivr/ivr-welcome.wav");
+```
+
+### `playAndGetDigits` — Lua only {#playandgetdigits}
+
+`playAndGetDigits` plays a prompt, collects DTMF, validates them against a regex, and retries on bad input. It is declared on `CoreSession` (`switch_cpp.h`) and bound by SWIG, so it is available in **Lua** but is **not** in the `mod_v8` `session_proc` table:
+
+```lua
+-- min, max, tries, timeout, terminators, prompt, badInput, regex
+local digits = session:playAndGetDigits(
+  1, 1, 3, 5000, "#",
+  "ivr/ivr-enter_ext.wav",
+  "ivr/ivr-that_was_an_invalid_entry.wav",
+  "\\d+")
+```
+
+In JavaScript, achieve the same by combining `streamFile` and `getDigits`, or by calling the underlying `play_and_get_digits` application via `session.execute(...)`.
+
+### `getDigits` {#getdigits}
+
+`getDigits` collects up to a fixed number of digits, ending early on a terminator or timeout. The first three arguments — maximum digit count, terminator string, and overall timeout in milliseconds — are the same in both languages (`switch_cpp.h`, `fssession.cpp`):
+
+```lua
+local d = session:getDigits(4, "#", 5000)
+```
+
+```javascript
+var d = session.getDigits(4, "#", 5000);
+```
+
+### `execute` {#execute}
+
+`execute(app, data)` runs any dialplan application by name — the same applications you would write in the XML dialplan — in the context of the session (`switch_cpp.h`, `fssession.cpp`). This is the most general lever a script has:
+
+```lua
+session:execute("playback", "ivr/ivr-welcome.wav")
+session:execute("sleep", "1000")
+```
+
+### `getVariable` / `setVariable` {#getvariable-setvariable}
+
+These read and write channel variables (`switch_cpp.h`, `fssession.cpp`):
+
+```lua
+local cid = session:getVariable("caller_id_number")
+session:setVariable("my_flag", "1")
+```
+
+```javascript
+var cid = session.getVariable("caller_id_number");
+session.setVariable("my_flag", "1");
+```
+
+### `setHangupHook` and input callbacks {#hangup-hooks-and-input-callbacks}
+
+`setHangupHook(func)` registers a function to be called when the channel hangs up — useful for cleanup and logging. Both modules support it (`freeswitch.i` for Lua; `fssession.cpp` `SetHangupHook` for JavaScript).
+
+For DTMF and event callbacks during playback, the two modules diverge:
+
+- **Lua** uses `session:setInputCallback(func, args)` to register a persistent callback, paired with `session:unsetInputCallback()` (`freeswitch.i`). The callback also fires during `streamFile`, `collectDigits`, and similar blocking calls.
+- **JavaScript** passes the callback function directly to the playback method (`streamFile`, `recordFile`, `speak`), and exposes `session.collectInput(func, arg, timeout)` for standalone collection (`fssession.cpp`).
+
+:::warning Lua vs. JavaScript: input collection
+There is no `collectDigits` method in `mod_v8`; the JavaScript equivalent is `session.collectInput(...)`. The Lua `CoreSession::collectDigits(...)` method is bound by SWIG and available in Lua.
+:::
+
+---
+
+## `freeswitch.API` — Running API Commands {#freeswitch-api}
+
+Any FreeSWITCH API command — everything you can type at `fs_cli` or send over the Event Socket — can be run from a script. The C++ class is `API` in `switch_cpp.h`; its `execute` and `executeString` methods are implemented in `switch_cpp.cpp`.
+
+### Lua {#api-lua}
+
+In Lua, create an `API` object and call `execute(cmd, args)` or `executeString("cmd args")`:
+
+```lua
+local api = freeswitch.API()
+
+-- two-argument form: command and its arguments
+local result = api:execute("sofia", "status")
+
+-- single-string form: command and args in one string
+local uptime = api:executeString("uptime")
+```
+
+`execute(cmd, args)` and `executeString(cmd)` both return the command's output as a string (`switch_cpp.cpp`, `API::execute` / `API::executeString`).
+
+### JavaScript {#api-js}
+
+:::warning Lua vs. JavaScript: API access
+`mod_v8` does **not** expose an `API` class. Instead it provides a global function `apiExecute(cmd, arg)` (`fsglobal.cpp`, `ApiExecute`). There is no `executeString` in JavaScript; pass the command and its arguments as two parameters.
+:::
+
+```javascript
+// global function, not a class
+var result = apiExecute("sofia", "status");
+var uptime = apiExecute("uptime", "");
+```
+
+An optional third argument to `apiExecute` is a session object, which scopes the command to that channel (`fsglobal.cpp`).
+
+---
+
+## `freeswitch.Event` — Building and Firing Events {#freeswitch-event}
+
+Scripts can construct custom events and fire them onto the FreeSWITCH event bus, where any other subscriber (an Event Socket client, an event hook, another script) can receive them. The C++ class is `Event` in `switch_cpp.h`.
+
+### Lua {#event-lua}
+
+Construct with an event type and an optional subclass name, add headers and a body, then `fire()`:
+
+```lua
+local event = freeswitch.Event("CUSTOM", "my::namespace")
+event:addHeader("Action", "ping")
+event:addHeader("Caller-ID", session:getVariable("caller_id_number"))
+event:addBody("hello from lua")
+event:fire()
+```
+
+Verified methods (`switch_cpp.h`, `switch_cpp.cpp`): `addHeader(name, value)`, `getHeader(name)`, `delHeader(name)`, `addBody(value)`, `getBody()`, `getType()`, `serialize(format)`, `setPriority(priority)`, `fire()`, `merge(other)`, `chat_execute(app, data)`, `chat_send(proto)`.
+
+### JavaScript {#event-js}
+
+The JavaScript surface is the same, exposed through the `Event` class (`fsevent.cpp`, `event_proc`):
+
+```javascript
+var event = new Event("CUSTOM", "my::namespace");
+event.addHeader("Action", "ping");
+event.addHeader("Caller-ID", session.getVariable("caller_id_number"));
+event.addBody("hello from js");
+event.fire();
+```
+
+Verified JavaScript methods (`fsevent.cpp`): `addHeader`, `getHeader`, `addBody`, `getBody`, `getType`, `serialize`, `fire`, `chatExecute`.
+
+:::note Lua vs. JavaScript: chat methods
+The Lua binding spells the chat method `chat_execute` (the C++ name); `mod_v8` spells it `chatExecute`.
+:::
+
+---
+
+## Logging and Stream Output {#logging-and-stream-output}
+
+### `consoleLog` {#consolelog}
+
+`consoleLog(level, msg)` writes to the FreeSWITCH log at the given level (`debug`, `info`, `notice`, `warning`, `err`, `crit`, `alert`, `console`). It is implemented as the free function `consoleLog` in `switch_cpp.cpp`.
+
+```lua
+freeswitch.consoleLog("INFO", "script reached branch A\n")
+```
+
+In JavaScript the global function is `consoleLog(level, msg)`. `mod_v8` also registers `log(level, msg)` as a short alias and keeps `console_log` as a deprecated name (`fsglobal.cpp`):
+
+```javascript
+consoleLog("INFO", "script reached branch A\n");
+```
+
+:::warning Lua vs. JavaScript: log function name
+Both languages use `consoleLog`. In JavaScript, `console_log` still works but is deprecated, and `log` is an accepted short alias. Append your own newline — neither function adds one in Lua, and `mod_v8` only adds one if the message does not already end in `\n`.
+:::
+
+### `stream` output {#stream-output}
+
+When a script runs as an **API command** (for example via `luarun`, or when serving an HTTP request through `mod_xml_rpc` / the Event Socket `api` command), the module injects a global `stream` object. Writing to it sends data back to the caller. In Lua the module conjures it under the name `stream` (`mod_lua.cpp`, `mod_lua_conjure_stream`), and it exposes `write` (`switch_cpp.cpp`, `Stream::write`):
+
+```lua
+-- in an API/luarun context, 'stream' is available
+stream:write("OK\n")
+```
+
+The `Stream` class also exposes `get_data()` and `raw_write(data, len)` (`switch_cpp.h`). A script launched from the dialplan on a call leg has a `session` but no `stream`; a script launched as an API command has a `stream` but no call `session`.
+
+---
+
+## Worked Example: Answer, Play, Collect, Branch {#worked-example}
+
+The following two scripts are functionally identical: each answers the call, plays a prompt, collects a single digit, and branches on the result. They are presented side by side to make the Lua/JavaScript parity — and the few naming differences — concrete.
+
+### Lua {#worked-example-lua}
+
+```lua title="press1.lua — run with: lua press1.lua (from the dialplan)"
+-- 'session' is provided by the lua dialplan application
+session:answer()
+
+-- play a prompt and collect exactly one digit, '#' terminates, 5s timeout
+local digit = session:getDigits(1, "#", 5000)
+
+freeswitch.consoleLog("INFO", "caller pressed: '" .. digit .. "'\n")
+
+if digit == "1" then
+  session:execute("playback", "ivr/ivr-welcome.wav")
+elseif digit == "2" then
+  -- run any API command from the script
+  local api = freeswitch.API()
+  api:execute("uuid_broadcast", session:getVariable("uuid") .. " tone_stream://%(500,0,800)")
+else
+  -- build and fire a custom event for monitoring
+  local ev = freeswitch.Event("CUSTOM", "press1::no_input")
+  ev:addHeader("Caller", session:getVariable("caller_id_number"))
+  ev:fire()
+  session:execute("playback", "ivr/ivr-that_was_an_invalid_entry.wav")
+end
+
+session:hangup()
+```
+
+### JavaScript (mod_v8) {#worked-example-js}
+
+```javascript title="press1.js — run with: javascript press1.js (from the dialplan)"
+// 'session' is provided by the javascript dialplan application
+session.answer();
+
+// play a prompt and collect exactly one digit, '#' terminates, 5s timeout
+var digit = session.getDigits(1, "#", 5000);
+
+consoleLog("INFO", "caller pressed: '" + digit + "'\n");
+
+if (digit == "1") {
+  session.execute("playback", "ivr/ivr-welcome.wav");
+} else if (digit == "2") {
+  // run any API command from the script (global function, not a class)
+  apiExecute("uuid_broadcast",
+    session.getVariable("uuid") + " tone_stream://%(500,0,800)");
+} else {
+  // build and fire a custom event for monitoring
+  var ev = new Event("CUSTOM", "press1::no_input");
+  ev.addHeader("Caller", session.getVariable("caller_id_number"));
+  ev.fire();
+  session.execute("playback", "ivr/ivr-that_was_an_invalid_entry.wav");
+}
+
+session.hangup();
+```
+
+The only substantive differences between the two are the language-level syntax (`:` vs `.` for method calls, `local`/`var`, string concatenation) and **two naming differences flagged above**: API access is the global `apiExecute(...)` in JavaScript versus the `freeswitch.API()` object in Lua, and the constructor for events is `new Event(...)` in JavaScript versus `freeswitch.Event(...)` in Lua. Everything else — `answer`, `getDigits`, `execute`, `getVariable`, `hangup`, the `Event` methods — is spelled the same.
+
+---
+
+## Summary {#summary}
+
+- A script gets a call leg as the global `session` from the `lua`/`javascript` dialplan app, by wrapping a UUID with `freeswitch.Session("<uuid>")` / `new Session("<uuid>")`, or by originating with a dial string.
+- The session object wraps `CoreSession`; the method names are bound near-verbatim in Lua and re-registered in `mod_v8`. `playAndGetDigits`, `read`, and `say` are Lua-only on the shared surface; JavaScript uses `collectInput` where Lua uses `setInputCallback`/`collectDigits`.
+- API commands run from `freeswitch.API():execute(cmd, args)` in Lua and from the global `apiExecute(cmd, arg)` in JavaScript.
+- Events are built with `freeswitch.Event(type, subclass)` (Lua) / `new Event(type, subclass)` (JavaScript), then `addHeader`/`addBody`/`fire()`.
+- Logging is `consoleLog(level, msg)` in both; API-context scripts write results with `stream:write(...)`.
+
+For module configuration, the dialplan applications, the API commands, and the event-hook wiring, see [Chapter 28: Scripting Integration](/integration/scripting).

--- a/docs/recipes/_category_.json
+++ b/docs/recipes/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Part 10: Recipes", "position": 10 }

--- a/docs/recipes/index.mdx
+++ b/docs/recipes/index.mdx
@@ -1,0 +1,16 @@
+---
+title: "Part 10: Recipes"
+slug: /recipes
+description: "End-to-end worked examples that compose the configuration, dialplan, and applications from the reference chapters into complete, working call flows."
+---
+
+import DocCardList from '@theme/DocCardList';
+
+The reference chapters document each piece of FreeSWITCH on its own. This part
+shows how those pieces fit together into complete, working call flows. Each
+recipe states the goal, gives the exact configuration and dialplan to paste in,
+explains how it works, and links back to the chapters that document each part in
+depth. Every example is built from features documented elsewhere in this manual
+and verified against the bundled `conf/vanilla/` configuration.
+
+<DocCardList />

--- a/docs/recipes/recipe-box-to-box.mdx
+++ b/docs/recipes/recipe-box-to-box.mdx
@@ -1,0 +1,282 @@
+---
+sidebar_position: 4
+id: recipe-box-to-box
+slug: /recipes/box-to-box
+title: "Recipe: Connecting Two FreeSWITCH Servers"
+description: "Link two FreeSWITCH servers with a SIP gateway or IP-authenticated trunk so users on box A can dial users on box B."
+sidebar_label: "Box-to-Box Trunk"
+---
+
+# Recipe: Connecting Two FreeSWITCH Servers
+
+## Goal
+
+Link two independent FreeSWITCH servers so that a user registered on **Box A** can
+dial a user registered on **Box B** by dialing a four-digit extension. Calls leave
+Box A through a SIP gateway pointed at Box B, arrive on Box B's `external` profile,
+land in its `public` context, and are routed to the target extension.
+
+```
+                    SIP trunk (port 5080)
+  Box A  192.0.2.10  ───────────────────────►  Box B  192.0.2.20
+  ┌──────────────────┐                         ┌──────────────────┐
+  │ user 1001 (5060) │                         │ user 2001 (5060) │
+  │ external (5080)  │  INVITE 2001            │ external (5080)  │
+  │  gateway "boxB" ─┼────────────────────────►│  public context  │
+  └──────────────────┘                         └──────────────────┘
+```
+
+In this recipe Box A reaches users in the `2xxx` range on Box B. The same pattern
+works in reverse to make the link bidirectional (see [Variations](#variations)).
+The `192.0.2.0/24` and `203.0.113.0/24` blocks are
+[RFC 5737](https://datatracker.ietf.org/doc/html/rfc5737) documentation ranges;
+substitute your own server IP addresses.
+
+## Prerequisites
+
+- A working FreeSWITCH install on each box from the vanilla configuration, with at
+  least one registered user per box (`1001` on Box A, `2001` on Box B).
+- Network reachability between the two servers on the SIP signaling port (`5080`,
+  the `external` profile) and the RTP media port range.
+- Familiarity with these chapters:
+  - [Chapter 8: Gateways and Trunk Registration](../users-endpoints/gateways.mdx)
+  - [Chapter 5: SIP Profiles (Sofia)](../users-endpoints/sip-profiles-sofia.mdx)
+  - [Chapter 13: Inbound Calls and the Public Context](../dialplan/inbound-public-context.mdx)
+  - [Chapter 11: The XML Dialplan](../dialplan/xml-dialplan.mdx)
+
+The two boxes do not share a user directory. Each authenticates its own
+registered users; the trunk between them carries calls only, not registrations.
+
+---
+
+## Build It
+
+There are two ways for Box A to authenticate to Box B over the trunk:
+
+- **Registered gateway** — Box A sends SIP REGISTER to Box B and authenticates with
+  a username and password. Box B must have a user account that Box A can register
+  as. This is the simplest option when the two boxes are on dynamic IP addresses.
+- **IP-authenticated trunk** — neither side registers. Box B trusts Box A by source
+  IP address. This is the cleaner option when both boxes have static IP addresses.
+
+Both variants are shown below. Choose one.
+
+### Box A — outbound gateway to Box B
+
+Gateways for provider-facing trunks live in `conf/sip_profiles/external/`, which the
+`external` profile pulls in with `<X-PRE-PROCESS cmd="include" data="external/*.xml"/>`.
+Create a new file there for the trunk to Box B.
+
+#### Variant 1: registered gateway
+
+`conf/sip_profiles/external/boxB.xml`:
+
+```xml
+<include>
+  <gateway name="boxB">
+    <!-- Credentials for a user account that exists on Box B -->
+    <param name="username" value="trunkA"/>
+    <param name="password" value="s3cr3tpass"/>
+
+    <!-- Box B's external profile address; realm and proxy default to each other -->
+    <param name="realm"    value="192.0.2.20"/>
+    <param name="proxy"    value="192.0.2.20:5080"/>
+
+    <!-- Register with Box B and refresh hourly -->
+    <param name="register"         value="true"/>
+    <param name="expire-seconds"   value="3600"/>
+    <param name="retry-seconds"    value="30"/>
+
+    <!-- Detect a dead trunk: OPTIONS ping every 30s -->
+    <param name="ping"             value="30"/>
+  </gateway>
+</include>
+```
+
+#### Variant 2: IP-authenticated gateway (no registration)
+
+`conf/sip_profiles/external/boxB.xml`:
+
+```xml
+<include>
+  <gateway name="boxB">
+    <!-- proxy is the only required field for a non-registering gateway -->
+    <param name="proxy"    value="192.0.2.20:5080"/>
+    <param name="register" value="false"/>
+
+    <!-- OPTIONS ping confirms the peer is reachable -->
+    <param name="ping"     value="30"/>
+  </gateway>
+</include>
+```
+
+When `register` is `false`, FreeSWITCH does not send REGISTER and marks the gateway
+**UP** immediately at profile load. `username` and `password` may be omitted
+(`username` defaults to `FreeSWITCH`, `password` to an empty string).
+
+Load the gateway without restarting:
+
+```
+sofia profile external rescan
+sofia status gateway boxB
+```
+
+The gateway should report `Status: UP`.
+
+### Box A — dialplan to route 2xxx out the gateway
+
+Add an extension to Box A's `default` context (for example, a new file in
+`conf/dialplan/default/`) that bridges four-digit numbers starting with `2` out the
+`boxB` gateway. The endpoint string is `sofia/gateway/<gateway-name>/<number>`.
+
+```xml
+<include>
+  <extension name="to_boxB">
+    <condition field="destination_number" expression="^(2\d{3})$">
+      <action application="set"    data="effective_caller_id_number=${caller_id_number}"/>
+      <action application="bridge" data="sofia/gateway/boxB/$1"/>
+    </condition>
+  </extension>
+</include>
+```
+
+`$1` captures the full four-digit number (for example `2001`), and the call is sent
+to Box B as an INVITE whose Request-URI user part is `2001`. The `set` action carries
+the original caller's number into the `From` header that Box A presents to Box B; see
+[How It Works](#how-it-works).
+
+### Box B — accept and route the inbound call
+
+The call arrives on Box B's `external` profile (port `5080`), which is configured with
+`context="public"` and `auth-calls="false"`. The call therefore enters the `public`
+context. Add an extension there to route the `2xxx` range to local users.
+
+Create `conf/dialplan/public/01_from_boxA.xml` on Box B:
+
+```xml
+<include>
+  <extension name="from_boxA">
+    <condition field="destination_number" expression="^(2\d{3})$">
+      <action application="set"      data="domain_name=$${domain}"/>
+      <action application="transfer" data="$1 XML default"/>
+    </condition>
+  </extension>
+</include>
+```
+
+This matches the four-digit number, sets `domain_name` so the user resolves against
+the correct domain, and transfers the call into Box B's `default` context, where the
+vanilla `Local_Extension` dialplan rings the registered user.
+
+> **Note on the `public` context.** The `public` context is the security boundary
+> for unauthenticated inbound traffic. Only add extensions here that are safe to run
+> for any caller that can reach port `5080`. Match a **specific** range (`2\d{3}`),
+> never a catch-all, and never transfer arbitrary destinations into `default`. See
+> [Chapter 13](../dialplan/inbound-public-context.mdx).
+
+#### Restricting Box B's trunk by source IP (IP-auth variant)
+
+With the IP-authenticated variant, lock the `external` profile down so that only Box A
+may send unauthenticated calls into `public`. First define an ACL list naming Box A's
+IP address in `conf/autoload_configs/acl.conf.xml`:
+
+```xml
+<configuration name="acl.conf" description="Network Lists">
+  <network-lists>
+    <list name="trusted-peers" default="deny">
+      <node type="allow" cidr="192.0.2.10/32"/>
+    </list>
+  </network-lists>
+</configuration>
+```
+
+Then reference that list from Box B's `external` profile with `apply-inbound-acl`:
+
+```xml
+<param name="apply-inbound-acl" value="trusted-peers"/>
+```
+
+With this in place, an inbound SIP request whose source IP is not permitted by
+`trusted-peers` is rejected with a `403`. Reload both files for the change to take
+effect:
+
+```
+reloadacl
+sofia profile external restart
+```
+
+The registered-gateway variant does not need this ACL: Box A authenticates with a
+username and password against a user account on Box B, so the trunk is identified by
+its registration rather than by source IP.
+
+---
+
+## How It Works
+
+**Registered gateway.** Box A's `external` profile sends a SIP REGISTER to Box B
+using the `username`/`password` you configured. Box B authenticates that registration
+against a user account in its directory. When Box A dials `2001`, the dialplan bridges
+to `sofia/gateway/boxB/2001`; FreeSWITCH consults the `boxB` gateway, builds an INVITE
+to Box B's `proxy` (`192.0.2.20:5080`) with `2001` in the Request-URI, and sends it
+over the registered trunk.
+
+**IP-authenticated trunk.** Neither side registers. Box A's gateway is marked UP at
+load time and sends the same `sofia/gateway/boxB/2001` INVITE directly to Box B's
+proxy. Box B trusts the call because the source IP matches the `trusted-peers` ACL
+applied with `apply-inbound-acl` (and because `auth-calls` is `false` on the `external`
+profile, no digest challenge is issued).
+
+**Entering Box B's `public` context.** Either way, the INVITE lands on Box B's
+`external` profile on port `5080`, which sets `context="public"`. The vanilla `public`
+context runs its built-in extensions (`outside_call`, etc.), then your `from_boxA`
+extension matches `2\d{3}` and `transfer`s the call into `default`, where the user's
+extension rings. The `public` context is the trust boundary between the two servers —
+calls from Box A reach only what `public` explicitly routes.
+
+**Caller-ID handling.** Box A presents a caller ID to Box B in the SIP `From` header.
+By default the gateway uses its own `username` (or `from-user`) as the `From` user. To
+pass the *original* caller's number across the trunk, either set
+`effective_caller_id_number` before the bridge (as the Box A dialplan above does) or
+set the gateway parameter `caller-id-in-from` to `true`, which uses the inbound caller
+ID as the `From` user on calls bridged out through that gateway. On Box B, the standard
+inbound caller-ID variables (`${caller_id_number}`, `${sip_from_user}`) are populated
+from that `From` header; see the
+[caller-ID table in Chapter 13](../dialplan/inbound-public-context.mdx#caller-id-on-inbound-calls).
+
+For the full gateway parameter reference see
+[Chapter 8](../users-endpoints/gateways.mdx); for ACL lists and the
+`apply-inbound-acl` semantics see the
+[Access Control Lists chapter](../integration/access-control-lists.mdx).
+
+---
+
+## Variations
+
+### Bidirectional linking
+
+To let Box B dial Box A's `1xxx` users, repeat the recipe with the roles reversed:
+define a `boxA` gateway in Box B's `external/` directory (pointed at `192.0.2.10:5080`),
+add a `to_boxA` dialplan extension on Box B that bridges `^(1\d{3})$` to
+`sofia/gateway/boxA/$1`, and add a `from_boxB` extension to Box A's `public` context
+(plus a `trusted-peers` ACL listing `192.0.2.20/32` if you use the IP-auth variant).
+Each box then has one gateway *to* the other and one `public` extension *from* the
+other.
+
+### Shared dialplan prefix
+
+When extension ranges might overlap between boxes, route by a dialed prefix instead of
+by range. For example, dial `8` + extension to reach Box B, stripping the prefix before
+it leaves Box A:
+
+```xml
+<extension name="to_boxB_prefix">
+  <condition field="destination_number" expression="^8(\d{4})$">
+    <action application="bridge" data="sofia/gateway/boxB/$1"/>
+  </condition>
+</extension>
+```
+
+Here `$1` is the captured four-digit number without the `8`, so Box A dials `82001` and
+Box B receives `2001`. This keeps each box's local numbering plan independent and makes
+the inter-box link explicit in the dialed string. To preserve the prefix on the wire
+instead, capture it inside the group (`^(8\d{4})$`) and match the full string on Box B.

--- a/docs/recipes/recipe-click-to-call.mdx
+++ b/docs/recipes/recipe-click-to-call.mdx
@@ -1,0 +1,203 @@
+---
+sidebar_position: 6
+id: recipe-click-to-call
+slug: /recipes/click-to-call
+title: "Recipe: Click-to-Call with originate"
+description: "Trigger an outbound call from fs_cli or the Event Socket that rings a user and, on answer, bridges them to another extension, an IVR, or a PSTN number using the originate API command."
+sidebar_label: "Click-to-Call (originate)"
+---
+
+# Recipe: Click-to-Call with originate
+
+## Goal
+
+Place a call to one party from outside any existing call -- from the `fs_cli`
+console, a script, or the Event Socket -- and, the moment that party answers,
+connect them to a second destination. This is the building block behind
+"click-to-call" buttons, callback services, and operator-initiated dialing.
+
+The `originate` API command drives the whole flow:
+
+1. FreeSWITCH originates an outbound leg to **party A** (the person you want to
+   ring first -- typically the agent or the user who clicked the button).
+2. When party A answers, FreeSWITCH runs whatever you told it to run on that
+   answered leg: an inline application such as `bridge` (to reach **party B**),
+   or a transfer into the dialplan that decides what happens next.
+
+Because the answered A-leg becomes a normal session, "party B" can be another
+extension, an IVR, a conference, or a PSTN number through a gateway.
+
+## Prerequisites
+
+This recipe composes features documented in the reference chapters. Read those
+first if a piece is unfamiliar:
+
+- [CLI &amp; API / `originate`](/reference/cli-and-api) -- the command syntax,
+  positional arguments, and how it shares the command set between `fs_cli` and
+  the Event Socket.
+- [dptools / `bridge`](/dialplan/dptools) -- the application that joins two
+  legs, plus the dial-string grammar (endpoint prefixes, multi-leg separators,
+  and channel-variable syntax) shared by `originate`.
+- [The XML dialplan](/dialplan/xml) -- needed for the form that routes party A
+  into a dialplan extension instead of an inline application.
+- [User directory](/users-and-endpoints/user-directory) -- defines the
+  `user/<ext>` users and their `dial-string`, which `originate` resolves when
+  you dial a `user/...` URL.
+
+The examples below assume the bundled `conf/vanilla/` configuration, where users
+`1000`-`1019` are defined in the directory and conference extensions `30XX` are
+present in the `default` context.
+
+## Build it
+
+All commands run at the `fs_cli` prompt (or over the Event Socket as the `api`
+method). The general form, from the command's own usage string, is:
+
+```
+originate <call url> <exten>|&<application_name>(<app_args>) [<dialplan>] [<context>] [<cid_name>] [<cid_num>] [<timeout_sec>]
+```
+
+The first argument is the dial string for **party A**. The second argument is
+**one of**:
+
+- `&<application>(<args>)` -- run this application inline on the A-leg after it
+  answers, **or**
+- `<exten>` -- transfer the answered A-leg to dialplan extension `<exten>`
+  (using the optional `<dialplan>` and `<context>`, which default to `XML` and
+  `default`).
+
+### Bridge two parties directly
+
+Ring user `1001`; when they answer, bridge them to user `1002`. The `&bridge(...)`
+inline form runs the `bridge` application on the answered A-leg, with party B's
+dial string as its argument.
+
+```console
+freeswitch@fs> originate user/1001 &bridge(user/1002)
++OK 4a3e6c1e-...-uuid
+```
+
+A successful `originate` prints `+OK` followed by the UUID of the A-leg. A
+failure prints `-ERR` followed by the hangup cause, for example `-ERR
+NO_ANSWER` or `-ERR USER_BUSY`.
+
+To reach a PSTN number for party B, point the inline `bridge` at a gateway dial
+string instead:
+
+```console
+freeswitch@fs> originate user/1001 &bridge(sofia/gateway/mycarrier/15551234567)
+```
+
+### Send party A into the dialplan
+
+Instead of an inline application, transfer the answered A-leg to a dialplan
+extension. Here party A (user `1001`) is sent to extension `9999` in dialplan
+`XML`, context `default`, where your routing decides what happens next (an IVR,
+a hunt group, voicemail, and so on):
+
+```console
+freeswitch@fs> originate user/1001 9999 XML default
+```
+
+`XML` and `default` are the defaults, so `originate user/1001 9999` is
+equivalent. Use this form when the post-answer behavior is more than a single
+application -- the dialplan can run conditions, set variables, and chain
+applications.
+
+### Add origination variables
+
+Prefix the party-A dial string with `{key=value,...}` to set channel variables
+on the originating leg. These are parsed before the leg is created. Common ones:
+
+```console
+freeswitch@fs> originate {origination_caller_id_name='Front Desk',origination_caller_id_number=5550100,ignore_early_media=true}user/1001 &bridge(user/1002)
+```
+
+- `origination_caller_id_name` / `origination_caller_id_number` -- set the
+  caller ID presented to party A.
+- `ignore_early_media=true` -- treat the call as answered only on a real answer,
+  ignoring early media (ringback, "the number you dialed..." announcements) so
+  the bridge does not connect prematurely.
+- `originate_timeout=20` -- give up on party A after 20 seconds. (This is the
+  per-`originate` timeout; you can also pass a timeout as the final positional
+  argument.)
+
+Variables in `{...}` apply to every leg in the dial string. To vary a value per
+leg, use the per-leg `[...]` form documented with the
+[dial-string grammar](/dialplan/dptools).
+
+### Run it non-blocking with bgapi
+
+`originate` **blocks** until party A answers, fails, or times out -- up to the
+timeout (60 seconds by default). At the `fs_cli` prompt or over the Event Socket
+that ties up the connection for the duration. Use `bgapi` to launch it in a
+background thread and return immediately:
+
+```console
+freeswitch@fs> bgapi originate user/1001 &bridge(user/1002)
++OK Job-UUID: 7c9f2a40-...-uuid
+```
+
+`bgapi` returns a Job-UUID right away; the eventual `+OK`/`-ERR` result is
+delivered later as a `BACKGROUND_JOB` event. This is the form a click-to-call
+web backend should use so the HTTP request is not held open while the phone
+rings.
+
+## How it works
+
+**Two legs.** `originate` first calls the core originate engine to create the
+A-leg toward your `<call url>`. That call returns only once the leg reaches a
+final state. If the A-leg answers, FreeSWITCH then acts on the second argument:
+
+- If it begins with `&`, the text inside is parsed as `application` and
+  `(args)`, and that application is queued to execute on the answered A-leg. So
+  `&bridge(user/1002)` makes the answered party A run `bridge user/1002`, which
+  originates the **B-leg** and joins the two.
+- Otherwise the argument is treated as an extension and the A-leg is transferred
+  into the dialplan at that extension, in the given dialplan and context.
+
+**Origination channel variables.** The `{key=value,...}` block at the front of
+the dial string seeds channel variables on the A-leg before it is created.
+`origination_caller_id_name` and `origination_caller_id_number` override the
+presented caller ID; `ignore_early_media` controls whether ringback or media
+before answer counts as a connect; `originate_timeout` caps how long to wait for
+A to answer.
+
+**Early media.** Without `ignore_early_media=true`, audio that arrives before a
+real answer (ringback, gateway announcements) can be treated as the call being
+up, which may bridge party B too soon. Setting `ignore_early_media=true` defers
+the bridge until party A truly answers -- usually what you want for
+click-to-call.
+
+**Inline `&application` vs the dialplan.** The `&app(args)` form is compact and
+self-contained: everything the call needs is on the command line, ideal for a
+one-shot bridge. Routing into the dialplan (`<exten> [<dialplan>] [<context>]`)
+trades that brevity for the full power of XML routing -- conditions, variable
+manipulation, and multi-step flows -- when the answered leg needs more than a
+single application.
+
+For the full command reference, positional arguments, and the shared
+`fs_cli`/Event Socket command set, see the
+[CLI &amp; API chapter](/reference/cli-and-api).
+
+## Variations
+
+**Originate into a conference.** Use the inline `&conference(...)` application to
+drop party A into a conference room on answer. With the bundled config, room
+names follow the `<name>@<profile>` pattern (the `30XX` extensions map to the
+`default` profile):
+
+```console
+freeswitch@fs> originate user/1001 &conference(3001@default)
+```
+
+Originate several parties into the same room (each as its own `originate`) to
+build an operator-assembled conference.
+
+**Trigger it from the Event Socket.** Everything here works verbatim over the
+Event Socket: send the same string with the ESL `api` method (blocking) or
+`bgapi` method (non-blocking, result via `BACKGROUND_JOB`). A web click-to-call
+button typically posts to a backend that opens an ESL connection and issues
+`bgapi originate ...`. See the
+[Event Socket chapter](/integration/event-socket) for connecting, the inbound
+vs outbound modes, and consuming the job-result event.

--- a/docs/recipes/recipe-conference-pin.mdx
+++ b/docs/recipes/recipe-conference-pin.mdx
@@ -1,0 +1,271 @@
+---
+sidebar_position: 5
+id: recipe-conference-pin
+slug: /recipes/conference-pin
+title: "Recipe: A Conference Bridge with a PIN"
+description: "Callers dial an extension, are prompted for a PIN, and join a moderated conference room. Built on the conference application's own PIN and member-flag handling, with a dialplan play_and_get_digits variation."
+sidebar_label: "Conference with PIN"
+---
+
+# Recipe: A Conference Bridge with a PIN
+
+## Goal
+
+A team wants a single conference number that is protected by a PIN. Callers
+dial an extension, are prompted to enter a PIN, and -- if it matches -- join a
+shared room. One PIN admits ordinary participants; a second PIN admits
+**moderators**, who get the moderator key map and `non_moderator` control over
+everyone else.
+
+`mod_conference` already knows how to collect and validate a PIN, so the
+simplest build needs no digit-collection logic in the dialplan at all: the
+profile carries a `pin` and a `moderator-pin`, and the `conference` application
+prompts the caller and checks what they enter. This recipe shows that
+profile-driven approach first, then a variation that collects the PIN in the
+dialplan with `play_and_get_digits` when you want full control over the prompt.
+
+**Call flow:**
+
+1. An internal caller dials the conference extension (`3500`).
+2. A dialplan extension answers the call and runs the `conference` application
+   with a room name and profile.
+3. The room is created on the first caller's entry from the named profile; later
+   callers join the existing room.
+4. Because the profile defines a `pin` (and a `moderator-pin`), `conference`
+   plays the `pin-sound` prompt and collects digits.
+5. If the digits match the moderator PIN, the caller joins with the `moderator`
+   flag; if they match the entry PIN, they join as an ordinary member; otherwise
+   they are re-prompted up to `pin-retries` times and then rejected.
+
+## Prerequisites
+
+- [Conferencing](../applications/conferencing.mdx) with `mod_conference` -- the
+  conference model, profiles, the `conference` application argument syntax, and
+  member flags.
+- [IVR Menus](../applications/ivr-menus.mdx) -- background on prompt-driven
+  digit collection (used by the dialplan-PIN variation below).
+- The [Dialplan Application Reference](../dialplan/dptools-reference.mdx) -- the
+  `answer`, `play_and_get_digits`, and `conference` applications.
+- A working [XML dialplan](../dialplan/xml-dialplan.mdx) -- this recipe adds an
+  extension to the `default` context that ships in `conf/vanilla/`.
+
+## Build it
+
+There are two pieces: a **profile** in `conference.conf.xml` that defines the
+PINs, and a **dialplan extension** that answers the call and enters the room.
+
+### 1. A conference profile with PINs
+
+The vanilla `conference.conf.xml` ships a `default` profile but leaves its `pin`
+and `moderator-pin` commented out. Rather than edit `default` (which the bundled
+`30xx` extensions reuse), add a dedicated profile. Place it inside the
+`<profiles>` block of `conf/autoload_configs/conference.conf.xml`:
+
+```xml
+<profile name="secure">
+  <param name="domain" value="$${domain}"/>
+  <param name="rate" value="8000"/>
+  <param name="interval" value="20"/>
+  <param name="energy-level" value="100"/>
+
+  <!-- Entry PIN for ordinary participants. -->
+  <param name="pin" value="12345"/>
+  <!-- A different PIN that grants moderator status on entry. -->
+  <param name="moderator-pin" value="54321"/>
+  <!-- Attempts allowed before the caller is rejected. -->
+  <param name="pin-retries" value="3"/>
+
+  <!-- Prompt and error files used while collecting the PIN. -->
+  <param name="pin-sound" value="conference/conf-pin.wav"/>
+  <param name="bad-pin-sound" value="conference/conf-bad-pin.wav"/>
+
+  <!-- Announce the member count once the room reaches one member. -->
+  <param name="announce-count" value="1"/>
+
+  <!-- Sounds and behaviors carried over from the default profile. -->
+  <param name="muted-sound" value="conference/conf-muted.wav"/>
+  <param name="unmuted-sound" value="conference/conf-unmuted.wav"/>
+  <param name="alone-sound" value="conference/conf-alone.wav"/>
+  <param name="moh-sound" value="$${hold_music}"/>
+  <param name="enter-sound" value="tone_stream://%(200,0,500,600,700)"/>
+  <param name="exit-sound" value="tone_stream://%(500,0,300,200,100,50,25)"/>
+  <param name="caller-id-name" value="$${outbound_caller_name}"/>
+  <param name="caller-id-number" value="$${outbound_caller_id}"/>
+  <param name="comfort-noise" value="true"/>
+</profile>
+```
+
+Run `reloadxml` from the FreeSWITCH console (or `fs_cli`) after saving so the new
+profile is picked up.
+
+### 2. A dialplan extension that enters the room
+
+Add this extension to `conf/dialplan/default.xml`, **above** the catch-all
+`Local_Extension`, so `3500` matches first. It answers the call and runs the
+`conference` application with the room name and the `secure` profile. No PIN
+logic is needed here -- the profile's `pin`/`moderator-pin` make `conference`
+prompt and validate on its own:
+
+```xml
+<extension name="secure_conference">
+  <condition field="destination_number" expression="^3500$">
+    <action application="answer"/>
+    <action application="conference" data="secure-${domain_name}@secure"/>
+  </condition>
+</extension>
+```
+
+Run `reloadxml` again. Dial `3500` from two registered phones: each is asked for
+a PIN. Enter `12345` to join as a participant or `54321` to join as a moderator.
+
+### Moderator vs. participant
+
+The two PINs produce two roles **on the same room**:
+
+- Entering `12345` (the `pin`) joins as an ordinary member.
+- Entering `54321` (the `moderator-pin`) sets the caller's `moderator` member
+  flag automatically. Moderators are matched by the `non_moderator` target in
+  the [conference API](../applications/conferencing.mdx#the-conference-api), so a
+  moderator can, for example, mute everyone else with
+  `conference secure-${domain_name} mute non_moderator`.
+
+You can also assign member flags explicitly at join time with the
+`+flags{...}` suffix on the `conference` argument. To force a caller into the
+room muted, append `+flags{mute}`; to grant moderator status without a PIN,
+append `+flags{moderator}` (`mute` and `moderator` are the verified flag names
+parsed from the dial string). The argument grammar is:
+
+```text
+conference <room>[@<profile>][+<pin>][+flags{<flag>|<flag>...}]
+```
+
+For example, a separate "listener" extension that joins the same room muted:
+
+```xml
+<extension name="secure_conference_listener">
+  <condition field="destination_number" expression="^3501$">
+    <action application="answer"/>
+    <action application="conference" data="secure-${domain_name}@secure+flags{mute}"/>
+  </condition>
+</extension>
+```
+
+## How it works
+
+**Room creation and profile lookup.** A conference room is identified by its
+name string. When `conference` runs with `room@profile`, FreeSWITCH looks up
+`profile` in `conference.conf.xml`; if the room does not already exist it is
+created from that profile, and later callers who dial the same name join the
+existing instance. Here the room name is `secure-${domain_name}`, which
+namespaces the room per domain, and the profile is `secure`. See the
+[conference model](../applications/conferencing.mdx#conference-model).
+
+**PIN handling.** When the resolved profile (or the dial-string `+<pin>` suffix)
+supplies an entry or moderator PIN, `conference` answers the channel, plays the
+`pin-sound`, and collects digits. The entered value is compared against the
+entry `pin` first, then the `moderator-pin`. A mismatch plays `bad-pin-sound`
+and re-prompts; after `pin-retries` failures the caller is rejected and the call
+is logged as a PIN-rejected CDR. A caller can also supply the PIN ahead of the
+prompt via the `supplied_pin` channel variable (or an `X-ConfPin=` SIP URL
+parameter), which skips the audio prompt when it already matches.
+
+**Moderator flag from the moderator PIN.** When the entered digits match the
+`moderator-pin` rather than the entry `pin`, `mod_conference` records the match
+and sets the member's `moderator` flag (`MFLAG_MOD`) as it joins. That is the
+only difference between the two PINs at the protocol level: same room, same
+profile, one bit of member state. Moderator members receive the
+`moderator-controls` key map (if the profile defines one) and are excluded from
+the `non_moderator` API target.
+
+**Member flags at join time.** Flags can come from three places, all merged: the
+profile's `member-flags` parameter, the `conference_member_flags` channel
+variable, and the `+flags{...}` suffix on the `conference` argument. The
+`mute`, `deaf`, and `moderator` names used above are taken verbatim from the
+dial-string flag parser. See
+[member flags at join time](../applications/conferencing.mdx#member-flags-at-join-time)
+and the full [conference application syntax](../applications/conferencing.mdx#the-conference-dialplan-application).
+
+For the complete profile parameter table -- including `pin`, `moderator-pin`,
+`pin-retries`, `announce-count`, and the sound files -- see
+[profile parameters](../applications/conferencing.mdx#profile-parameters).
+
+## Variations
+
+### Collect the PIN in the dialplan instead
+
+If you want to design the prompt yourself -- a custom greeting, a regex on the
+digits, or a transfer on failure -- collect the PIN before entering the room
+with `play_and_get_digits`, then pass it through as the dial-string `+<pin>`.
+Leave the profile's `pin`/`moderator-pin` defined so `conference` still
+validates the value you forward:
+
+```xml
+<extension name="secure_conference_dp_pin">
+  <condition field="destination_number" expression="^3502$">
+    <action application="answer"/>
+    <action application="sleep" data="500"/>
+    <!-- min max tries timeout(ms) terminators prompt invalid_file var regexp -->
+    <action application="play_and_get_digits"
+      data="4 6 3 7000 # conference/conf-pin.wav conference/conf-bad-pin.wav conf_pin \d+"/>
+    <action application="conference" data="secure-${domain_name}@secure+${conf_pin}"/>
+  </condition>
+</extension>
+```
+
+The `play_and_get_digits` arguments are positional, in this exact order:
+`<min> <max> <tries> <timeout_ms> <terminators> <file> <invalid_file> <var_name> <regexp>`.
+Above it collects 4 to 6 digits, allows 3 tries, waits 7 seconds, accepts `#` as
+a terminator, plays `conf-pin.wav`, replays `conf-bad-pin.wav` on a bad regex
+match, stores the result in `conf_pin`, and validates against `\d+`. The
+collected `${conf_pin}` is appended as the `+<pin>` suffix, so `conference`
+checks it against both the entry and moderator PINs -- preserving the
+moderator-by-PIN behavior. The full argument list (including the optional
+`digit_timeout` and `failure_ext`) is documented in the
+[Dialplan Application Reference](../dialplan/dptools-reference.mdx).
+
+### Separate moderator and listener entry points
+
+Instead of one extension that branches on the PIN, expose distinct numbers and
+set the role with the `+flags{...}` suffix -- no PIN prompt at all on these
+internal-only extensions. A moderator extension and a muted-listener extension
+that share the same room:
+
+```xml
+<extension name="conf_moderator_entry">
+  <condition field="destination_number" expression="^3510$">
+    <action application="answer"/>
+    <action application="conference" data="secure-${domain_name}@secure+flags{moderator}"/>
+  </condition>
+</extension>
+
+<extension name="conf_listener_entry">
+  <condition field="destination_number" expression="^3511$">
+    <action application="answer"/>
+    <action application="conference" data="secure-${domain_name}@secure+flags{mute|deaf}"/>
+  </condition>
+</extension>
+```
+
+Dialing `3510` joins as a moderator; `3511` joins muted and deaf (a pure
+listener, hearing nothing and contributing no audio -- useful for a monitor
+feed). Because these grant roles by extension rather than by PIN, restrict
+access to them in your dialplan or directory rather than publishing them
+externally.
+
+### Play custom entry and exit sounds
+
+The `enter-sound` and `exit-sound` profile parameters play to the room when a
+member joins or leaves. The vanilla profiles use short `tone_stream://` chirps;
+point them at recorded files (relative to the conference `sound-prefix`) for a
+spoken announcement instead:
+
+```xml
+<param name="enter-sound" value="conference/conf-has-joined.wav"/>
+<param name="exit-sound" value="conference/conf-has-left.wav"/>
+```
+
+To announce the running member count as people arrive, set
+`announce-count` to the threshold at which counting begins (`1` announces from
+the first member). See the
+[profile parameters](../applications/conferencing.mdx#profile-parameters) for
+the related sound and announcement options.

--- a/docs/recipes/recipe-did-ivr-voicemail.mdx
+++ b/docs/recipes/recipe-did-ivr-voicemail.mdx
@@ -1,0 +1,231 @@
+---
+sidebar_position: 1
+id: recipe-did-ivr-voicemail
+slug: /recipes/did-ivr-voicemail
+title: "Recipe: Inbound DID to IVR to Voicemail"
+description: "Route a PSTN DID through the public context into an auto-attendant IVR menu, then fall through unanswered options to a user's voicemail."
+sidebar_label: "DID to IVR to Voicemail"
+---
+
+# Recipe: Inbound DID to IVR to Voicemail
+
+## Goal
+
+Answer a PSTN number with an auto-attendant menu and route each option to the
+right place, sending unanswered calls to voicemail. A call arrives on the
+`external` SIP profile, is matched in the `public` context by its DID, and is
+transferred into an IVR menu. The menu offers "press 1 for sales, 2 for
+support," and so on. Each selection bridges to an internal extension; if that
+extension does not answer, the call lands in that user's voicemail box.
+
+The call flow is:
+
+```
+PSTN ──▶ external profile ──▶ public context ──▶ ivr (auto_attendant)
+                                                       │
+                          ┌────────────────────────────┼────────────────────────┐
+                          ▼                             ▼                         ▼
+                    1: Sales ext 1000           2: Support ext 1001        9: repeat menu
+                          │                             │
+                    no answer ──▶ voicemail       no answer ──▶ voicemail
+```
+
+## Prerequisites
+
+This recipe composes pieces documented in the reference chapters. Read those
+first if any step is unfamiliar:
+
+- [Chapter 13: Inbound Calls and the Public Context](../dialplan/inbound-public-context.mdx) — how unauthenticated PSTN calls reach the `public` context through the `external` profile.
+- [Chapter 12: The XML Dialplan](../dialplan/xml-dialplan.mdx) — how extensions, conditions, and actions are evaluated.
+- [Chapter 14: Dialplan Application Reference](../dialplan/dptools-reference.mdx) — the `transfer`, `bridge`, `set`, `export`, `answer`, and `sleep` applications used below.
+- [Chapter 21: IVR Menus](../applications/ivr-menus.mdx) — the `<menu>` schema, entry actions, and the `ivr` dialplan application.
+- [Chapter 19: Voicemail](../applications/voicemail.mdx) — the `voicemail` application and the per-user mailboxes it writes to.
+
+It also assumes the vanilla user directory: users `1000` and `1001` exist under
+`directory/default/` with a `vm-password`, exactly as shipped. The DID
+`+15551234567` is a placeholder; substitute the number your carrier delivers in
+the SIP Request-URI.
+
+## Build it
+
+### 1. Match the DID in the `public` context
+
+Add an extension to `conf/dialplan/public.xml` (or drop a file into
+`conf/dialplan/public/`, which the shipped `public.xml` already includes). It
+matches the inbound DID and transfers the call into the IVR menu by name, in the
+`default` context:
+
+```xml
+<extension name="did_auto_attendant">
+  <condition field="destination_number" expression="^(\+?1?5551234567)$">
+    <action application="set" data="domain_name=$${domain}"/>
+    <action application="answer"/>
+    <action application="sleep" data="500"/>
+    <action application="ivr" data="auto_attendant"/>
+  </condition>
+</extension>
+```
+
+Place this extension before the catch-all blocks near the bottom of
+`public.xml`. The leading `\+?1?` makes the match tolerant of carriers that
+deliver the number with or without a leading `+1`. `set domain_name` pins the
+domain so the later `voicemail` lookups resolve against your directory; `answer`
+brings the call up before prompts play.
+
+### 2. Define the IVR menu
+
+Create `conf/ivr_menus/auto_attendant.xml`. The shipped `ivr.conf.xml` already
+includes every file in that directory with
+`<X-PRE-PROCESS cmd="include" data="../ivr_menus/*.xml"/>`, so no other change is
+needed. This menu uses the `say:` prefix for prompts so it works without
+recording any audio; swap in `phrase:` or a `.wav` path once you have real
+greetings.
+
+```xml
+<include>
+  <menu name="auto_attendant"
+      greet-long="say:Thank you for calling. Press 1 for sales, 2 for support, or 0 for the operator."
+      greet-short="say:Press 1 for sales, 2 for support, or 0 for the operator."
+      invalid-sound="ivr/ivr-that_was_an_invalid_entry.wav"
+      exit-sound="voicemail/vm-goodbye.wav"
+      tts-engine="flite"
+      tts-voice="rms"
+      timeout="10000"
+      inter-digit-timeout="2000"
+      max-failures="3"
+      max-timeouts="3"
+      digit-len="1"
+      exec-on-max-failures="transfer 1001 XML default"
+      exec-on-max-timeouts="transfer 1001 XML default">
+
+    <entry action="menu-exec-app" digits="1" param="transfer 1000 XML default"/>
+    <entry action="menu-exec-app" digits="2" param="transfer 1001 XML default"/>
+    <entry action="menu-exec-app" digits="0" param="transfer 1001 XML default"/>
+    <entry action="menu-top"      digits="9"/>
+  </menu>
+</include>
+```
+
+The `say:` prompts need a TTS engine; the vanilla install ships `mod_flite`,
+which the `tts-engine`/`tts-voice` attributes select. A caller who presses
+nothing or only invalid keys falls out through `exec-on-max-timeouts` /
+`exec-on-max-failures`, which here forwards to support; point those at any
+extension you prefer.
+
+### 3. Route the menu options to extensions and voicemail
+
+The menu transfers digit 1 to `1000` and digits 2 and 0 to `1001`, both in the
+`default` context. The vanilla `default.xml` already ships a `Local_Extension`
+block matching `^(10[01][0-9])$` that bridges to the user and falls through to
+voicemail on no answer, so `1000` and `1001` work out of the box. If you want a
+self-contained, minimal version instead of relying on the shipped block, this is
+the essential pattern:
+
+```xml
+<extension name="ring_then_voicemail">
+  <condition field="destination_number" expression="^(10[01][0-9])$">
+    <action application="export" data="dialed_extension=$1"/>
+    <action application="set" data="call_timeout=30"/>
+    <action application="set" data="hangup_after_bridge=true"/>
+    <action application="set" data="continue_on_fail=true"/>
+    <action application="bridge" data="user/${dialed_extension}@${domain_name}"/>
+    <action application="answer"/>
+    <action application="sleep" data="1000"/>
+    <action application="voicemail" data="default ${domain_name} ${dialed_extension}"/>
+  </condition>
+</extension>
+```
+
+`continue_on_fail=true` lets the dialplan keep running when the `bridge` fails
+(no answer, busy, or timeout) instead of hanging up, so execution reaches the
+`voicemail` application. `voicemail default ${domain_name} ${dialed_extension}`
+runs the application in leave-message mode for that mailbox in the `default`
+voicemail profile.
+
+### 4. Apply the changes
+
+From `fs_cli`, reload the dialplan and IVR configuration:
+
+```
+reloadxml
+```
+
+`reloadxml` re-reads the dialplan and the IVR menus into the XML registry; no
+restart is required.
+
+## How it works
+
+1. **The DID enters the `public` context.** The carrier sends the call to the
+   `external` profile on port 5080, which is bound to the `public` context. As
+   covered in [Chapter 13](../dialplan/inbound-public-context.mdx), this context
+   is the security boundary for untrusted traffic — it must never route to
+   provider gateways. Our `did_auto_attendant` extension matches the DID in the
+   `destination_number` field and answers the call.
+
+2. **The dialplan invokes the IVR.** The `ivr` application
+   ([Chapter 14](../dialplan/dptools-reference.mdx)) looks up the menu named
+   `auto_attendant` in the loaded IVR configuration and runs it. The XML
+   dialplan engine that performed the DID match is described in
+   [Chapter 12](../dialplan/xml-dialplan.mdx).
+
+3. **The menu collects a digit.** The IVR engine
+   ([Chapter 21](../applications/ivr-menus.mdx)) plays `greet-long`, then waits
+   up to `timeout` milliseconds for a key. Because `digit-len="1"`, it matches
+   as soon as one digit arrives. A matching `<entry>` of action
+   `menu-exec-app` runs its `param` as a dialplan application and the caller
+   leaves the menu; `menu-top` replays the menu.
+
+4. **The option transfers to an extension.** Each `menu-exec-app` runs
+   `transfer <ext> XML default`, sending the caller back into the dialplan, this
+   time in the `default` context, at the chosen extension.
+
+5. **No answer falls through to voicemail.** The extension bridges to
+   `user/<ext>@domain`. With `continue_on_fail=true`, a failed bridge does not
+   end the call; execution continues to the `voicemail` application
+   ([Chapter 19](../applications/voicemail.mdx)), which records a message into
+   that user's mailbox in the `default` profile.
+
+6. **No interaction also routes somewhere.** If the caller never presses a valid
+   key, the menu's `exec-on-max-failures` and `exec-on-max-timeouts` hooks fire
+   and forward the call rather than dropping it.
+
+## Variations
+
+**Direct-to-voicemail option.** To let callers leave a message for a department
+without ringing a phone, add an entry that calls `voicemail` directly. Define a
+small `default`-context extension and point a digit at it:
+
+```xml
+<!-- in conf/ivr_menus/auto_attendant.xml -->
+<entry action="menu-exec-app" digits="3" param="transfer vm_sales XML default"/>
+```
+
+```xml
+<!-- in the default context -->
+<extension name="vm_sales">
+  <condition field="destination_number" expression="^vm_sales$">
+    <action application="answer"/>
+    <action application="sleep" data="500"/>
+    <action application="voicemail" data="default ${domain_name} 1000"/>
+  </condition>
+</extension>
+```
+
+**Dial-by-extension.** The `digits` attribute accepts a PCRE regex in `/`
+delimiters, with capture groups exposed as `$1` in the `param`. Let callers dial
+any four-digit extension directly:
+
+```xml
+<entry action="menu-exec-app" digits="/^(10[01][0-9])$/" param="transfer $1 XML default"/>
+```
+
+Keep single-digit menu options and this regex in the same menu only if they do
+not overlap; raise `digit-len` to the longest pattern so the engine waits for
+the full extension.
+
+**Business-hours gate.** Wrap the IVR transfer in a time condition so after-hours
+calls go straight to a closed-greeting or voicemail. The `public` extension can
+test `hour`, `wday`, or `minute-of-day` on the condition before running
+`ivr` — the same time fields shown in the shipped `default.xml`
+`tod_example`. Route the off-hours branch to a `voicemail` extension or a
+dedicated closed-greeting menu instead of `auto_attendant`.

--- a/docs/recipes/recipe-ring-group.mdx
+++ b/docs/recipes/recipe-ring-group.mdx
@@ -1,0 +1,253 @@
+---
+sidebar_position: 2
+id: recipe-ring-group
+slug: /recipes/ring-group
+title: "Recipe: Ring Group and Hunt Group"
+description: "Ring several phones at once (ring group) or one after another on no-answer (hunt group) using the bridge application's comma and pipe dial-string operators, with per-leg timeouts and voicemail fallback."
+sidebar_label: "Ring Group / Hunt Group"
+---
+
+# Recipe: Ring Group and Hunt Group
+
+## Goal
+
+A small office wants a single number that reaches a team of phones. Two
+behaviors are common:
+
+- **Ring group (simultaneous ring):** dial `3000` and every phone in the
+  group rings at the same time. The first person to pick up takes the call;
+  the other phones stop ringing.
+- **Hunt group (sequential hunt):** dial `3001` and the phones ring one after
+  another. The first phone rings; if nobody answers within the per-leg
+  timeout, the next phone rings, and so on down the list. Whoever answers
+  first takes the call.
+
+Both are built from a single `bridge` action whose dial string lists the
+member endpoints. Two separators control the dialing behavior:
+
+- A **comma** (`,`) dials the legs around it **simultaneously**.
+- A **pipe** (`\|`) dials the groups around it **sequentially** -- the next
+  group is attempted only after the previous group fails or times out.
+
+When nobody answers, the call falls through to voicemail.
+
+**Call flow:**
+
+1. An internal caller dials the group number (`3000` or `3001`).
+2. A dialplan extension matches the number and sets the failover and timeout
+   variables.
+3. `bridge` originates the member legs -- in parallel, in series, or a mix.
+4. The first member to answer is bridged to the caller; the remaining legs
+   are cancelled.
+5. If no member answers before the timeout, `continue_on_fail` lets the
+   dialplan proceed to a voicemail fallback.
+
+## Prerequisites
+
+- The [`bridge` application and dial-string syntax](../dialplan/dptools-reference.mdx)
+  -- the comma, pipe, per-leg variable, and global variable operators.
+- A working [XML dialplan](../dialplan/xml-dialplan.mdx) -- this recipe adds
+  extensions to the `default` context that ships in `conf/vanilla/`.
+- Member phones registered in the [user directory](../users-endpoints/user-directory.mdx)
+  -- this recipe assumes users `1001`, `1002`, and `1003` exist in the default
+  domain (the vanilla configuration ships users `1000`-`1019`).
+- For the find-me/follow-me variation, an outbound
+  [gateway](../users-endpoints/gateways.mdx).
+
+## Build it
+
+Add the following extensions to `conf/dialplan/default.xml`, **above** the
+catch-all `Local_Extension` extension so the group numbers match first. Run
+`reloadxml` from the FreeSWITCH console (or `fs_cli`) after saving.
+
+### Simultaneous ring group
+
+Extension `3000` rings users `1001`, `1002`, and `1003` at the same time. The
+commas between the legs make `bridge` originate all three in parallel; the
+first to answer wins and the others are hung up automatically.
+
+```xml
+<extension name="ring_group_simultaneous">
+  <condition field="destination_number" expression="^3000$">
+    <action application="set" data="hangup_after_bridge=true"/>
+    <action application="set" data="continue_on_fail=true"/>
+    <!-- Give the whole group 25 seconds to answer, then fall through. -->
+    <action application="set" data="call_timeout=25"/>
+    <action application="bridge"
+      data="user/1001@${domain_name},user/1002@${domain_name},user/1003@${domain_name}"/>
+    <!-- Reached only if no member answered (continue_on_fail=true). -->
+    <action application="answer"/>
+    <action application="sleep" data="1000"/>
+    <action application="voicemail" data="default ${domain_name} 1001"/>
+  </condition>
+</extension>
+```
+
+`call_timeout` is a global ceiling for the originate. Because the legs ring in
+parallel, a single timeout for the whole group is usually what you want.
+
+### Sequential hunt group
+
+Extension `3001` rings the members in order. Each pipe-separated group is a
+separate originate attempt; FreeSWITCH tries the next group only after the
+current one fails or times out. A per-leg `[leg_timeout=N]` on each group
+controls how long that phone rings before moving on.
+
+```xml
+<extension name="hunt_group_sequential">
+  <condition field="destination_number" expression="^3001$">
+    <action application="set" data="hangup_after_bridge=true"/>
+    <action application="set" data="continue_on_fail=true"/>
+    <action application="bridge"
+      data="[leg_timeout=15]user/1001@${domain_name}|[leg_timeout=15]user/1002@${domain_name}|[leg_timeout=15]user/1003@${domain_name}"/>
+    <!-- Reached only if no member answered any group. -->
+    <action application="answer"/>
+    <action application="sleep" data="1000"/>
+    <action application="voicemail" data="default ${domain_name} 1001"/>
+  </condition>
+</extension>
+```
+
+Each leg here rings for 15 seconds. If `1001` does not answer, `bridge` moves
+to `1002`, then `1003`, then -- because no group answered -- the action fails
+and the dialplan continues to voicemail.
+
+:::note
+With sequential hunting, prefer the per-leg `[leg_timeout=N]` shown above over
+a single global `call_timeout`. `call_timeout` caps the total originate, so a
+30-second `call_timeout` across three 15-second legs would expire before the
+third phone ever rings. Setting `leg_timeout` per group makes each step
+independent.
+:::
+
+### Mixing the two: groups that ring in parallel, in sequence
+
+The comma and pipe operators combine. Within a pipe group, commas dial those
+members at once; the pipe advances to the next group on failure. This rings
+the front desk pair simultaneously, then the manager, then voicemail:
+
+```xml
+<extension name="ring_group_then_manager">
+  <condition field="destination_number" expression="^3002$">
+    <action application="set" data="hangup_after_bridge=true"/>
+    <action application="set" data="continue_on_fail=true"/>
+    <action application="bridge"
+      data="[leg_timeout=20]user/1001@${domain_name},[leg_timeout=20]user/1002@${domain_name}|[leg_timeout=20]user/1003@${domain_name}"/>
+    <action application="answer"/>
+    <action application="sleep" data="1000"/>
+    <action application="voicemail" data="default ${domain_name} 1003"/>
+  </condition>
+</extension>
+```
+
+## How it works
+
+The argument you pass to `bridge` is a **dial string**, parsed by
+`switch_ivr_originate.c`. The two multi-leg separators have precise,
+distinct meanings, verified in the originate source:
+
+- **Comma (`,`) -- simultaneous (parallel).** Within a single group, every
+  comma-separated leg is dialed at the same time. The dial string is split on
+  the comma into a set of "and" peers that are all originated together; the
+  first leg to answer is bridged to the caller and the rest are cancelled.
+  This is the ring-group behavior.
+- **Pipe (`\|`) -- sequential (failover).** The dial string is first split on
+  the pipe into ordered groups. FreeSWITCH tries the groups one at a time, in
+  left-to-right order, and only advances to the next group when **every leg in
+  the current group** has failed or timed out. This is the hunt-group
+  behavior.
+
+**Precedence:** the string is split by the pipe first, then each pipe group is
+split by commas. So `A,B|C,D` means "ring A and B together; if both fail, ring
+C and D together." A bare comma list with no pipe is a pure ring group; a list
+of single legs joined by pipes is a pure hunt group.
+
+**Timeouts.** `call_timeout` (set as a channel variable or as a `{call_timeout=N}`
+global brace on the dial string) caps the entire originate. `leg_timeout`,
+applied per leg with `[leg_timeout=N]`, caps an individual leg. For sequential
+hunting you want per-leg timeouts so each phone gets its own ring window; for a
+parallel group a single `call_timeout` is simpler.
+
+**`ignore_early_media`.** By default an outbound leg that sends early media
+(ringback or an announcement before answering) can satisfy the originate and
+suppress further progress. Setting `ignore_early_media=true` -- globally with
+`{ignore_early_media=true}` or per leg -- tells `bridge` to wait for a real
+answer (SIP `200 OK`) rather than treating early media as the win. This matters
+for hunt groups whose legs route to gateways or devices that play early media,
+because without it the first leg's ringback can stop the hunt prematurely. The
+vanilla `conf/dialplan/default.xml` uses this on its group-dial extensions
+(`{leg_timeout=15,ignore_early_media=true}`).
+
+**Answer and bridge behavior.** `bridge` does **not** pre-answer the caller; it
+bridges audio once a member answers, so the caller hears natural ringback while
+the group rings. Set `hangup_after_bridge=true` so the caller's channel hangs up
+when the bridged call ends instead of returning to the dialplan. The voicemail
+fallback after the `bridge` action runs only when no member answered, which is
+why `continue_on_fail=true` is required -- without it, a failed `bridge` would
+hang up the caller instead of continuing to the next action.
+
+For the full dial-string grammar -- endpoint prefixes, the `:_:` enterprise
+delimiter, and global/per-leg variable braces -- see the
+[Dialplan Application Reference](../dialplan/dptools-reference.mdx).
+
+## Variations
+
+### Enterprise ring group, then a shared voicemail box
+
+A department number rings everyone at once for 30 seconds, then drops the
+caller into the department's shared mailbox (`2000`):
+
+```xml
+<extension name="sales_ring_group">
+  <condition field="destination_number" expression="^3010$">
+    <action application="set" data="hangup_after_bridge=true"/>
+    <action application="set" data="continue_on_fail=true"/>
+    <action application="bridge"
+      data="{call_timeout=30,ignore_early_media=true}user/1001@${domain_name},user/1002@${domain_name},user/1003@${domain_name}"/>
+    <action application="answer"/>
+    <action application="sleep" data="1000"/>
+    <action application="voicemail" data="default ${domain_name} 2000"/>
+  </condition>
+</extension>
+```
+
+Here the timeout and early-media settings are carried inline as a global
+`{...}` brace on the dial string instead of separate `set` actions -- either
+style works.
+
+If you maintain the team membership in the directory rather than hard-coding
+extensions, replace the comma list with a directory **group**:
+`bridge` accepts `group/<name>@<domain>` to ring every member of a directory
+group at once using each member's `dial-string` (see the
+[user directory](../users-endpoints/user-directory.mdx) for defining groups).
+
+### Find me / follow me to an external number
+
+A hunt sequence that rings the user's desk phone, then their cell phone via an
+outbound gateway, then voicemail. The pipe makes each step sequential; the
+external leg is a gateway dial string (see
+[Gateways and Trunk Registration](../users-endpoints/gateways.mdx)):
+
+```xml
+<extension name="follow_me_1001">
+  <condition field="destination_number" expression="^3020$">
+    <action application="set" data="hangup_after_bridge=true"/>
+    <action application="set" data="continue_on_fail=true"/>
+    <action application="bridge"
+      data="[leg_timeout=20]user/1001@${domain_name}|[leg_timeout=25,ignore_early_media=true]sofia/gateway/mycarrier/15551234567"/>
+    <action application="answer"/>
+    <action application="sleep" data="1000"/>
+    <action application="voicemail" data="default ${domain_name} 1001"/>
+  </condition>
+</extension>
+```
+
+The desk phone rings for 20 seconds; if unanswered, the call is sent out the
+`mycarrier` gateway to the cell number for 25 seconds. `ignore_early_media=true`
+on the gateway leg is important here -- PSTN carriers frequently send early
+media (ringback, network announcements) that would otherwise be treated as an
+answer and stop the hunt. If both legs fail, the caller lands in voicemail.
+
+Replace `mycarrier` with the name of a gateway you have defined and registered.
+The gateway must be configured under a loaded Sofia profile before this
+extension will work.

--- a/docs/recipes/recipe-time-routing.mdx
+++ b/docs/recipes/recipe-time-routing.mdx
@@ -1,0 +1,320 @@
+---
+sidebar_position: 3
+id: recipe-time-routing
+slug: /recipes/time-routing
+title: "Recipe: Business-Hours and Time-of-Day Routing"
+description: "Route calls to the operator or IVR during open hours and to a closed greeting plus voicemail after hours and on holidays, using XML dialplan time conditions."
+sidebar_label: "Time-of-Day Routing"
+---
+
+# Recipe: Business-Hours and Time-of-Day Routing
+
+## Goal
+
+Send callers to a live destination when you are open and to a recorded closed
+greeting plus voicemail when you are not. During business hours (Monday to
+Friday, 9 AM to 5 PM) the call reaches the operator or an IVR auto-attendant.
+Outside those hours, on weekends, and on holidays the call hears a "we are
+closed" greeting and is offered voicemail.
+
+The decision is made entirely in the XML dialplan with `<condition>` time
+attributes, so it needs no scripting and re-evaluates on every call. A single
+channel variable, `open`, carries the open/closed decision; the routing
+extension reads it and dispatches accordingly.
+
+The call flow is:
+
+```
+Inbound call ──▶ holiday check ──┬─ holiday today? ──▶ set open=false
+                                 │
+                 business-hours check ──┬─ Mon-Fri 9-17 & not a holiday? ──▶ open=true
+                                        │
+                          route on ${open} ──┬─ open=true  ──▶ operator / ivr
+                                             └─ open=false ──▶ closed greeting ──▶ voicemail
+```
+
+## Prerequisites
+
+This recipe composes pieces documented in the reference chapters. Read those
+first if any step is unfamiliar:
+
+- [Chapter 15: Time and Condition Routing](../dialplan/time-and-condition-routing.mdx) — the full reference for `<condition>` time attributes, value ranges, and timezone handling.
+- [Chapter 12: The XML Dialplan](../dialplan/xml-dialplan.mdx) — how extensions, conditions, actions, and the `continue` / `break` flags are evaluated.
+- [Chapter 21: IVR Menus](../applications/ivr-menus.mdx) — the `<menu>` schema and the `ivr` dialplan application used for the open-hours destination.
+- [Chapter 19: Voicemail](../applications/voicemail.mdx) — the `voicemail` application and the per-user mailboxes the closed branch writes to.
+
+It assumes the vanilla configuration: an `ivr_menus` directory included by
+`ivr.conf.xml`, the `default` voicemail profile, and the `default` dialplan
+context. The examples mirror the shipped `default.xml` `tod_example` and
+`holiday_example` blocks, so you can paste them alongside the existing config.
+
+## Build it
+
+The pattern uses three cooperating extensions, all with `continue="true"` so
+evaluation flows from one to the next:
+
+1. **Holiday override** — runs first; if today is a holiday it forces
+   `open=false`.
+2. **Business-hours window** — sets `open=true` only inside the open window.
+3. **Router** — reads `${open}` and sends the call to the operator/IVR or to the
+   closed greeting and voicemail.
+
+Add all three to the `default` context in `conf/dialplan/default.xml` (or a file
+under `conf/dialplan/default/`, which the shipped `default.xml` includes), in
+this order.
+
+### 1. Default to closed, then open during business hours
+
+Start by establishing a safe default and the open window. The first extension
+sets `open=false` unconditionally so that any path that does not explicitly open
+the business stays closed. The second matches the business-hours window and flips
+`open` to `true`:
+
+```xml
+<extension name="set_closed_default" continue="true">
+  <condition>
+    <action application="set" data="open=false"/>
+  </condition>
+</extension>
+
+<extension name="business_hours" continue="true">
+  <condition wday="2-6" hour="9-17">
+    <action application="set" data="open=true"/>
+  </condition>
+</extension>
+```
+
+`wday="2-6"` matches Monday through Friday (`wday` is `1`-`7` with Sunday = 1),
+and `hour="9-17"` matches the hours 9 through 17 inclusive — that is, from
+9:00:00 up to 17:59:59. If you need the window to end exactly at 5:00 PM, use
+`time-of-day="09:00-17:00"` instead, which compares to the second. Both
+attributes take comma-separated lists and ranges, so `wday="2-6"` and
+`hour="9-17"` are ranges; `hour="9,13,14"` would be a list.
+
+### 2. Override for holidays (matched first)
+
+Holidays must be decided *before* the business-hours check can open the
+business, so place this extension **above** `business_hours` in the file. Each
+`<condition>` matches one holiday and forces `open=false`; because the holiday
+extension runs first, a holiday that lands on a weekday cannot be re-opened by
+the later business-hours rule. These conditions are copied from the shipped
+`default.xml` `holiday_example`:
+
+```xml
+<extension name="holiday_override" continue="true">
+  <condition mday="1" mon="1">
+    <!-- New Year's Day -->
+    <action application="set" data="open=false"/>
+  </condition>
+  <condition wday="2" mweek="3" mon="1">
+    <!-- Martin Luther King Jr. Day: 3rd Monday in January -->
+    <action application="set" data="open=false"/>
+  </condition>
+  <condition mday="4" mon="7">
+    <!-- Independence Day -->
+    <action application="set" data="open=false"/>
+  </condition>
+  <condition wday="5-6" mweek="4" mon="11">
+    <!-- Thanksgiving: 4th Thursday in November (plus the Friday after) -->
+    <action application="set" data="open=false"/>
+  </condition>
+  <condition mday="25" mon="12">
+    <!-- Christmas Day -->
+    <action application="set" data="open=false"/>
+  </condition>
+</extension>
+```
+
+Each holiday is its own `<condition>` so they are evaluated independently rather
+than as one combined test. `mday="1" mon="1"` is a fixed-date holiday;
+`wday="2" mweek="3" mon="1"` matches a relative one — the 3rd Monday in January —
+by combining day-of-week (`wday="2"` = Monday) with week-of-month
+(`mweek="3"`). Add or remove holidays to match your calendar.
+
+Order in the file matters. The full sequence is:
+
+```xml
+<!-- 1. holiday_override  (forces open=false on holidays) -->
+<!-- 2. set_closed_default (open=false unless a later rule opens) -->
+<!-- 3. business_hours     (open=true only inside the window) -->
+```
+
+Putting `set_closed_default` after `holiday_override` is harmless because both
+set `open=false`; what matters is that `business_hours` comes last so it is the
+only thing that can set `open=true`, and that on a holiday the business-hours
+window never runs against a `true` value that survives. If you prefer to make
+the precedence explicit, gate the business-hours rule on the holiday result —
+see the variation below.
+
+### 3. Route on the open/closed decision
+
+The router reads `${open}` and dispatches. When open, it transfers to the
+operator extension or invokes the IVR; when closed, it plays a greeting and
+drops the caller into a voicemail box:
+
+```xml
+<extension name="time_router">
+  <condition field="${open}" expression="^true$" break="never">
+    <!-- OPEN: send to the operator IVR (or transfer to a live extension) -->
+    <action application="answer"/>
+    <action application="sleep" data="500"/>
+    <action application="ivr" data="demo_ivr"/>
+  </condition>
+  <condition field="${open}" expression="^false$">
+    <!-- CLOSED: play the closed greeting, then take a message -->
+    <action application="answer"/>
+    <action application="sleep" data="500"/>
+    <action application="playback" data="ivr/ivr-thank_you_for_calling.wav"/>
+    <action application="playback" data="voicemail/vm-not_available_no_voicemail.wav"/>
+    <action application="voicemail" data="default ${domain_name} 1000"/>
+  </condition>
+</extension>
+```
+
+The open branch uses `break="never"` so that, after the `open=true` actions run,
+evaluation still falls through and the `open=false` condition is tested — which
+fails and is skipped — keeping both branches in one extension without one
+swallowing the other. Replace `ivr demo_ivr` with `transfer 1000 XML default`
+to ring a live operator instead, and replace the closed-branch `playback` files
+with your own recorded greeting. `voicemail default ${domain_name} 1000` runs the
+`voicemail` application in leave-message mode for mailbox `1000` in the `default`
+profile; point it at whichever mailbox should collect after-hours messages.
+
+### 4. Apply the changes
+
+From `fs_cli`, reload the dialplan:
+
+```
+reloadxml
+```
+
+No restart is required. You can confirm which branch a call would take by
+watching the dialplan log: with the time-condition debug enabled, each
+`<condition>` logs a `Date/Time Match (PASS)` or `(FAIL)` line as it is
+evaluated.
+
+## How it works
+
+1. **Conditions are evaluated top to bottom.** Within an extension, the dialplan
+   tests each `<condition>` in order. A time condition with no `field`/`expression`
+   is a pure date/time test: it passes when the current time matches every time
+   attribute present on the tag and fails otherwise. See
+   [Chapter 15](../dialplan/time-and-condition-routing.mdx) for the full
+   evaluation model.
+
+2. **`continue="true"` chains the extensions.** Each of the three setup
+   extensions has `continue="true"`, so after one finishes the engine moves on
+   to the next instead of stopping at the first match. That is what lets the
+   holiday, business-hours, and router extensions cooperate through the shared
+   `open` variable.
+
+3. **`break` controls fall-through inside an extension.** For a time
+   `<condition>`, the default `break` behavior is `on-false`: a *failing* time
+   condition stops evaluating the rest of that extension. That is exactly what
+   you want for the holiday and business-hours rules — when today is not a
+   holiday, the holiday condition fails and its `set` action is correctly
+   skipped. In the router, the open branch uses `break="never"` so that a
+   *passing* open branch does not stop the extension before the closed branch is
+   even tested; the closed branch then fails its own `^false$` check and is
+   skipped.
+
+4. **The holiday check goes first on purpose.** Because the extensions run in
+   file order, the holiday override sets `open=false` before `business_hours`
+   has a chance to set `open=true`. With the explicit-gate variation below, the
+   business-hours rule additionally refuses to open on a day already marked
+   closed, so a holiday falling on a weekday stays closed even though it is
+   inside the 9-to-5 weekday window.
+
+5. **The router dispatches on a plain field condition.** `time_router` no longer
+   tests time at all — it tests the `${open}` variable that the earlier
+   extensions computed. This separates the *schedule* (when are we open) from the
+   *routing* (what to do when open or closed), so you can change either
+   independently.
+
+## Timezone handling
+
+Time attributes are evaluated against the server's local time unless the channel
+provides a timezone. To route by a specific zone regardless of where the server
+runs, set the `timezone` channel variable (a zone name from
+`timezones.conf.xml`) before the time conditions are evaluated:
+
+```xml
+<extension name="set_tz" continue="true">
+  <condition>
+    <action application="set" data="timezone=America/New_York"/>
+  </condition>
+</extension>
+```
+
+Place this above the holiday and business-hours extensions so the schedule is
+computed in that zone. The dialplan also honors a numeric `tod_tz_offset`
+channel variable (hours from UTC) as an alternative to a named zone. Daylight
+Saving Time is handled automatically when you use a named `timezone`; a fixed
+`tod_tz_offset` does not shift with DST. See
+[Timezone Selection](../dialplan/time-routing#timezone-selection) in the
+time-routing chapter.
+
+## Variations
+
+### Explicit holiday gate
+
+To make the precedence between holidays and business hours unmistakable, set a
+separate `holiday` flag and require it to be unset before opening. The holiday
+extension sets `holiday=true`; the business-hours condition then adds a field
+test so it only opens on a non-holiday weekday:
+
+```xml
+<!-- holiday extension sets: <action application="set" data="holiday=true"/> -->
+
+<extension name="business_hours" continue="true">
+  <condition field="${holiday}" expression="^true$" break="on-true">
+    <!-- a holiday: do nothing, leave open=false -->
+  </condition>
+  <condition wday="2-6" hour="9-17">
+    <action application="set" data="open=true"/>
+  </condition>
+</extension>
+```
+
+Here `break="on-true"` stops the extension when `holiday` is `true`, so the
+business-hours time condition is never reached on a holiday.
+
+### A separate lunch-hour break
+
+To close the line over lunch, add a condition that re-closes the business during
+a midday window. Because it runs after `business_hours`, it overrides the open
+decision for that hour only:
+
+```xml
+<extension name="lunch_break" continue="true">
+  <condition wday="2-6" time-of-day="12:00-13:00">
+    <action application="set" data="open=false"/>
+  </condition>
+</extension>
+```
+
+Place this **after** `business_hours` so its `open=false` wins inside the lunch
+window. `time-of-day` compares to the second, so `12:00-13:00` reopens exactly at
+1:00:00 PM.
+
+### Per-DID schedules
+
+To give each inbound number its own schedule, branch on the DID first and route
+to a per-DID router. Match `destination_number` in the `public` context, set a
+variable identifying the line, and use it to select the destination in the
+closed and open branches:
+
+```xml
+<extension name="did_sales" continue="true">
+  <condition field="destination_number" expression="^(\+?1?5551112222)$">
+    <action application="set" data="vm_box=2000"/>
+    <action application="set" data="open_dest=sales_ivr"/>
+  </condition>
+</extension>
+```
+
+Then in the time router, transfer the open branch to `${open_dest}` and use
+`${vm_box}` in the closed branch's `voicemail` data, so one schedule serves many
+numbers while each keeps its own operator menu and mailbox. Different lines can
+also carry different `timezone` values, giving each DID a schedule in its own
+zone.

--- a/docs/troubleshooting/_category_.json
+++ b/docs/troubleshooting/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Part 11: Troubleshooting", "position": 11 }

--- a/docs/troubleshooting/audio-problems.mdx
+++ b/docs/troubleshooting/audio-problems.mdx
@@ -1,0 +1,253 @@
+---
+sidebar_position: 3
+id: audio-problems
+slug: /troubleshooting/audio
+title: "No Audio and One-Way Audio"
+description: "Diagnose silent and one-way calls in FreeSWITCH: NAT and firewall RTP failures, advertised media addresses, codec mismatches, and media timeouts, using SIP traces and session variables."
+sidebar_label: "Audio Problems"
+---
+
+# No Audio and One-Way Audio
+
+A call that connects but carries no audio, or audio in only one direction, almost
+always means SIP signaling succeeded while RTP media did not. The two paths are
+independent: SIP can negotiate a session end to end while the RTP packets that
+carry the actual audio are blackholed by a firewall, sent to an unreachable
+private address, or never agreed on a common codec.
+
+This chapter is diagnostic. It does not re-document the media subsystem — for the
+parameter reference see [Chapter 17: Media Handling](../media/media-handling.mdx)
+and [Chapter 16: Codecs and Negotiation](../media/codecs-and-negotiation.mdx), and
+for the profile model see [Chapter 7: SIP Profiles with Sofia](../users-endpoints/sip-profiles-sofia.mdx).
+Here the focus is the read: given a silent call, where do you look, what confirms
+the cause, and what is the corrective change.
+
+The single most useful diagnostic is a SIP trace of the call, because the
+advertised media address and the offered/answered codecs are all carried in the
+SDP body of the INVITE and its answer. Enable tracing per profile before placing
+the test call:
+
+```
+sofia profile internal siptrace on
+```
+
+or globally with `sofia global siptrace on`. Turn it off again with `off`. Each
+SDP block in the trace contains a connection line (`c=`) giving the IP address the
+far end will send RTP to, and one or more media lines (`m=`) giving the port and
+the offered codec payload types. Reading those two lines on both legs is the core
+skill for every symptom below.
+
+## The Usual Root Cause: RTP Cannot Flow {#rtp-cannot-flow}
+
+When FreeSWITCH and an endpoint exchange SDP, each side advertises an IP address
+and port where it expects to receive RTP. If that advertised address is a private
+address behind NAT, or if a firewall blocks the UDP port range, signaling still
+completes and the call appears answered, but no media arrives.
+
+**Symptom.** The call connects and both parties hear silence, or one party hears
+the other but not vice versa.
+
+**Cause.** FreeSWITCH advertised an address the far end cannot reach, the far end
+advertised an address FreeSWITCH cannot reach, or a firewall drops the RTP UDP
+flow. Behind NAT, the address FreeSWITCH binds RTP to (its private `rtp-ip`) is
+not the address remote endpoints must send to (its public IP). FreeSWITCH resolves
+this with separate "external" parameters that control what goes into the SDP `c=`
+line.
+
+The relevant Sofia profile parameters, all verified in `mod_sofia`:
+
+| Parameter | Role | Vanilla default |
+| --- | --- | --- |
+| `rtp-ip` | Local IP address RTP sockets bind to | `$${local_ip_v4}` |
+| `sip-ip` | Local IP address the SIP transport binds to | `$${local_ip_v4}` |
+| `ext-rtp-ip` | Public IP advertised in the SDP `c=` line for media | `$${external_rtp_ip}` (external profile) |
+| `ext-sip-ip` | Public IP advertised in SIP `Contact`/`Via` | `$${external_sip_ip}` (external profile) |
+| `apply-nat-acl` | ACL that marks a remote contact as being behind NAT | `nat.auto` (internal profile) |
+| `local-network-acl` | ACL defining which networks are "local" (no NAT treatment) | `localnet.auto` |
+
+`ext-rtp-ip` accepts a literal IP address, `auto` (use the guessed local IP),
+`auto-nat` (use an address learned from NAT-PMP or UPnP), `stun:<server>` (resolve
+the public IP by STUN), or `host:<name>` (resolve by DNS). The vanilla
+`external.xml` profile points `ext-rtp-ip` and `ext-sip-ip` at the
+`$${external_rtp_ip}` and `$${external_sip_ip}` preprocessor variables, which
+`conf/vanilla/vars.xml` resolves by STUN against `stun.freeswitch.org` by default.
+The `internal.xml` profile does the same on its TLS/alternate binding.
+
+**Confirm.** In the SIP trace, read the `c=` line in the SDP that FreeSWITCH sends.
+If it shows a private (RFC 1918) address while the call crosses the public
+internet, FreeSWITCH is advertising an unroutable media address. Then read the
+running profile's actual values:
+
+```
+sofia status profile internal
+```
+
+The XML/status output prints the live `rtp-ip`, `ext-rtp-ip`, `sip-ip`, and
+`ext-sip-ip` for the profile, which is what FreeSWITCH will actually advertise —
+useful when a preprocessor variable or STUN lookup resolved to something
+unexpected.
+
+**Fix.** Set `ext-rtp-ip` (and usually `ext-sip-ip`) to the public address, by
+literal IP for a static deployment or by `stun:` when the public IP is dynamic.
+Open the RTP UDP port range on the firewall (the range is governed by the global
+`rtp-start-port`/`rtp-end-port`, separate from the SIP signaling port). Confirm
+that `local-network-acl` correctly classifies your LAN so that local calls are not
+given external NAT treatment.
+
+## One-Way Audio Specifically {#one-way-audio}
+
+One-way audio is the asymmetric case of the problem above: RTP flows in one
+direction but not the other. It is most common when one endpoint is behind NAT and
+the other is not.
+
+**Symptom.** Caller hears callee but callee hears silence (or the reverse). SIP is
+fully established; only one RTP direction is dead.
+
+**Cause.** Typically a NATed endpoint advertises its private address in SDP, so
+FreeSWITCH sends RTP into a void, while the endpoint's own outbound RTP reaches
+FreeSWITCH normally. Other causes: `ext-rtp-ip` configured on only one of two
+profiles so one leg advertises a public address and the other a private one; or
+auto-adjust/timing correction disabled when an endpoint needs it.
+
+By default FreeSWITCH learns the real source address of incoming RTP and adjusts
+where it sends return media — this is what makes most symmetric-NAT phones work
+without per-device configuration. Two profile parameters govern this behavior
+(both documented with their defaults and per-call channel-variable overrides in
+[Chapter 17](../media/media-handling.mdx)):
+
+- `disable-rtp-auto-adjust` — when `true`, stops FreeSWITCH from re-pointing the
+  outbound RTP stream at the observed packet source. Auto-adjust is **enabled by
+  default**; disabling it breaks one direction for many NATed endpoints. The
+  per-call override is `disable_rtp_auto_adjust`.
+- `rtp-autofix-timing` — corrects RTP from endpoints that send at irregular packet
+  rates. **Enabled by default.** The per-call override is
+  `rtp_media_autofix_timing`.
+
+The media mode also matters. With **bypass media** the two endpoints exchange RTP
+directly and FreeSWITCH cannot help either side traverse NAT; with **proxy media**
+or full media-path mode FreeSWITCH terminates RTP and can apply auto-adjust. See
+the media modes in [Chapter 17](../media/media-handling.mdx). A one-way call that
+uses `bypass_media=true` is a strong hint that the two endpoints simply cannot
+reach each other's advertised addresses directly.
+
+**Confirm.** Compare the `c=`/`m=` lines from both legs in the trace. The dead
+direction is the leg whose advertised RTP address is unreachable from the other
+side. Check whether the channel is in bypass media (the `bypass_media` channel
+variable) and check the profile's auto-adjust/autofix settings against the
+defaults.
+
+**Fix.** Ensure FreeSWITCH is in the media path for cross-NAT calls (do not set
+`bypass_media`), keep auto-adjust enabled, and set `ext-rtp-ip` consistently on
+*every* profile that faces the public internet — not just one.
+
+## Codec Mismatch: No Common Codec {#codec-mismatch}
+
+If the two sides share no codec, negotiation either fails outright or, after
+transcoding constraints, leaves a leg with no usable media format and the audio is
+silent.
+
+**Symptom.** No audio, sometimes with the call failing at answer, sometimes
+connecting silently. The far end offered only codecs FreeSWITCH's profile does not
+list, or vice versa.
+
+**Cause.** The intersection of the offered codecs and the profile's preference
+list is empty, or a forced codec string excluded the only common format. The
+controlling parameters:
+
+| Setting | Where | Role |
+| --- | --- | --- |
+| `inbound-codec-prefs` | Sofia profile param | Ordered codec list applied to inbound INVITEs |
+| `outbound-codec-prefs` | Sofia profile param | Ordered codec list used to build outbound offers |
+| `absolute_codec_string` | Channel variable | Forces an exact codec list, ignoring profile prefs |
+| `codec_string` | Channel variable | Sets a preferred codec list (lower precedence than `absolute_codec_string`) |
+
+In vanilla both profiles set `inbound-codec-prefs` and `outbound-codec-prefs` from
+the `$${global_codec_prefs}` variable, which `vars.xml` defines as
+`OPUS,G722,PCMU,PCMA,H264,VP8`. The full negotiation logic — preference ordering,
+inbound policy, and the offer/answer exchange — is in
+[Chapter 16](../media/codecs-and-negotiation.mdx).
+
+**Confirm.** Read the `m=` line and the `a=rtpmap` attributes in the offer SDP from
+the trace and compare them to the profile's `inbound-codec-prefs`. If there is no
+overlap, that is the cause. On an established call, dump the session and read the
+negotiated codec variables FreeSWITCH sets on the channel:
+
+```
+uuid_dump <uuid>
+```
+
+The relevant variables include `rtp_use_codec_name` (the negotiated audio codec,
+e.g. `PCMU`), `rtp_use_codec_rate`, `rtp_use_codec_ptime`, and
+`rtp_use_codec_string`. If the call answered with a codec neither side actually
+wanted, or one of these is empty, negotiation is where to look.
+
+**Fix.** Add the needed codec to `inbound-codec-prefs`/`outbound-codec-prefs`, or
+load the codec module that provides it. To force a specific codec for a route, set
+`absolute_codec_string` in the dialplan; remember it overrides the profile lists
+entirely, so an over-restrictive value can itself cause the mismatch.
+
+## RTP and Media Timeouts {#media-timeouts}
+
+When media stops arriving mid-call, FreeSWITCH can tear the call down after a
+configured period of RTP inactivity. A call that connects with audio and then goes
+silent and drops after a fixed interval is the classic media-timeout signature.
+
+**Symptom.** Audio works, then cuts out and the call clears after a consistent
+number of seconds with hangup cause `MEDIA_TIMEOUT`.
+
+**Cause.** RTP stopped flowing — often the same NAT/firewall issue as above, but
+triggered partway through a call (for example after a re-INVITE moves media) — and
+the inactivity timer fired. The controlling settings:
+
+- `media_timeout` — channel variable, milliseconds of RTP inactivity on an active
+  call before hangup. This is the current mechanism.
+- `media_hold_timeout` — channel variable, milliseconds of inactivity while on
+  hold; if unset it defaults to 10× `media_timeout`.
+- `rtp_timeout_sec` / `rtp_hold_timeout_sec` — **deprecated** channel variables (in
+  *seconds*). FreeSWITCH logs `rtp_timeout_sec deprecated use media_timeout
+  variable.` when they are used. The profile parameters `rtp-timeout-sec` /
+  `rtp-hold-timeout-sec` are likewise deprecated (vanilla still ships
+  `rtp-timeout-sec` at `300`).
+
+The exact precedence, the millisecond-vs-second distinction, and the
+`execute_on_media_timeout` hook are documented in
+[Chapter 17](../media/media-handling.mdx). For diagnosis the key fact is that a
+`MEDIA_TIMEOUT` hangup means media genuinely stopped — the timer is reporting the
+real problem, not causing it.
+
+**Confirm.** Check the hangup cause in the logs or CDR for `MEDIA_TIMEOUT`. If the
+call ran for exactly the timeout duration, the timer fired on an inactive stream.
+
+**Fix.** Treat the timeout as a symptom and fix the underlying RTP path (NAT,
+firewall, re-INVITE handling) as in the sections above. Adjust `media_timeout`
+only if the threshold itself is wrong for your traffic; do not raise it to mask a
+real media failure.
+
+## Confirming Whether RTP Is Flowing {#confirming-rtp-flow}
+
+Two independent reads tell you whether media is actually moving and where it is
+being sent.
+
+**Read the SDP in a SIP trace.** With `siptrace` enabled, each SDP body shows:
+
+- `c=IN IP4 <address>` — the address the far end will send RTP to. If this is a
+  private address on a public call, RTP cannot arrive.
+- `m=audio <port> RTP/AVP <payload-types>` — the receiving port and offered codec
+  payload types. Compare the offered payload types against the answered ones to see
+  the negotiated codec.
+
+Reading these lines on **both** legs locates a one-way problem to the specific leg
+with the unreachable address.
+
+**Read the session variables.** On a live call, `uuid_dump <uuid>` prints the
+channel variables. Useful ones for media diagnosis:
+
+- `rtp_use_codec_name`, `rtp_use_codec_string`, `rtp_use_codec_rate`,
+  `rtp_use_codec_ptime` — the negotiated audio codec and parameters.
+- `rtp_local_sdp_str` — the full local SDP FreeSWITCH generated, including the very
+  `c=`/`m=` lines it advertised, which you can compare directly against the trace.
+
+Between the trace and these variables you can establish, for any silent or one-way
+call, exactly which address each side is sending to and which codec was agreed —
+which is enough to assign the problem to NAT/firewall, asymmetric advertising, or
+codec negotiation.

--- a/docs/troubleshooting/call-setup-failures.mdx
+++ b/docs/troubleshooting/call-setup-failures.mdx
@@ -1,0 +1,295 @@
+---
+sidebar_position: 4
+id: call-setup-failures
+slug: /troubleshooting/call-setup
+title: "Call-Setup Failures"
+description: "Diagnose calls that never connect: read Q.850 hangup causes, trace dialplan misroutes, and resolve gateway and originate failures using the FreeSWITCH console."
+sidebar_label: "Call-Setup Failures"
+---
+
+# Call-Setup Failures
+
+A call-setup failure is any attempt that never reaches the talking state: the
+caller hears a fast busy or a SIP error, an outbound leg returns immediately, or
+an `originate` from the console comes back with an error. Almost every one of
+these leaves a single, decisive piece of evidence behind — a *hangup cause* — and
+the fastest path to a fix is to read that cause first and only then look at where
+it came from.
+
+This chapter is diagnostic. It assumes you can already place a call and watch the
+console; it does not re-explain dialplan or gateway configuration. For the
+configuration side, see the
+[Dialplan Application Reference](/dialplan/dptools),
+the [Inbound Public Context](/dialplan/public-context) chapter,
+[Gateways](/users-and-endpoints/gateways), and the
+[Channel Variables](/reference/channel-variables) reference.
+
+## Reading a hangup cause {#reading-a-hangup-cause}
+
+FreeSWITCH terminates every channel with a Q.850 call cause. The cause is exposed
+three ways, all of which carry the same uppercase name:
+
+- The channel variable `hangup_cause`, available in the dialplan, in events, and
+  in the CDR.
+- The `Hangup-Cause` header on the `CHANNEL_HANGUP` event.
+- The log line printed when the channel hangs up.
+
+The names come from a fixed table in the core (`CAUSE_CHART` in
+`src/switch_channel.c`), and `switch_channel_cause2str()` is what turns the
+numeric cause into the string you see. The most common call-setup causes are:
+
+| Cause | Q.850 | What it means at setup time |
+|---|---|---|
+| `NORMAL_CLEARING` | 16 | The call ended cleanly. At *setup* this usually means the far end answered then hung up, or a `200 OK` was followed by a normal teardown. |
+| `USER_BUSY` | 17 | Destination is busy — a SIP `486` or `600`, or a registered endpoint returning busy. |
+| `NO_USER_RESPONSE` | 18 | No response from the destination within the protocol timer; maps from SIP `480`. |
+| `NO_ANSWER` | 19 | The destination rang but no one answered before the timeout. |
+| `SUBSCRIBER_ABSENT` | 20 | The user exists but is currently unreachable. |
+| `CALL_REJECTED` | 21 | The far end actively refused — SIP `401`, `402`, `403`, `407`, `603`, or `608`. |
+| `NUMBER_CHANGED` | 22 | SIP `410 Gone`. |
+| `INVALID_NUMBER_FORMAT` | 28 | The dialed number was malformed for the route; SIP `484 Address Incomplete`. |
+| `NORMAL_TEMPORARY_FAILURE` | 41 | A transient upstream failure — SIP `400`, `481`, `500`, or `503`. Retry-worthy. |
+| `NETWORK_OUT_OF_ORDER` | 38 | SIP `502 Bad Gateway`. |
+| `SERVICE_UNAVAILABLE` | 63 | Service not available on this route; SIP `405`. |
+| `INCOMPATIBLE_DESTINATION` | 88 | Codec or media negotiation failed; SIP `488` or `606`. |
+| `RECOVERY_ON_TIMER_EXPIRE` | 102 | A timer expired with no answer at all; SIP `408 Request Timeout` or `504`. |
+| `UNALLOCATED_NUMBER` | 1 | The number is not assigned; SIP `404 Not Found`. |
+| `NO_ROUTE_DESTINATION` | 3 | No route to the destination; SIP `485 Ambiguous` or `604`. |
+
+The non-Q.850 causes FreeSWITCH adds for its own conditions are equally useful at
+setup time:
+
+| Cause | What it means |
+|---|---|
+| `USER_NOT_REGISTERED` | You tried to reach a `user/` or registered endpoint that has no live registration. |
+| `GATEWAY_DOWN` | The named gateway exists but is not usable (not registered, or marked down). |
+| `INVALID_GATEWAY` | The gateway name in the dial string does not exist. |
+| `INVALID_URL` | The dial string could not be parsed into a valid URL. |
+| `INVALID_PROFILE` | The Sofia profile named in the dial string does not exist or is not running. |
+| `ORIGINATOR_CANCEL` | The originator (A-leg or the `originate` caller) cancelled before answer; SIP `487`. |
+| `PROGRESS_TIMEOUT` | The call got media/progress but never advanced; controlled by the progress timeout. |
+| `ALLOTTED_TIMEOUT` | The originate-wide timeout elapsed before any leg answered. |
+
+:::tip
+Two extra variables sharpen the picture for SIP legs. `sip_term_status` holds the
+bare SIP response number (for example `480`), and `proto_specific_hangup_cause`
+holds it as `sip:480`. Both are set from the actual response code before it is
+folded into the Q.850 cause, so they tell you the *wire* reason even when several
+SIP codes collapse to one cause. On a bridge, the B-leg's cause is copied to the
+A-leg as `last_bridge_hangup_cause`, and `originate_disposition` records the
+outcome of an originate (`success`, `failure`, or the cause string itself).
+:::
+
+## Symptom: the call never matched an extension {#dialplan-no-match}
+
+**Symptom.** The call arrives but nothing happens, or it is rejected outright,
+and no dialplan action you expected runs.
+
+**Cause.** The destination number, context, or dialplan name FreeSWITCH used does
+not match the extension you wrote. The single most common version is an inbound
+call landing in the wrong context — calls from an unauthenticated source arrive
+in `public`, not `default`.
+
+**Confirm.** Raise the console to at least `INFO` and place the call. The XML
+dialplan prints exactly what it is routing, from `mod_dialplan_xml`:
+
+```text
+Processing Caller Name <1001>->18005551212 in context public
+```
+
+That one line gives you the caller-ID name, the caller-ID number, the
+*destination number* it will try to match, and the *context* it is matching in.
+If the context reads `public` when you expected `default`, the call came in
+unauthenticated and is being handled by your public dialplan — which by design
+should not reach your internal extensions. Raise the verbosity further with
+`console loglevel debug` to see each condition evaluated:
+
+```text
+Dialplan: Processing recursive conditions level:0 ...
+Dialplan: sofia/internal/... Regex (FAIL) [my_ext] destination_number(18005551212) =~ /^(1\d{10})$/ match=false
+Dialplan: sofia/internal/... Action set(...)
+```
+
+`Regex (PASS)` / `Regex (FAIL)` shows precisely which condition matched and which
+did not, so you can see whether the problem is your pattern or the destination
+number itself.
+
+**Fix.** Match the context, dialplan name, and destination shown in the
+`Processing ...` line against your XML. If the context is `public`, decide
+whether the call *should* be authenticated (fix the source so it registers or
+falls inside your ACL) or whether the public context should explicitly route it
+into `default` with a `transfer`. The
+[Inbound Public Context](/dialplan/public-context) chapter covers that handoff;
+the conditions and the `transfer` application are documented in the
+[Dialplan Application Reference](/dialplan/dptools).
+
+## Symptom: outbound call fails through a gateway {#gateway-down}
+
+**Symptom.** Calls to an external number fail instantly with `GATEWAY_DOWN`,
+`USER_NOT_REGISTERED`, or `NORMAL_TEMPORARY_FAILURE`, and the B-leg never even
+sends an INVITE you can trace.
+
+**Cause.** The gateway is not in a usable state. A gateway you expect to be
+registered may be retrying, failed, or expired.
+
+**Confirm.** Ask Sofia directly:
+
+```text
+sofia status gateway my_gateway
+```
+
+The output has two state fields that you must read together. The `State` line is
+the registration state machine, and the `Status` line is the up/down summary:
+
+```text
+State   	REGED
+Status  	UP
+```
+
+`State` is one of the values from `sofia_state_names` in `mod_sofia.c`:
+
+| State | Meaning |
+|---|---|
+| `REGED` | Registered and current — the healthy state for a registering gateway. |
+| `TRYING` | A REGISTER is in flight. |
+| `REGISTER` | Queued to send a REGISTER. |
+| `UNREGED` | Not registered (the starting / reset state). |
+| `UNREGISTER` | Queued to send an un-REGISTER. |
+| `FAILED` | The last REGISTER attempt failed. |
+| `FAIL_WAIT` | Backing off after a failure before retrying. |
+| `EXPIRED` | The registration lapsed and has not yet been renewed. |
+| `NOREG` | Configured *not* to register (`register=false`) — normal for IP-auth trunks. |
+| `DOWN` | The gateway is down / unregistered. |
+| `TIMEOUT` | The REGISTER timed out with no response. |
+
+`Status` is simpler — it is only ever `DOWN` or `UP` (with a trailing `(ping)`
+when an OPTIONS ping is in flight), from the `status_names` table in `mod_sofia.c`.
+
+The combinations that explain a failed outbound call:
+
+- `State NOREG / Status UP` — an IP-authenticated trunk that does not register.
+  This is healthy; the problem is elsewhere (dialplan, codecs, or the upstream).
+- `State NOREG / Status DOWN` — a non-registering gateway whose OPTIONS ping is
+  failing; the far end is unreachable.
+- `State FAILED`, `FAIL_WAIT`, `EXPIRED`, or `TIMEOUT` — registration is broken.
+  This is a credentials, network, or far-end problem, and any call routed through
+  it returns `GATEWAY_DOWN`.
+
+**Fix.** Bring the gateway back to a usable state. For a registering gateway,
+correct the credentials or realm and re-register; for a non-registering trunk,
+fix the network path or the ping target. Gateway parameters and the OPTIONS-ping
+keepalive are covered in [Gateways](/users-and-endpoints/gateways).
+
+## Symptom: upstream returns 403, 404, 480, or 503 {#sip-response-mapping}
+
+**Symptom.** A SIP trace shows the far end answering your INVITE with an error
+response, and the leg ends with a Q.850 cause rather than the raw SIP number.
+
+**Cause.** `mod_sofia` maps every final SIP response onto a Q.850 cause
+(`sofia_glue_sip_cause_to_freeswitch` in `sofia_glue.c`). Several SIP codes can
+collapse onto one cause, which is why the cause alone can be ambiguous — read the
+SIP code too.
+
+**Confirm.** Turn on SIP tracing for the profile and re-run the call:
+
+```text
+sofia profile internal siptrace on
+```
+
+(or `sofia global siptrace on` for every profile). Then read the response code in
+the trace and check `proto_specific_hangup_cause` / `sip_term_status` on the leg.
+The mappings you will hit most:
+
+| SIP response | Maps to cause |
+|---|---|
+| `403 Forbidden` (also `401`, `402`, `407`, `603`, `608`) | `CALL_REJECTED` |
+| `404 Not Found` | `UNALLOCATED_NUMBER` |
+| `480 Temporarily Unavailable` | `NO_USER_RESPONSE` |
+| `486 Busy Here` (also `600`) | `USER_BUSY` |
+| `484 Address Incomplete` | `INVALID_NUMBER_FORMAT` |
+| `488 Not Acceptable Here` (also `606`) | `INCOMPATIBLE_DESTINATION` |
+| `408` / `504` | `RECOVERY_ON_TIMER_EXPIRE` |
+| `485` / `604` | `NO_ROUTE_DESTINATION` |
+| `502 Bad Gateway` | `NETWORK_OUT_OF_ORDER` |
+| `400` / `481` / `500` / `503` | `NORMAL_TEMPORARY_FAILURE` |
+| `487 Request Terminated` | `ORIGINATOR_CANCEL` |
+
+Note the non-obvious ones: a `404` becomes `UNALLOCATED_NUMBER` (not
+`NO_ROUTE_DESTINATION`), and a `480` becomes `NO_USER_RESPONSE` (not `NO_ANSWER`).
+Any SIP code with no explicit mapping falls through to `NORMAL_UNSPECIFIED`.
+
+**Fix.** The fix lives upstream, not in FreeSWITCH: a `403` is the provider
+rejecting your credentials or caller-ID, a `404` is a number the provider does
+not recognize, a `480`/`503` is the destination temporarily down. Correct the
+outbound identity or route and retry.
+
+## Symptom: a bridge ends instead of trying the next leg {#continue-on-fail}
+
+**Symptom.** A `bridge` to multiple destinations stops at the first failure, or
+conversely keeps going when you wanted it to stop, and the dialplan continues (or
+hangs up) unexpectedly.
+
+**Cause.** Whether the dialplan continues after a failed outbound leg is governed
+by `continue_on_fail` and `failure_causes` (read in `switch_channel.c`). By
+default, with neither variable set, only `NO_ANSWER`, `NO_USER_RESPONSE`, and
+`ORIGINATOR_CANCEL` are treated as "keep going" — every other cause hangs up the
+A-leg.
+
+**Confirm.** Inspect the cause of the failed B-leg (`hangup_cause`, or
+`last_bridge_hangup_cause` on the A-leg) and check which variables are set:
+
+- `continue_on_fail=true` — continue the dialplan on *any* failure cause.
+- `continue_on_fail=false` — do not continue (only the listed causes, if any, let
+  it through).
+- `continue_on_fail=user_busy,no_route_destination,603` — continue only when the
+  cause matches one of these names or numbers (case-insensitive; numeric Q.850
+  values are accepted).
+- `failure_causes=...` — the inverse filter: only the listed causes are treated
+  as failures that stop processing; everything else continues.
+
+`ATTENDED_TRANSFER` is always treated as a non-failure and never triggers
+continuation logic.
+
+For parallel originate (the `,` and `|` operators), `fail_on_single_reject`
+controls whether one rejected leg aborts the whole set. Set
+`fail_on_single_reject=true` to abort on the first reject, or give it a
+comma-list of causes to abort only on those; prefix with `!` to invert. Use
+`originate_continue_on_timeout` to keep trying remaining legs after the timeout.
+
+**Fix.** Set `continue_on_fail` (or `failure_causes`) to match the routing you
+want before the `bridge`. These are ordinary channel variables — see
+[Channel Variables](/reference/channel-variables) — and the `bridge` application
+is in the [Dialplan Application Reference](/dialplan/dptools).
+
+## Symptom: originate from the CLI returns -ERR {#originate-cli}
+
+**Symptom.** You run `originate` from `fs_cli` and it returns an error rather than
+connecting.
+
+**Cause.** The `originate` API command reports its result directly. On success it
+prints the new session UUID; on failure it prints the Q.850 cause of the failed
+attempt (from `originate_function` in `mod_commands.c`).
+
+**Confirm.** Read the response:
+
+```text
+freeswitch@host> originate sofia/gateway/my_gateway/18005551212 &echo
+-ERR GATEWAY_DOWN
+```
+
+A success looks like:
+
+```text
++OK 4f8c9a10-...-uuid
+```
+
+The string after `-ERR` is exactly the cause name from the table above, so the
+same reasoning applies: `-ERR USER_NOT_REGISTERED` means the destination has no
+live registration, `-ERR INVALID_GATEWAY` means the gateway name is wrong,
+`-ERR NO_ROUTE_DESTINATION` means there was no usable route, and
+`-ERR RECOVERY_ON_TIMER_EXPIRE` means it timed out with no response.
+
+**Fix.** Map the `-ERR` cause back to its section above and fix the underlying
+condition — the gateway state, the registration, the dial string, or the
+upstream. Re-run the same `originate` with `sofia profile <name> siptrace on` if
+the cause points at the SIP exchange and you need to see the wire response.

--- a/docs/troubleshooting/diagnostic-toolbox.mdx
+++ b/docs/troubleshooting/diagnostic-toolbox.mdx
@@ -1,0 +1,330 @@
+---
+sidebar_position: 1
+id: diagnostic-toolbox
+slug: /troubleshooting/toolbox
+title: "The Diagnostic Toolbox"
+description: "Connect with fs_cli, set log levels, inspect channel and SIP-profile state, and trace SIP with the diagnostic commands FreeSWITCH ships with."
+sidebar_label: "Diagnostic Toolbox"
+---
+
+# The Diagnostic Toolbox
+
+Before you can fix a call that misbehaves, you have to *see* what FreeSWITCH is
+doing. This chapter is a tour of the diagnostic surface that ships in the box:
+the interactive console, the log-level controls, the state-inspection commands,
+and SIP tracing. Every command shown here is a real API command — the same set
+documented in the [CLI and API Command
+Reference](../reference/cli-and-api.mdx) — so anything you type at the console
+can also be sent over the Event Socket with `api` or `bgapi`.
+
+Nothing here changes how FreeSWITCH routes calls; these are read-and-observe
+tools. Reach for them first when something is wrong, then use the
+configuration chapters to apply a fix.
+
+## Connecting with fs_cli
+
+`fs_cli` is the interactive client that attaches to a running FreeSWITCH over
+the Event Socket. On the same host you can usually just run it:
+
+```bash
+fs_cli
+```
+
+To reach a remote instance, point it at the host, port, and Event Socket
+password:
+
+```bash
+fs_cli -H 192.0.2.10 -P 8021 -p ClueCon
+```
+
+Once connected you get the `freeswitch@host>` prompt. Type `/help` to list the
+client-side commands the console understands:
+
+```text
+Command                    	Description
+-----------------------------------------------
+/help                      	Help
+/exit, /quit, /bye, ...    	Exit the program.
+/event, /noevents, /nixevent	Event commands.
+/log, /nolog               	Log commands.
+/uuid                      	Filter logs for a single call uuid
+/filter                    	Filter commands.
+/logfilter                 	Filter Log for a single string.
+/debug [0-7]               	Set debug level.
+```
+
+Anything that does *not* begin with `/` is sent to FreeSWITCH as an API command.
+So `status` at the prompt runs the `status` API; `/help` is handled by the
+client itself.
+
+### Controlling the log stream from the console
+
+Three slash-commands shape what scrolls past you while you watch a call:
+
+| Command | What it does |
+| --- | --- |
+| `/log <level>` | Subscribe this console to log events at `<level>` and above (for example `/log debug`). Sent to the server as a `log` command. |
+| `/nolog` | Stop streaming log events to this console. |
+| `/logfilter <string>` | Show only log lines that contain `<string>`; run `/logfilter` with no argument to clear it. The filter is applied client-side. |
+| `/uuid <uuid>` | Show only log lines tagged with one call's UUID; run with no argument to clear. |
+
+`/log` controls *which* log events the server sends you; `/logfilter` and
+`/uuid` narrow what the client prints from that stream. A common pattern is
+`/log debug` to open the firehose, then `/logfilter 1001` or `/uuid <uuid>` to
+follow a single user or call.
+
+:::note
+`/log debug` only affects the events streamed to *your* console session. It does
+not change the system-wide console verbosity — that is the next section.
+:::
+
+## Log levels
+
+FreeSWITCH log levels, from most to least severe, are:
+
+```text
+CONSOLE  ALERT  CRIT  ERR  WARNING  NOTICE  INFO  DEBUG
+```
+
+A given level includes everything more severe than it, so `DEBUG` is the most
+verbose and `CONSOLE` the quietest. (`CONSOLE` is a special always-shown level,
+not "console output in general.") Note the names are `ERR` (not `ERROR`) and
+`WARNING`.
+
+There are three places these levels are set, and they do different things.
+
+### console loglevel — the console logger's verbosity
+
+The `console` logger (`mod_console`) prints to the terminal where FreeSWITCH is
+running. Its verbosity is set with the `console loglevel` API command:
+
+```text
+console loglevel debug
+console loglevel 7
+```
+
+You can give a level name or its numeric index `0`–`7`. Run `console loglevel`
+with no argument to see usage. The matching startup default lives in
+`autoload_configs/console.conf.xml`:
+
+```xml
+<settings>
+  <param name="colorize" value="true"/>
+  <param name="loglevel" value="$${console_loglevel}"/>
+</settings>
+```
+
+In the vanilla config that variable is set in `vars.xml`:
+
+```xml
+<X-PRE-PROCESS cmd="set" data="console_loglevel=info"/>
+```
+
+so a fresh install logs at `info` until you raise it. The `<mappings>` section
+of `console.conf.xml` can further scope which files or functions emit which
+levels — useful when you want `debug` from `sofia.c` only, without drowning in
+the rest.
+
+### fsctl loglevel — the core's global log level
+
+`fsctl loglevel` sets the level on the core logging engine itself — the gate
+every logger sits behind:
+
+```text
+fsctl loglevel debug
++OK log level: DEBUG [7]
+```
+
+Like `console loglevel` it accepts a name or `0`–`7`. Because it operates on the
+core, it affects every attached logger, not just the console. The full `fsctl`
+command surface is large; `loglevel` and `debug_level` are the parts relevant to
+diagnostics.
+
+### Which one do I use?
+
+- Watching one console session? Use `/log <level>`.
+- Changing what the terminal logger prints? Use `console loglevel <level>`.
+- Need everything louder, including files and Event Socket subscribers? Use
+  `fsctl loglevel <level>`.
+
+## Inspecting state
+
+These commands answer "what does FreeSWITCH think is going on right now?"
+
+### status
+
+`status` is the one-line health check: uptime, version, session counts, and
+sessions-per-second:
+
+```text
+UP 0 years, 2 days, 4 hours, 17 minutes, 9 seconds, 31 milliseconds, 502 microseconds
+FreeSWITCH (Version 1.10.x ...) is ready
+1234 session(s) since startup
+3 session(s) - peak 27, last 5min 5
+0 session(s) per Sec out of max 30, peak 12, last 5min 4
+1000 session(s) max
+min idle cpu 0.00/98.70
+```
+
+Look at "is ready" first — if it says "not ready", the system is still starting
+or shutting down. The session counts tell you whether you are near a configured
+ceiling.
+
+### show — live tables of channels, calls, and registrations
+
+The `show` command dumps the core's internal tables. The subcommands you reach
+for most:
+
+```text
+show channels
+show channels count
+show calls
+show registrations
+```
+
+- `show channels` lists every active channel (leg). Add `count` for just the
+  number, or `like <match string>` to filter.
+- `show calls` lists bridged calls (two legs joined).
+- `show registrations` lists SIP endpoints currently registered to FreeSWITCH —
+  the first thing to check when a phone "can't be reached."
+
+`show` accepts many other reports (`show modules`, `show codec`, `show api`,
+`show dialplan`, and more); run `show` with no argument to see the full list.
+Output is CSV-style, so `show channels` over the Event Socket is easy to parse.
+
+### sofia status — SIP profile and gateway health
+
+For anything SIP, `mod_sofia` exposes its own `sofia` command tree. Start with
+the summary:
+
+```text
+sofia status
+```
+
+```text
+                     Name	   Type	                                      Data	State
+=================================================================================================
+                 internal	profile	          sip:mod_sofia@192.0.2.10:5060	RUNNING (0)
+                 external	profile	          sip:mod_sofia@192.0.2.10:5080	RUNNING (0)
+            example.com::gw	gateway	          sip:user@example.com	         NOREG
+=================================================================================================
+```
+
+`State` is the column to read: a profile should be `RUNNING`; a gateway should be
+`REGED` (registered) when it is meant to register upstream.
+
+Drill into one profile to see its bindings, codecs, and counters:
+
+```text
+sofia status profile internal
+```
+
+Drill into a single gateway to see its registration state and call counters:
+
+```text
+sofia status gateway example.com::gw
+```
+
+The exact subcommand syntax is `sofia status profile <name>` and `sofia status
+gateway <name>`; an `xmlstatus` variant produces the same data as XML for
+tooling. The Sofia configuration these reflect is covered in the [SIP Profiles
+with Sofia](../users-endpoints/sip-profiles-sofia.mdx) chapter.
+
+## SIP tracing
+
+When a call fails at the SIP layer, you want to see the messages on the wire.
+Sofia can print them to the log without an external sniffer.
+
+Turn tracing on for **every** profile at once:
+
+```text
+sofia global siptrace on
+sofia global siptrace off
+```
+
+Or scope it to a single profile, which is far quieter on a busy box:
+
+```text
+sofia profile internal siptrace on
+sofia profile internal siptrace off
+```
+
+With tracing on, every SIP request and response on that profile is written to
+the log (at the console level you have set), prefixed with `send`/`recv` and the
+peer address — so you can watch a `REGISTER` get a `401` then a `200 OK`, or see
+exactly which `INVITE` earns a `403 Forbidden`.
+
+For deeper stack-level detail there is `sofia loglevel`, which sets the
+verbosity of individual Sofia-SIP components on a `0`–`9` scale:
+
+```text
+sofia loglevel all 9
+sofia loglevel tport 9
+```
+
+The components you can target are
+`all|default|tport|iptsec|nea|nta|nth_client|nth_server|nua|soa|sresolv|stun`.
+`tport` (transport) is the useful one for connection-level problems. This is
+noisy — turn it back down (`sofia loglevel all 0`) when you are done. Run `sofia`
+with no argument to print the full usage block.
+
+## Per-call inspection
+
+Once you have a call's UUID — from `show channels`, the logs, or `/uuid`
+filtering — you can interrogate that one channel.
+
+`uuid_dump` prints every channel variable for the session:
+
+```text
+uuid_dump <uuid>
+```
+
+This is the single richest view of a leg: caller ID, the matched gateway, codec
+in use, the dialplan context, hangup cause if it has ended, and hundreds more.
+It is the go-to when "the call connected but something is wrong."
+
+When you only need one variable, `uuid_getvar` fetches it directly instead of
+scrolling the whole dump:
+
+```text
+uuid_getvar <uuid> read_codec
+uuid_getvar <uuid> sip_gateway_name
+```
+
+To raise the log verbosity of one live call without touching the rest of the
+system, `uuid_loglevel` sets a per-session level:
+
+```text
+uuid_loglevel <uuid> debug
+```
+
+## External capture tools
+
+The commands above are enough for most diagnosis, but sometimes you need a
+packet-level view — for example to inspect SDP that never reached the log, or to
+hand a capture to a vendor. These tools are **not part of FreeSWITCH**; install
+them from your OS package manager.
+
+| Tool | Use |
+| --- | --- |
+| `sngrep` | Interactive ncurses SIP viewer. Shows call flows as ladder diagrams live on the wire — the fastest way to see a dialog. |
+| `tcpdump` | Capture raw packets to a `.pcap` file for later analysis. |
+| `tshark` | The command-line Wireshark; filter and decode SIP/RTP from a live interface or a `.pcap`. |
+
+A typical capture of SIP on the default ports:
+
+```bash
+sudo tcpdump -i any -s 0 -w /tmp/sip.pcap 'port 5060 or port 5080'
+```
+
+Open the resulting file in Wireshark (or `tshark -r /tmp/sip.pcap`) and use its
+*Telephony → VoIP Calls* view to reconstruct the dialog. For one-way-audio
+problems, follow the RTP streams to confirm media is flowing in both directions
+and to the addresses the SDP advertised.
+
+:::tip
+Start inside FreeSWITCH with `sofia profile <name> siptrace on`. It costs
+nothing to enable, needs no second process, and answers most "what did the other
+side send?" questions on its own. Reach for `sngrep` or a packet capture only
+when you need to see media or traffic the log cannot show you.
+:::

--- a/docs/troubleshooting/index.mdx
+++ b/docs/troubleshooting/index.mdx
@@ -1,0 +1,16 @@
+---
+title: "Part 11: Troubleshooting"
+slug: /troubleshooting
+description: "Diagnose the common failures operators hit — registration, audio, and call-setup problems — using FreeSWITCH's own console, status, and tracing tools."
+---
+
+import DocCardList from '@theme/DocCardList';
+
+The reference chapters document how to *configure* FreeSWITCH; this part documents
+how to *diagnose* it when a call does not behave. It covers the tools FreeSWITCH
+gives you — the console, `sofia status`, SIP tracing, logs, and CDRs — and the
+methodical reads for the failures operators hit most: registrations that fail,
+calls with no audio or one-way audio, and calls that will not connect. It is
+about the diagnostic surface, not internals.
+
+<DocCardList />

--- a/docs/troubleshooting/reading-traces-cdr.mdx
+++ b/docs/troubleshooting/reading-traces-cdr.mdx
@@ -1,0 +1,294 @@
+---
+sidebar_position: 5
+id: reading-traces-cdr
+slug: /troubleshooting/traces
+title: "Reading a SIP Trace and a CDR"
+description: "Capture a Sofia SIP trace, read the SIP transaction at an operator level, and read a cdr_csv record to localize which leg failed and when."
+sidebar_label: "Reading Traces & CDRs"
+---
+
+# Reading a SIP Trace and a CDR
+
+When a call misbehaves, two artifacts tell you almost everything you need: the
+**SIP trace** (the signaling messages that set the call up and tear it down)
+and the **CDR** (the Call Detail Record written when the call ends). The trace
+shows you *what the two endpoints said to each other*; the CDR shows you *how
+the call ended and how long each phase lasted*. Read together, they localize a
+fault to a specific leg and a specific moment.
+
+This chapter is a diagnostic read, not a protocol tutorial. It covers how to
+turn tracing on in `mod_sofia`, how to follow a normal SIP transaction and spot
+the common deviations, how to read a `mod_cdr_csv` line, and how to tie the two
+together by `Call-ID` and UUID.
+
+## Capture {#capture}
+
+SIP tracing is a function of the Sofia stack, so you enable it from the console
+with the `sofia` API command. There are three controls, from coarsest to
+finest.
+
+**Trace every profile at once:**
+
+```
+sofia global siptrace on
+```
+
+**Trace a single profile** (replace `<profile>` with the profile name, e.g.
+`internal` or `external`):
+
+```
+sofia profile <profile> siptrace on
+```
+
+Turn either off again with `off`. Per-profile tracing is usually what you want:
+it keeps the log readable by limiting output to the profile carrying the call
+under investigation.
+
+For deeper visibility into the Sofia-SIP transport and transaction layers — for
+example when messages appear to be sent but never acknowledged — raise the
+sofia-sip library log level:
+
+```
+sofia loglevel all 9
+```
+
+`loglevel` takes a component and a level from `0` (silent) to `9` (most
+verbose). Valid components are `all`, `default`, `tport`, `iptsec`, `nea`,
+`nta`, `nth_client`, `nth_server`, `nua`, `soa`, `sresolv`, and `stun`. Use
+`all` to set every component at once, or name a single component (for instance
+`sofia loglevel tport 9` for transport-level detail). A related command,
+`sofia tracelevel <level>`, sets the FreeSWITCH log level at which trace lines
+are emitted.
+
+:::tip
+Tracing is verbose. Enable it just before you reproduce the problem, capture the
+call, then turn it back off with `sofia profile <profile> siptrace off`. The
+`internal` profile's siptrace toggles are bound to the F10/F11 console hot keys
+in the vanilla configuration.
+:::
+
+Trace output appears **in the FreeSWITCH log** alongside everything else, so
+filter it. At the `fs_cli` console, `/log info` (or higher) ensures the lines
+are shown; capturing the console to a file, or reading `log/freeswitch.log`,
+lets you grep the call out afterward. Each traced message is prefixed with its
+direction — a line indicating a message was *sent to* or *received from* a peer
+address — followed by the full SIP message. That send/receive direction is the
+first thing to read: it tells you whether FreeSWITCH originated a message or
+merely received it.
+
+## Read the Trace {#read-the-trace}
+
+### The shape of a normal call {#the-shape-of-a-normal-call}
+
+A successful call is a small, predictable sequence of messages. Reading a trace
+is mostly a matter of confirming that this sequence happened and, if it did not,
+noticing where it stopped. A normal answered call looks like this:
+
+```
+  caller (or upstream)            FreeSWITCH
+        |  INVITE  ----------------->  |   request: caller wants to set up a call
+        |  <----------------  100 Trying    provisional: request received, working on it
+        |  <----------------  180 Ringing   provisional: remote end is alerting
+        |  <----------------  200 OK         final: call answered, SDP for media included
+        |  ACK  ------------------->  |   caller confirms the 200 OK; media flows
+        |            ... talk ...        |
+        |  BYE  ------------------->  |   either side hangs up
+        |  <----------------  200 OK         confirms the BYE; call torn down
+```
+
+Read it top to bottom:
+
+- **`INVITE`** opens the call and carries the caller's media offer (SDP).
+- **`100 Trying`** means the request was received. Its absence on an outbound
+  leg suggests the next hop never got the INVITE — a routing or network
+  problem, not a call-logic problem.
+- **`180 Ringing`** (or `183 Session Progress`) means the far end is alerting.
+  Reaching `180` but never `200` is a call that rang and was never answered.
+- **`200 OK`** is the answer and carries the answering side's SDP. This is the
+  point at which media negotiation completes.
+- **`ACK`** completes the three-way handshake. A `200 OK` with no following
+  `ACK` is a classic NAT symptom: the answer was sent but could not reach the
+  originator.
+- **`BYE` / `200 OK`** is the normal teardown. Which side sent the `BYE` tells
+  you who hung up.
+
+### Authentication: the 401/407 challenge {#authentication-the-challenge}
+
+A registered endpoint or an authenticating trunk does not get a call through on
+the first INVITE. FreeSWITCH challenges it, and the endpoint resends the request
+with credentials:
+
+```
+        |  INVITE (no credentials)  ----------->  |
+        |  <-------------  407 Proxy Authentication Required
+        |  ACK  ------------------------------>  |   acknowledges the 407
+        |  INVITE (with Proxy-Authorization)  -->  |   same request, now signed
+        |  <--------------------------  100 Trying / 200 OK
+```
+
+This challenge-then-resend is **normal and expected** — do not mistake the
+`401 Unauthorized` or `407 Proxy Authentication Required` for a failure. The
+failure case is when the *second* INVITE is also rejected (a repeated `401`/`407`,
+or a `403 Forbidden`): that means the credentials were wrong or the user is not
+provisioned. A `401` is used by user agents that are being challenged directly;
+a `407` is used when a proxy issues the challenge. Functionally you read them the
+same way.
+
+### Re-INVITE {#re-invite}
+
+A **re-INVITE** is a second INVITE sent *inside an established dialog* — same
+`Call-ID`, same `From`/`To` tags, a higher `CSeq`. It renegotiates media
+mid-call: putting a call on hold, resuming it, or switching codecs. If audio
+drops partway through a call, look for a re-INVITE around that moment and read
+its SDP — a media change is often the cause.
+
+### The headers and SDP lines that matter {#the-headers-and-sdp-lines-that-matter}
+
+You do not need to read every header. For operator-level diagnosis, four headers
+and three SDP lines carry most of the signal:
+
+| Field | What it tells you |
+|---|---|
+| `Via` | The path the request took. Look for a `received=` / `rport=` added by FreeSWITCH — it reveals the sender's real public address behind NAT. |
+| `From` / `To` | The logical parties. The `tag=` parameters identify the dialog; matching tags across messages confirm they belong to the same call. |
+| `Contact` | The address the peer wants follow-up requests sent to. A private address (e.g. `10.x` / `192.168.x`) here on a call coming from the public internet is a NAT misconfiguration — replies will be unroutable. |
+| `Call-ID` | The unique dialog identifier. This is your key for correlating every message of one leg, and for tying the trace to the CDR (see [Correlate](#correlate)). |
+
+Inside the SDP body (carried by the INVITE and the `200 OK`), three line types
+localize media problems:
+
+| SDP line | What it tells you |
+|---|---|
+| `c=` | The **connection address** — the IP the peer expects media on. A `c=` pointing at a private address on a call from the internet is the signature of one-way or no audio caused by NAT. |
+| `m=` | The **media line**: media type, port, and the list of payload numbers offered, e.g. `m=audio 16384 RTP/AVP 0 8 101`. A port of `0` means that stream is disabled. |
+| `a=rtpmap:` | Maps each payload number to a codec name, e.g. `a=rtpmap:0 PCMU/8000`. Compare the offer's `a=rtpmap` set against the answer's. If they share no common codec, negotiation fails — a codec mismatch rather than a network fault. |
+
+A worked, illustrative SDP body (the kind you would see inside an INVITE):
+
+```
+v=0
+o=FreeSWITCH 1632858000 1632858001 IN IP4 198.51.100.10
+s=FreeSWITCH
+c=IN IP4 198.51.100.10
+t=0 0
+m=audio 16384 RTP/AVP 0 8 101
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-16
+a=ptime:20
+```
+
+Reading this: the peer expects audio at `198.51.100.10:16384`; it offers PCMU
+(`0`), PCMA (`8`), and DTMF events (`101`). If the answering side's SDP comes
+back with, say, only `m=audio ... RTP/AVP 9` (G.722), there is no overlap with
+PCMU/PCMA and the call will fail to negotiate audio. If instead the `c=` line in
+either body holds a `10.x` or `192.168.x` address while the signaling came over
+the public internet, expect one-way or no audio — the classic NAT read covered
+in the [Audio Problems](./audio-problems.mdx) chapter of this part.
+
+## Read the CDR {#read-the-cdr}
+
+When the call ends, `mod_cdr_csv` writes one line per logged leg. The vanilla
+configuration logs the **A leg** only (`<param name="legs" value="a"/>`) and
+selects the **`example`** template (`<param name="default-template" value="example"/>`),
+so by default every record lands in `log/cdr-csv/Master.csv`. (See
+[Chapter 27: Call Detail Records](/integration/cdr) for full configuration of the
+CDR backends.)
+
+The `example` template renders these fields, in order:
+
+```
+"${caller_id_name}","${caller_id_number}","${destination_number}","${context}","${start_stamp}","${answer_stamp}","${end_stamp}","${duration}","${billsec}","${hangup_cause}","${uuid}","${bleg_uuid}","${accountcode}","${read_codec}","${write_codec}"
+```
+
+| Field | Meaning |
+|---|---|
+| `caller_id_name`, `caller_id_number` | The calling party's display name and number. |
+| `destination_number` | The dialed number / request target. |
+| `context` | The dialplan context the call was processed in. |
+| `start_stamp` | When the call leg began (the INVITE was received / the channel was created). |
+| `answer_stamp` | When the call was answered (the `200 OK`). **Empty if the call was never answered.** |
+| `end_stamp` | When the call ended (hangup). |
+| `duration` | Total seconds from `start_stamp` to `end_stamp`. |
+| `billsec` | Billable seconds from `answer_stamp` to `end_stamp` — the talk time. |
+| `hangup_cause` | Why the call ended (see below). |
+| `uuid` | This leg's channel UUID. |
+| `bleg_uuid` | The UUID of the bridged (other) leg, if the call was bridged. |
+| `accountcode` | Billing/account tag, if set on the channel. |
+| `read_codec`, `write_codec` | The negotiated inbound and outbound audio codecs. |
+
+### Localizing a fault from one line {#localizing-a-fault-from-one-line}
+
+Read the three timestamps and `billsec` together — they tell you *how far the
+call got*:
+
+- **`answer_stamp` empty and `billsec` = `0`:** the call never connected. The
+  caller dialed, but the destination never answered. Whether it rang depends on
+  the trace (did you see a `180`?). The `hangup_cause` says why — typically
+  `NO_ANSWER`, `USER_BUSY`, `CALL_REJECTED`, or `NO_ROUTE_DESTINATION`.
+- **`answer_stamp` present, `billsec` very small:** the call answered and dropped
+  almost immediately — frequently a media failure (no agreed codec, or no audio
+  so a watchdog tore it down) or an endpoint hanging up on a one-way-audio call.
+  Cross-check the `read_codec`/`write_codec` fields and the SDP in the trace.
+- **`answer_stamp` present, `billsec` reasonable, `hangup_cause` = `NORMAL_CLEARING`:**
+  a normal, completed call. Nothing to chase here.
+
+The **`hangup_cause`** is the single most useful CDR field for triage. Common
+values and the direction they point:
+
+| `hangup_cause` | Typical read |
+|---|---|
+| `NORMAL_CLEARING` | Call completed and one side hung up normally. |
+| `USER_BUSY` | Destination was busy. |
+| `NO_ANSWER` | Rang but was never answered. |
+| `CALL_REJECTED` | Far end actively refused (often a `403`/`603`). |
+| `NO_ROUTE_DESTINATION` | No dialplan route or next hop matched — a routing problem, covered in the [Call-Setup Failures](./call-setup-failures.mdx) chapter of this part. |
+| `INCOMPATIBLE_DESTINATION` | Negotiation failed, commonly a codec mismatch. |
+| `RECOVERY_ON_TIMER_EXPIRE` | A timer (e.g. session or no-answer) expired. |
+
+The **`bleg_uuid`** field tells you whether — and to what — the call was
+bridged. If `bleg_uuid` is empty, this leg was never bridged to another leg, so
+the fault is on the inbound side (routing, auth, or the originator). If it is
+populated, the call reached a second leg, and you can pull that leg's own record
+or channel data to see how the *other* side fared. Pairing the A-leg's
+`hangup_cause` with the B-leg's narrows the fault to one side of the bridge.
+
+## Correlate {#correlate}
+
+A trace and a CDR describe the same call from two angles. Tie them together so a
+symptom in one points to evidence in the other.
+
+**By `Call-ID` ↔ UUID.** Every SIP message of one leg carries the same `Call-ID`
+header; the CDR for that leg carries the channel `uuid`. FreeSWITCH does not
+make the SIP `Call-ID` *identical* to the internal `uuid`, but it stores the
+inbound SIP `Call-ID` as the channel variable `sip_call_id`, so you can pivot
+between them:
+
+1. Find the failing leg in the CDR — say a row with `hangup_cause` of
+   `INCOMPATIBLE_DESTINATION` and an empty `billsec`. Note its `uuid`.
+2. In the trace, that call's messages share one `Call-ID`. Add `sip_call_id` to
+   your CDR template (or read it from `uuid_dump <uuid>` while the call is live)
+   to map the `uuid` to the `Call-ID` and pull exactly that leg's messages out of
+   the log.
+3. With both in hand: the CDR's `hangup_cause` and timestamps tell you *what
+   went wrong and when*; the trace's INVITE/`200 OK` SDP tells you *why* — the
+   `c=` address (NAT) or the `a=rtpmap` overlap (codec).
+
+**By UUID across legs.** For a bridged call, the A-leg CDR's `bleg_uuid` is the
+B-leg's `uuid`. That single field walks you from one leg's record to the other's,
+and from there to the other leg's `Call-ID` and its own slice of the trace. This
+is how you decide, for a call that "failed," which of the two legs actually
+failed — the question every troubleshooting session ultimately has to answer.
+
+## See Also {#see-also}
+
+- [Chapter 27: Call Detail Records](/integration/cdr) — full configuration of
+  `mod_cdr_csv`, `mod_xml_cdr`, and `mod_cdr_sqlite`, including templates and
+  field expansion.
+- [Chapter 7: SIP Profiles with Sofia](/users-and-endpoints/sip-profiles) — the
+  profiles whose traffic you are tracing.
+- [Audio Problems](./audio-problems.mdx) (this part) — reading the SDP `c=`/`m=`/`a=rtpmap`
+  lines to diagnose one-way and no audio.
+- [Call-Setup Failures](./call-setup-failures.mdx) (this part) — using `hangup_cause` and
+  the trace to diagnose calls that never connect.

--- a/docs/troubleshooting/registration-problems.mdx
+++ b/docs/troubleshooting/registration-problems.mdx
@@ -1,0 +1,312 @@
+---
+sidebar_position: 2
+id: registration-problems
+slug: /troubleshooting/registration
+title: "Registration Problems"
+description: "Diagnose why SIP endpoints fail to register with FreeSWITCH: confirm registration state with sofia status and show registrations, then read the common causes — bad credentials, NAT, expiry flapping, and transport mismatch — symptom by symptom."
+sidebar_label: "Registration Problems"
+---
+
+# Registration Problems
+
+A SIP phone or softphone that cannot register is the single most common failure
+operators report. The symptoms vary — the device shows "registration failed,"
+calls to the extension go straight to voicemail, or a phone that worked yesterday
+quietly drops off the network — but the diagnostic path is the same. FreeSWITCH
+already knows what it saw: it records every successful registration in its
+database and logs every rejected attempt. This chapter shows how to read that
+state, then walks the four causes that account for nearly every registration
+failure: wrong credentials, NAT, expiry flapping, and transport mismatch.
+
+Registration is handled by [`mod_sofia`](../users-endpoints/sip-profiles-sofia.mdx),
+and the credentials it checks come from the
+[user directory](../users-endpoints/user-directory.mdx). Keep both chapters within
+reach — most fixes here are a one-line change in a profile or a directory user.
+
+## Confirming Registration State {#confirming-registration-state}
+
+Before changing anything, find out whether FreeSWITCH currently has a
+registration for the user. There are two views.
+
+### Per-profile: `sofia status profile <name> reg` {#sofia-status-reg}
+
+The Sofia view shows registrations as the SIP stack sees them, per profile. Run
+it against the profile the phone targets (the bundled internal-phone profile is
+`internal`):
+
+```
+sofia status profile internal reg
+```
+
+This lists every registration on that profile. For each one FreeSWITCH prints
+the fields it stored at registration time:
+
+```
+Registrations:
+===============================================================================
+Call-ID:        a1b2c3d4-....
+User:           1000@192.168.1.10
+Contact:        sip:1000@192.168.1.50:5060;...
+Agent:          Yealink SIP-T46G ...
+Status:         Registered(UDP)(unknown) EXP(2026-06-15 12:34:56) EXPSECS(295)
+Ping-Status:    Reachable
+Ping-Time:      0.00
+Host:           192.168.1.10
+IP:             192.168.1.50
+Port:           5060
+Auth-User:      1000
+Auth-Realm:     192.168.1.10
+MWI-Account:    1000@192.168.1.10
+===============================================================================
+Total items returned: 1
+```
+
+The fields that matter most when diagnosing:
+
+- **Contact** — the address FreeSWITCH will send INVITEs to. If this is a private
+  address (`192.168.x.x`, `10.x.x.x`) but **IP** shows a public address, the device
+  is behind NAT and the Contact was *not* rewritten. See [NAT](#cause-nat).
+- **Status** shows the transport in parentheses, e.g. `Registered(UDP)`. A
+  mismatch here against what the phone is configured to use points to
+  [transport problems](#cause-transport).
+- **EXPSECS** is the seconds until this registration expires. A value that is
+  always small and resets constantly is a sign of [flapping](#cause-expiry).
+
+You can narrow the list. Pass a substring to match against the **Contact** column:
+
+```
+sofia status profile internal reg 192.168.1.50
+```
+
+To look up a specific user, use the `user` keyword with a `user@domain` argument
+(either part may be omitted to match on just the user or just the host):
+
+```
+sofia status profile internal user 1000@192.168.1.10
+```
+
+:::note
+`reg <string>` filters on the Contact column, not the user. To find a
+registration by extension, use `user 1000@domain` (or `user 1000`), not
+`reg 1000`.
+:::
+
+If the command prints `Total items returned: 0`, FreeSWITCH has no registration
+for that user — the REGISTER never succeeded. Move to the causes below.
+
+### Across the box: `show registrations` {#show-registrations}
+
+The core `show` command queries the shared registration table across all profiles
+and is convenient for a quick global count:
+
+```
+show registrations
+show registrations as xml
+```
+
+```
+show registrations count
+```
+
+The `count` form returns just the number of rows, which is the fastest way to
+confirm whether *anything* is registered.
+
+---
+
+## Cause: Wrong Credentials {#cause-credentials}
+
+**Symptom.** The phone reports authentication failure, or it challenges, retries,
+and gives up. `sofia status ... reg` shows nothing for the user.
+
+**Likely cause.** A REGISTER must pass digest authentication when the profile has
+`auth-calls` set to `true` (the default on the bundled internal profile). The
+credentials are checked against the matching user in the
+[directory](../users-endpoints/user-directory.mdx). Two different rejections look
+very different on the wire, and the difference tells you where the problem is:
+
+- **A `401 Unauthorized` that repeats.** FreeSWITCH challenged, the phone answered,
+  and the digest did not verify — wrong password, or the device computed the digest
+  against a different realm than the one FreeSWITCH expects. FreeSWITCH simply
+  re-challenges. A phone that loops on 401s has a credential or realm mismatch.
+- **A `403 Forbidden`.** FreeSWITCH found a hard reason to reject. The most common
+  is *no matching user in the directory at all* — the username/domain pair the
+  phone presented does not exist. When this happens FreeSWITCH logs a very specific
+  warning:
+
+  ```
+  Can't find user [1000@example.com] from 192.168.1.50
+  You must define a domain called 'example.com' in your directory and add a user
+  with the id="1000" attribute ...
+  ```
+
+  A 403 is also returned for an empty password when the user has neither a
+  `password` nor an `a1-hash` (unless `allow-empty-password` is set on the user),
+  and for a user explicitly disabled with `sip-forbid-register`.
+
+**How to confirm.**
+
+1. Watch the registration attempt in the log while the phone retries. The
+   `Can't find user` warning pins it to a directory miss; a repeated 401 with no
+   such warning pins it to a bad password or realm.
+2. Check the **realm**. The realm the phone authenticates against must equal the
+   domain it is registering to. In the `reg` output, **Auth-Realm** is the realm
+   FreeSWITCH used. If the phone is configured with one domain but presents
+   credentials for another realm, the digest will never verify.
+3. Confirm the directory has the user. The `id` attribute and the domain in the
+   directory must match the username and domain the phone sends.
+
+**Fix.**
+
+- Correct the `password` (or `a1-hash`) `param` in the directory user record. The
+  `a1-hash` is the precomputed MD5 of `user:realm:password`; if you set it, it must
+  be computed against the *same* realm the phone uses.
+- Make sure a `<domain>` matching the phone's domain exists and contains a user
+  whose `id` matches the phone's username. The directory chapter covers
+  [directory structure and user records](../users-endpoints/user-directory.mdx).
+- If you intend the profile to authenticate by IP instead of credentials (a
+  trunk, not a phone), that is a different setup — registrations from phones still
+  need `auth-calls` and valid directory credentials.
+
+---
+
+## Cause: NAT {#cause-nat}
+
+**Symptom.** The phone registers (it appears in `reg`), but calls to it never
+arrive — they ring nowhere or fail to set up — and the **Contact** in the `reg`
+output is a private address while **IP** is the device's public address.
+
+**Likely cause.** A device behind NAT puts its *private* LAN address in the SIP
+Contact header. If FreeSWITCH stores that Contact verbatim, every INVITE it later
+sends to the phone goes to an unroutable private address. FreeSWITCH has to detect
+the NAT and rewrite the Contact to the public address and port it actually saw the
+packet arrive from.
+
+**How to confirm.** Compare the **Contact** and **IP** fields in
+`sofia status profile internal reg`. If Contact contains a private address but IP
+is a public one, the Contact was not rewritten and inbound calls will fail.
+
+**Fix.** These are all `<param>` settings on the Sofia
+[profile](../users-endpoints/sip-profiles-sofia.mdx):
+
+- **`apply-nat-acl`** — names an ACL of networks to treat as "behind NAT." The
+  bundled internal profile ships with `apply-nat-acl` set to `nat.auto`, which
+  matches RFC 1918 private ranges automatically. Devices whose source IP matches
+  this ACL get NAT handling. This is the first thing to confirm is present.
+- **`aggressive-nat-detection`** — when `true`, FreeSWITCH uses additional cues
+  (such as a private address in the Contact or Via) to decide a device is NATed,
+  beyond what `apply-nat-acl` matches. Whether it is on is reported as
+  `AGGRESSIVENAT` in `sofia status profile <name>`. It is commented out in the
+  bundled internal profile; enable it when phones behind NAT are still not being
+  detected.
+- **`ext-sip-ip`** — the public IP FreeSWITCH advertises in its own SIP signaling.
+  Set this when FreeSWITCH itself sits behind NAT (for example, a cloud box with a
+  1:1 NAT), so it tells phones to reach it at the public address. It accepts an
+  explicit IP, `auto` (resolve via STUN), or `auto-nat` (use the router's
+  UPnP/NAT-PMP mapping).
+- **`NDLB-*`** "No Device Left Behind" workarounds for misbehaving clients.
+  Relevant ones here are **`NDLB-received-in-nat-reg-contact`**, which appends the
+  source IP and port (the `received`/`rport` the packet actually came from) into
+  the stored registration Contact, and **`NDLB-force-rport`**, which forces use of
+  the rport source address. Enable these only for specific clients that need them;
+  they are not on by default.
+
+After changing NAT params, restart or rescan the profile
+(`sofia profile internal rescan`) and have the phone re-register, then re-check
+the Contact in `reg`.
+
+---
+
+## Cause: Expiry and Flapping {#cause-expiry}
+
+**Symptom.** A phone registers, drops, and re-registers in a tight loop, or its
+registration disappears between calls. **EXPSECS** in the `reg` output is always a
+small number, or the registration vanishes and reappears in the log repeatedly.
+
+**Likely cause.** Each REGISTER carries an `Expires` value — how long the binding
+should last. FreeSWITCH honors the value the client asks for; if the phone requests
+a very short expiry, it must re-register that often, and any lost packet drops it.
+Separately, if many phones request the *same* expiry they all re-register in
+lockstep, producing a synchronized "thundering herd" of REGISTERs.
+
+**How to confirm.** Read **EXPSECS** in `sofia status profile internal reg` right
+after a registration. A value of, say, 60 means the phone asked for a 60-second
+expiry and will re-register every minute. Watch the log: regular REGISTERs at that
+interval are normal re-registration; REGISTERs *between* the expected times,
+combined with `expire` events, indicate true flapping (usually packet loss or a
+NAT binding that times out faster than the registration).
+
+**Fix.** On the Sofia [profile](../users-endpoints/sip-profiles-sofia.mdx):
+
+- **`sip-expires-max-deviation`** — when set to N (seconds), FreeSWITCH jitters each
+  registration's effective expiry by a random amount up to N. This de-synchronizes
+  phones that all asked for the same expiry, smoothing the re-registration load.
+  It defaults to `0` (no jitter); set it to spread out a fleet that re-registers in
+  lockstep. There is a matching `sip-subscription-max-deviation` for SUBSCRIBE.
+- **Registration pings** — instead of relying on short client expiries to detect
+  dead phones, have FreeSWITCH probe them with SIP OPTIONS. **`nat-options-ping`**
+  pings registrations that were detected as behind NAT (keeping the NAT pinhole
+  open); **`all-reg-options-ping`** pings *every* registration. The cadence is
+  governed by **`ping-mean-interval`** (target seconds between pings to a given
+  registration) and **`ping-thread-frequency`** (how often the ping thread wakes).
+  The result shows up as **Ping-Status** (`Reachable` / `Unreachable`) and
+  **Ping-Time** in the `reg` output. Use these to let phones keep a longer expiry
+  while FreeSWITCH still tracks reachability.
+
+The expiry a phone asks for is set on the *device*, not in FreeSWITCH; if a phone
+re-registers far too often, raise its registration interval in the phone's own
+configuration and let `sip-expires-max-deviation` plus pings handle the rest.
+
+:::note
+The `expire-seconds` `param` controls the expiry FreeSWITCH *requests* when it acts
+as a registering client toward a gateway — it is a gateway/outbound setting, not
+the lifetime of an inbound phone registration. See the
+[gateways chapter](../users-endpoints/gateways.mdx).
+:::
+
+---
+
+## Cause: Transport Mismatch {#cause-transport}
+
+**Symptom.** The phone sends REGISTERs but FreeSWITCH never answers, or answers on
+a transport the phone is not listening on. Nothing appears in `reg`, and a packet
+capture shows REGISTERs arriving (or not) on an unexpected port or protocol.
+
+**Likely cause.** A profile binds specific transports on specific ports. If the
+phone is configured for TCP but the profile only listens on UDP, or it points at
+the wrong port, the REGISTER never reaches a listener that will process it.
+
+**How to confirm.**
+
+1. Check what the profile actually binds. `sofia status` lists each profile's URL
+   and the transports it offers; `sofia status profile internal` shows its bound
+   addresses. The transport of an existing registration appears in the **Status**
+   field, e.g. `Registered(UDP)` versus `Registered(TCP)`.
+2. Confirm the port. The bundled internal profile binds **`sip-port`** 5060 by
+   default. If the phone targets a different port, it will not reach this profile.
+
+**Fix.** On the Sofia [profile](../users-endpoints/sip-profiles-sofia.mdx):
+
+- Match the phone's transport to a transport the profile binds. UDP and TCP are
+  available by SIP port; TLS requires TLS to be enabled on the profile with the
+  **`tls`** `param` (and optionally **`tls-only`** to refuse plaintext, with
+  **`tls-sip-port`** for its port). WebSocket transports for WebRTC clients are
+  enabled with **`ws-binding`** (and **`wss-binding`** for secure WebSocket).
+- Verify the phone targets the profile's **`sip-port`**. If you run multiple
+  profiles, each binds its own port — point the phone at the right one.
+- After changing transport or TLS settings, restart the profile so it rebinds:
+  `sofia profile internal restart`.
+
+---
+
+## Reading the REGISTER on the Wire {#reading-the-register}
+
+When state and config both look correct but registration still fails, read the
+actual SIP exchange. Enable Sofia's tracing with `sofia global siptrace on` (or
+the per-profile `sip-trace` `param`) and watch the REGISTER, the `401` challenge,
+the authenticated REGISTER, and the final `200 OK` — or the `403` — go by. The
+challenge/response pair tells you the realm and whether the digest verified; the
+Contact and Via headers tell you what the device claims its address is versus where
+the packet actually came from.
+
+Reading a SIP trace end to end — what each header means and how to follow a
+transaction — is covered in the [trace-reading chapter](./reading-traces-cdr.mdx).


### PR DESCRIPTION
## Summary

Learner-oriented additions plus two consistency fixes for the module reference and numbering. **139 files, ~+5,560 lines**, every fact source-verified, `npm run build` clean (`onBrokenLinks`/`onBrokenAnchors = throw`).

### New learning content
- **Part 10 — Recipes** (Ch 33–38): 6 verified end-to-end worked examples (DID→IVR→VM, ring/hunt group, time-of-day, box-to-box, conference+PIN, click-to-call).
- **Part 11 — Troubleshooting** (Ch 39–43): the diagnostic toolbox, registration, audio, call-setup, and reading traces/CDRs — tools and reads, not internals.
- **Part 12 — Programming (ESL & Scripting)** (Ch 44–48): the event model, an events catalog, inbound/outbound Event Socket, and the embedded scripting APIs (Lua + JS).
- `CONTENT-ROADMAP.md` (gap analysis) and a `README.md` scope update so troubleshooting and the programming surfaces are in scope.

### Complete the Part 9 module index
Part 9 only documented modules *not* covered by a topical chapter, so common ones (`mod_lua`, `mod_sofia`, `mod_conference`, the codecs…) were missing from their category. Added a short **pointer page** for each of the ~63 remaining bundled modules — purpose + a link to its authoritative chapter — and a new **Codecs** category. Every Part 9 category is now a complete module index; folders renumbered alphabetically.

### Numbering consistency
Numbered the contents of Parts 10–12 to match Parts 1–8 (`Chapter 33` … `Chapter 48`, with `N.` sidebar labels). Part 9 stays a reference index (module entries unnumbered, like the Part 8 appendices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
